### PR TITLE
begins deprecation of 'bundle' syntax in CLI

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"github.com/defenseunicorns/uds-cli/src/config"
 	"github.com/defenseunicorns/uds-cli/src/config/lang"
-	"github.com/defenseunicorns/uds-cli/src/types"
 	"github.com/defenseunicorns/uds-cli/src/pkg/utils"
+	"github.com/defenseunicorns/uds-cli/src/types"
 	"github.com/defenseunicorns/zarf/src/cmd/common"
 	"github.com/defenseunicorns/zarf/src/cmd/tools"
 	zarfConfig "github.com/defenseunicorns/zarf/src/config"
@@ -49,7 +49,6 @@ var rootCmd = &cobra.Command{
 		cliSetup()
 	},
 	Short: lang.RootCmdShort,
-	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		_, _ = fmt.Fprintln(os.Stderr)
 		cmd.Help()

--- a/src/cmd/uds.go
+++ b/src/cmd/uds.go
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The UDS Authors
+
+// Package cmd contains the CLI commands for UDS.
+package cmd
+
+import (
+	"fmt"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/defenseunicorns/uds-cli/src/config"
+	"github.com/defenseunicorns/uds-cli/src/config/lang"
+	"github.com/defenseunicorns/uds-cli/src/pkg/bundle"
+	zarfConfig "github.com/defenseunicorns/zarf/src/config"
+	"github.com/defenseunicorns/zarf/src/pkg/message"
+	"github.com/defenseunicorns/zarf/src/pkg/oci"
+	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
+	zarfTypes "github.com/defenseunicorns/zarf/src/types"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/defenseunicorns/uds-cli/src/pkg/utils"
+	zarfUtils "github.com/defenseunicorns/zarf/src/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+var createCmd = &cobra.Command{
+	Use:     "create [DIRECTORY]",
+	Aliases: []string{"c"},
+	Args:    cobra.MaximumNArgs(1),
+	Short:   lang.CmdBundleCreateShort,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if len(args) > 0 && !zarfUtils.IsDir(args[0]) {
+			message.Fatalf(nil, "(%q) is not a valid path to a directory", args[0])
+		}
+		if _, err := os.Stat(config.BundleYAML); len(args) == 0 && err != nil {
+			message.Fatalf(err, "%s not found in directory", config.BundleYAML)
+		}
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		srcDir, err := os.Getwd()
+		if err != nil {
+			message.Fatalf(err, "error reading the current working directory")
+		}
+		if len(args) > 0 {
+			srcDir = args[0]
+		}
+		bundleCfg.CreateOpts.SourceDirectory = srcDir
+
+		bundleCfg.CreateOpts.SetVariables = utils.MergeVariables(v.GetStringMapString(V_BNDL_CREATE_SET), bundleCfg.CreateOpts.SetVariables)
+
+		bndlClient := bundle.NewOrDie(&bundleCfg)
+		defer bndlClient.ClearPaths()
+
+		if err := bndlClient.Create(); err != nil {
+			bndlClient.ClearPaths()
+			message.Fatalf(err, "Failed to create bundle: %s", err.Error())
+		}
+	},
+}
+
+var deployCmd = &cobra.Command{
+	Use:     "deploy [BUNDLE_TARBALL|OCI_REF]",
+	Aliases: []string{"d"},
+	Short:   lang.CmdBundleDeployShort,
+	Args:    cobra.MaximumNArgs(1),
+	PreRun:  firstArgIsEitherOCIorTarball,
+	Run: func(cmd *cobra.Command, args []string) {
+		bundleCfg.DeployOpts.Source = choosePackage(args)
+		configureZarf()
+
+		// read config file and unmarshal
+		if v.ConfigFileUsed() != "" {
+			err := v.ReadInConfig()
+			if err != nil {
+				message.Fatalf(err, "Failed to read config: %s", err.Error())
+				return
+			}
+			err = v.UnmarshalKey(V_BNDL_DEPLOY_ZARF_PACKAGES, &bundleCfg.DeployOpts.ZarfPackageVariables)
+			if err != nil {
+				message.Fatalf(err, "Failed to unmarshal config: %s", err.Error())
+				return
+			}
+		}
+		bndlClient := bundle.NewOrDie(&bundleCfg)
+		defer bndlClient.ClearPaths()
+
+		if err := bndlClient.Deploy(); err != nil {
+			bndlClient.ClearPaths()
+			message.Fatalf(err, "Failed to deploy bundle: %s", err.Error())
+		}
+	},
+}
+
+var inspectCmd = &cobra.Command{
+	Use:     "inspect [BUNDLE_TARBALL|OCI_REF]",
+	Aliases: []string{"i"},
+	Short:   lang.CmdBundleInspectShort,
+	Args:    cobra.MaximumNArgs(1),
+	PreRun: func(cmd *cobra.Command, args []string) {
+		firstArgIsEitherOCIorTarball(nil, args)
+		if cmd.Flag("extract").Value.String() == "true" && cmd.Flag("sbom").Value.String() == "false" {
+			message.Fatal(nil, "cannot use 'extract' flag without 'sbom' flag")
+		}
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		bundleCfg.InspectOpts.Source = choosePackage(args)
+		configureZarf()
+
+		bndlClient := bundle.NewOrDie(&bundleCfg)
+		defer bndlClient.ClearPaths()
+
+		if err := bndlClient.Inspect(); err != nil {
+			bndlClient.ClearPaths()
+			message.Fatalf(err, "Failed to inspect bundle: %s", err.Error())
+		}
+	},
+}
+
+var removeCmd = &cobra.Command{
+	Use:     "remove [BUNDLE_TARBALL|OCI_REF]",
+	Aliases: []string{"r"},
+	Args:    cobra.ExactArgs(1),
+	Short:   lang.CmdBundleRemoveShort,
+	PreRun:  firstArgIsEitherOCIorTarball,
+	Run: func(cmd *cobra.Command, args []string) {
+		bundleCfg.RemoveOpts.Source = args[0]
+		configureZarf()
+
+		bndlClient := bundle.NewOrDie(&bundleCfg)
+		defer bndlClient.ClearPaths()
+
+		if err := bndlClient.Remove(); err != nil {
+			bndlClient.ClearPaths()
+			message.Fatalf(err, "Failed to remove bundle: %s", err.Error())
+		}
+	},
+}
+
+var publishCmd = &cobra.Command{
+	Use:     "publish [BUNDLE_TARBALL] [OCI_REF]",
+	Aliases: []string{"p"},
+	Short:   lang.CmdBundlePullShort,
+	Args:    cobra.ExactArgs(2),
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if _, err := os.Stat(args[0]); err != nil {
+			message.Fatalf(err, "First argument (%q) must be a valid local Bundle path: %s", args[0], err.Error())
+		}
+		if !strings.HasPrefix(args[1], helpers.OCIURLPrefix) {
+			err := fmt.Errorf("oci url reference must begin with %s", helpers.OCIURLPrefix)
+			message.Fatalf(err, "Second argument (%q) must be a valid OCI URL: %s", args[0], err.Error())
+		}
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		bundleCfg.PublishOpts.Source = args[0]
+		bundleCfg.PublishOpts.Destination = args[1]
+		configureZarf()
+		bndlClient := bundle.NewOrDie(&bundleCfg)
+		defer bndlClient.ClearPaths()
+
+		if err := bndlClient.Publish(); err != nil {
+			bndlClient.ClearPaths()
+			message.Fatalf(err, "Failed to publish bundle: %s", err.Error())
+		}
+	},
+}
+
+var pullCmd = &cobra.Command{
+	Use:     "pull [OCI_REF]",
+	Aliases: []string{"p"},
+	Short:   lang.CmdBundlePullShort,
+	Args:    cobra.ExactArgs(1),
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := oci.ValidateReference(args[0]); err != nil {
+			message.Fatalf(err, "First argument (%q) must be a valid OCI URL: %s", args[0], err.Error())
+		}
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		bundleCfg.PullOpts.Source = args[0]
+		configureZarf()
+		bndlClient := bundle.NewOrDie(&bundleCfg)
+		defer bndlClient.ClearPaths()
+
+		if err := bndlClient.Pull(); err != nil {
+			bndlClient.ClearPaths()
+			message.Fatalf(err, "Failed to pull bundle: %s", err.Error())
+		}
+	},
+}
+
+func firstArgIsEitherOCIorTarball(_ *cobra.Command, args []string) {
+	if len(args) == 0 {
+		return
+	}
+	var errString string
+	var err error
+	if utils.IsValidTarballPath(args[0]) {
+		return
+	}
+	if !helpers.IsOCIURL(args[0]) && !utils.IsValidTarballPath(args[0]) {
+		errString = fmt.Sprintf("First argument (%q) must either be a valid OCI URL or a valid path to a bundle tarball", args[0])
+	} else {
+		err = oci.ValidateReference(args[0])
+	}
+	if errString != "" {
+		message.Fatalf(err, "Failed to validate first argument: %s", errString)
+	}
+}
+
+func init() {
+	initViper()
+	v.SetDefault(V_BNDL_OCI_CONCURRENCY, 3)
+
+	// remove after deprecating 'bundle' syntax
+	initDeprecated(rootCmd)
+
+	rootCmd.PersistentFlags().IntVar(&config.CommonOptions.OCIConcurrency, "oci-concurrency", v.GetInt(V_BNDL_OCI_CONCURRENCY), lang.CmdBundleFlagConcurrency)
+
+	// create cmd flags
+	rootCmd.AddCommand(createCmd)
+	createCmd.Flags().BoolVarP(&config.CommonOptions.Confirm, "confirm", "c", false, lang.CmdBundleRemoveFlagConfirm)
+	createCmd.Flags().StringVarP(&bundleCfg.CreateOpts.Output, "output", "o", v.GetString(V_BNDL_CREATE_OUTPUT), lang.CmdBundleCreateFlagOutput)
+	createCmd.Flags().StringVarP(&bundleCfg.CreateOpts.SigningKeyPath, "signing-key", "k", v.GetString(V_BNDL_CREATE_SIGNING_KEY), lang.CmdBundleCreateFlagSigningKey)
+	createCmd.Flags().StringVarP(&bundleCfg.CreateOpts.SigningKeyPassword, "signing-key-password", "p", v.GetString(V_BNDL_CREATE_SIGNING_KEY_PASSWORD), lang.CmdBundleCreateFlagSigningKeyPassword)
+	createCmd.Flags().StringToStringVarP(&bundleCfg.CreateOpts.SetVariables, "set", "s", v.GetStringMapString(V_BNDL_CREATE_SET), lang.CmdBundleCreateFlagSet)
+
+	// deploy cmd flags
+	rootCmd.AddCommand(deployCmd)
+	// todo: add "set" flag on deploy for high-level bundle configs?
+	deployCmd.Flags().BoolVarP(&config.CommonOptions.Confirm, "confirm", "c", false, lang.CmdBundleDeployFlagConfirm)
+
+	// inspect cmd flags
+	rootCmd.AddCommand(inspectCmd)
+	inspectCmd.Flags().BoolVarP(&bundleCfg.InspectOpts.IncludeSBOM, "sbom", "s", false, lang.CmdPackageInspectFlagSBOM)
+	inspectCmd.Flags().BoolVarP(&bundleCfg.InspectOpts.ExtractSBOM, "extract", "e", false, lang.CmdPackageInspectFlagExtractSBOM)
+	inspectCmd.Flags().StringVarP(&bundleCfg.InspectOpts.PublicKeyPath, "key", "k", v.GetString(V_BNDL_INSPECT_KEY), lang.CmdBundleInspectFlagKey)
+
+	// remove cmd flags
+	rootCmd.AddCommand(removeCmd)
+	// confirm does not use the Viper config
+	removeCmd.Flags().BoolVarP(&config.CommonOptions.Confirm, "confirm", "c", false, lang.CmdBundleRemoveFlagConfirm)
+	_ = removeCmd.MarkFlagRequired("confirm")
+
+	// publish cmd flags
+	rootCmd.AddCommand(publishCmd)
+
+	// pull cmd flags
+	rootCmd.AddCommand(pullCmd)
+	pullCmd.Flags().StringVarP(&bundleCfg.PullOpts.OutputDirectory, "output", "o", v.GetString(V_BNDL_PULL_OUTPUT), lang.CmdBundlePullFlagOutput)
+	pullCmd.Flags().StringVarP(&bundleCfg.PullOpts.PublicKeyPath, "key", "k", v.GetString(V_BNDL_PULL_KEY), lang.CmdBundlePullFlagKey)
+}
+
+// configureZarf copies configs from UDS-CLI to Zarf
+func configureZarf() {
+	zarfConfig.CommonOptions = zarfTypes.ZarfCommonOptions{
+		Insecure:       config.CommonOptions.Insecure,
+		TempDirectory:  config.CommonOptions.TempDirectory,
+		OCIConcurrency: config.CommonOptions.OCIConcurrency,
+		Confirm:        config.CommonOptions.Confirm,
+		CachePath:      config.CommonOptions.CachePath,
+	}
+}
+
+// choosePackage provides a file picker when users don't specify a file
+func choosePackage(args []string) string {
+	if len(args) > 0 {
+		return args[0]
+	}
+	var path string
+	prompt := &survey.Input{
+		Message: lang.CmdPackageChoose,
+		Suggest: func(toComplete string) []string {
+			files, _ := filepath.Glob(config.BundlePrefix + toComplete + "*.tar")
+			gzFiles, _ := filepath.Glob(config.BundlePrefix + toComplete + "*.tar.zst")
+			partialFiles, _ := filepath.Glob(config.BundlePrefix + toComplete + "*.part000")
+
+			files = append(files, gzFiles...)
+			files = append(files, partialFiles...)
+			return files
+		},
+	}
+
+	if err := survey.AskOne(prompt, &path, survey.WithValidator(survey.Required)); err != nil {
+		message.Fatalf(nil, lang.CmdPackageChooseErr, err.Error())
+	}
+
+	return path
+}

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -186,25 +186,25 @@ func TestRemoteBundle(t *testing.T) {
 }
 
 func create(t *testing.T, bundlePath string) {
-	cmd := strings.Split(fmt.Sprintf("bundle create %s --set INIT_VERSION=%s --confirm --insecure", bundlePath, zarfVersion), " ")
+	cmd := strings.Split(fmt.Sprintf("create %s --set INIT_VERSION=%s --confirm --insecure", bundlePath, zarfVersion), " ")
 	_, _, err := e2e.UDS(cmd...)
 	require.NoError(t, err)
 }
 
 func createSecure(t *testing.T, bundlePath string) {
-	cmd := strings.Split(fmt.Sprintf("bundle create %s --set INIT_VERSION=%s --confirm", bundlePath, zarfVersion), " ")
+	cmd := strings.Split(fmt.Sprintf("create %s --set INIT_VERSION=%s --confirm", bundlePath, zarfVersion), " ")
 	_, _, err := e2e.UDS(cmd...)
 	require.NoError(t, err)
 }
 
 func createRemote(t *testing.T, bundlePath string, registry string) {
-	cmd := strings.Split(fmt.Sprintf("bundle create %s -o oci://%s --set INIT_VERSION=%s --confirm --insecure", bundlePath, registry, zarfVersion), " ")
+	cmd := strings.Split(fmt.Sprintf("create %s -o oci://%s --set INIT_VERSION=%s --confirm --insecure", bundlePath, registry, zarfVersion), " ")
 	_, _, err := e2e.UDS(cmd...)
 	require.NoError(t, err)
 }
 
 func inspectRemote(t *testing.T, ref string) {
-	cmd := strings.Split(fmt.Sprintf("bundle inspect oci://%s --insecure --sbom", ref), " ")
+	cmd := strings.Split(fmt.Sprintf("inspect oci://%s --insecure --sbom", ref), " ")
 	_, _, err := e2e.UDS(cmd...)
 	require.NoError(t, err)
 	_, err = os.Stat(config.BundleSBOMTar)
@@ -213,7 +213,7 @@ func inspectRemote(t *testing.T, ref string) {
 	require.NoError(t, err)
 }
 func inspectRemoteAndSBOMExtract(t *testing.T, ref string) {
-	cmd := strings.Split(fmt.Sprintf("bundle inspect oci://%s --insecure --sbom --extract", ref), " ")
+	cmd := strings.Split(fmt.Sprintf("inspect oci://%s --insecure --sbom --extract", ref), " ")
 	_, _, err := e2e.UDS(cmd...)
 	require.NoError(t, err)
 	_, err = os.Stat(config.BundleSBOM)
@@ -261,11 +261,11 @@ func deployAndRemoveRemote(t *testing.T, ref string, tarballPath string) {
 	t.Run(
 		"deploy+remove bundle via OCI",
 		func(t *testing.T) {
-			cmd = strings.Split(fmt.Sprintf("bundle deploy oci://%s --insecure --oci-concurrency=10 --confirm", ref), " ")
+			cmd = strings.Split(fmt.Sprintf("deploy oci://%s --insecure --oci-concurrency=10 --confirm", ref), " ")
 			_, _, err := e2e.UDS(cmd...)
 			require.NoError(t, err)
 
-			cmd = strings.Split(fmt.Sprintf("bundle remove oci://%s --confirm --insecure", ref), " ")
+			cmd = strings.Split(fmt.Sprintf("remove oci://%s --confirm --insecure", ref), " ")
 			_, _, err = e2e.UDS(cmd...)
 			require.NoError(t, err)
 		},
@@ -274,11 +274,11 @@ func deployAndRemoveRemote(t *testing.T, ref string, tarballPath string) {
 	t.Run(
 		"deploy+remove bundle via local tarball",
 		func(t *testing.T) {
-			cmd = strings.Split(fmt.Sprintf("bundle deploy %s --confirm", tarballPath), " ")
+			cmd = strings.Split(fmt.Sprintf("deploy %s --confirm", tarballPath), " ")
 			_, _, err := e2e.UDS(cmd...)
 			require.NoError(t, err)
 
-			cmd = strings.Split(fmt.Sprintf("bundle remove %s --confirm --insecure", tarballPath), " ")
+			cmd = strings.Split(fmt.Sprintf("remove %s --confirm --insecure", tarballPath), " ")
 			_, _, err = e2e.UDS(cmd...)
 			require.NoError(t, err)
 		},


### PR DESCRIPTION
- Adds create, deploy, etc cmds to the the root `uds` cmd
- Adds deprecation warnings for using `uds bundle ...` syntax
- Updates tests that use remotes to the uds `uds ...` syntax (attempting to test both syntaxes before deprecation without running every test twice)