### PR TITLE
cleans up confirm behavior on create and deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ The above `UDSBundle` deploys the Zarf init package and podinfo.
 
 The packages referenced in `zarf-packages` can exist either locally or in an OCI registry. See [here](src/test/packages/03-local-and-remote) for an example that deploys both local and remote Zarf packages. More `UDSBundle` examples can be found in the [src/test/packages](src/test/packages) folder. 
 
+#### Declarative Syntax
+The syntax of a `uds-bundle.yaml` is entirely declarative. As a result, the UDS CLI will not prompt users to deploy optional components in a Zarf package. If you want to deploy an optional Zarf component, it must be specified in the `optional-components` key of a particular `zarf-package`.
+
 ### Bundle Create
 Pulls the Zarf packages from the registry and bundles them into an OCI artifact.
 
@@ -38,8 +41,8 @@ Noting that the `--insecure` flag will be necessary when running the registry fr
 Deploys the bundle
 
 There are 2 ways to deploy Bundles:
-1. From an OCI registry: `uds deploy oci://localhost:5000/<name>:<tag> --insecure --confirm`
-1. From your local filesystem: `uds deploy uds-bundle-<name>.tar.zst --confirm`
+1. From an OCI registry: `uds deploy oci://localhost:5000/<name>:<tag> --insecure`
+1. From your local filesystem: `uds deploy uds-bundle-<name>.tar.zst`
 
 ### Bundle Inspect
 Inspect the `uds-bundle.yaml` of a bundle

--- a/src/pkg/bundle/create.go
+++ b/src/pkg/bundle/create.go
@@ -101,7 +101,7 @@ func (b *Bundler) Create() error {
 	return Create(b, signatureBytes)
 }
 
-// adapted from p.confirmAction
+// confirmBundleCreation prompts the user to confirm bundle creation
 func (b *Bundler) confirmBundleCreation() (confirm bool) {
 
 	message.HeaderInfof("🎁 BUNDLE DEFINITION")
@@ -115,12 +115,11 @@ func (b *Bundler) confirmBundleCreation() (confirm bool) {
 	}
 
 	prompt := &survey.Confirm{
-		Message: "Create this UDS Create?",
+		Message: fmt.Sprintf("Create this bundle?"),
 	}
 
 	pterm.Println()
 
-	// Prompt the user for confirmation, on abort return false
 	if err := survey.AskOne(prompt, &confirm); err != nil || !confirm {
 		// User aborted or declined, cancel the action
 		return false

--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -7,21 +7,23 @@ package bundle
 import (
 	"context"
 	"fmt"
-	"github.com/AlecAivazis/survey/v2"
-	"github.com/pterm/pterm"
-	"golang.org/x/exp/maps"
 	"os"
 	"path/filepath"
 	"runtime/debug"
 	"strings"
 
-	"github.com/defenseunicorns/uds-cli/src/config"
-	"github.com/defenseunicorns/uds-cli/src/types"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/pterm/pterm"
+	"golang.org/x/exp/maps"
+
 	zarfConfig "github.com/defenseunicorns/zarf/src/config"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/packager"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	zarfTypes "github.com/defenseunicorns/zarf/src/types"
+
+	"github.com/defenseunicorns/uds-cli/src/config"
+	"github.com/defenseunicorns/uds-cli/src/types"
 )
 
 // Deploy deploys a bundle

--- a/src/types/bundle.go
+++ b/src/types/bundle.go
@@ -31,7 +31,7 @@ type BundleVariableImport struct {
 	Description string `json:"description,omitempty" jsonschema:"name=Description of the variable"`
 }
 
-// BundleVariableImport represents variables in the bundle
+// BundleVariableExport represents variables in the bundle
 type BundleVariableExport struct {
 	Name        string `json:"name" jsonschema:"name=Name of the variable"`
 	Description string `json:"description,omitempty" jsonschema:"name=Description of the variable"`


### PR DESCRIPTION
- Cleans up verbiage during `confirm` messages
- Ensures users are `confirm`'ing bundle deployment, not Zarf pkg deployment