### PR TITLE
Restore OCI concurrency

### DIFF
--- a/src/cmd/deprecated_bundle.go
+++ b/src/cmd/deprecated_bundle.go
@@ -6,18 +6,21 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/defenseunicorns/uds-cli/src/config"
-	"github.com/defenseunicorns/uds-cli/src/config/lang"
-	"github.com/defenseunicorns/uds-cli/src/pkg/bundle"
-	"github.com/defenseunicorns/zarf/src/pkg/message"
-	"github.com/defenseunicorns/zarf/src/pkg/oci"
-	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
 	"os"
 	"strings"
 
-	"github.com/defenseunicorns/uds-cli/src/pkg/utils"
+	"github.com/defenseunicorns/zarf/src/pkg/message"
+	"github.com/defenseunicorns/zarf/src/pkg/oci"
+	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
+
+	"github.com/defenseunicorns/uds-cli/src/config"
+	"github.com/defenseunicorns/uds-cli/src/config/lang"
+	"github.com/defenseunicorns/uds-cli/src/pkg/bundle"
+
 	zarfUtils "github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/spf13/cobra"
+
+	"github.com/defenseunicorns/uds-cli/src/pkg/utils"
 )
 
 var bundleCmd = &cobra.Command{

--- a/src/cmd/internal.go
+++ b/src/cmd/internal.go
@@ -7,11 +7,13 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/alecthomas/jsonschema"
-	"github.com/defenseunicorns/uds-cli/src/config/lang"
-	"github.com/defenseunicorns/uds-cli/src/types"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/spf13/cobra"
+
+	"github.com/defenseunicorns/uds-cli/src/config/lang"
+	"github.com/defenseunicorns/uds-cli/src/types"
 )
 
 var internalCmd = &cobra.Command{

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -5,10 +5,8 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/defenseunicorns/uds-cli/src/config"
-	"github.com/defenseunicorns/uds-cli/src/config/lang"
-	"github.com/defenseunicorns/uds-cli/src/pkg/utils"
-	"github.com/defenseunicorns/uds-cli/src/types"
+	"os"
+
 	"github.com/defenseunicorns/zarf/src/cmd/common"
 	"github.com/defenseunicorns/zarf/src/cmd/tools"
 	zarfConfig "github.com/defenseunicorns/zarf/src/config"
@@ -16,7 +14,11 @@ import (
 	"github.com/defenseunicorns/zarf/src/pkg/utils/exec"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
+
+	"github.com/defenseunicorns/uds-cli/src/config"
+	"github.com/defenseunicorns/uds-cli/src/config/lang"
+	"github.com/defenseunicorns/uds-cli/src/pkg/utils"
+	"github.com/defenseunicorns/uds-cli/src/types"
 )
 
 var (

--- a/src/cmd/uds.go
+++ b/src/cmd/uds.go
@@ -6,22 +6,25 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/defenseunicorns/uds-cli/src/config"
-	"github.com/defenseunicorns/uds-cli/src/config/lang"
-	"github.com/defenseunicorns/uds-cli/src/pkg/bundle"
 	zarfConfig "github.com/defenseunicorns/zarf/src/config"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/oci"
 	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
 	zarfTypes "github.com/defenseunicorns/zarf/src/types"
-	"os"
-	"path/filepath"
-	"strings"
 
-	"github.com/defenseunicorns/uds-cli/src/pkg/utils"
+	"github.com/defenseunicorns/uds-cli/src/config"
+	"github.com/defenseunicorns/uds-cli/src/config/lang"
+	"github.com/defenseunicorns/uds-cli/src/pkg/bundle"
+
 	zarfUtils "github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/spf13/cobra"
+
+	"github.com/defenseunicorns/uds-cli/src/pkg/utils"
 )
 
 var createCmd = &cobra.Command{

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -7,9 +7,10 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/defenseunicorns/uds-cli/src/config"
 	"github.com/defenseunicorns/uds-cli/src/config/lang"
-	"github.com/spf13/cobra"
 )
 
 var versionCmd = &cobra.Command{

--- a/src/cmd/viper.go
+++ b/src/cmd/viper.go
@@ -5,10 +5,12 @@
 package cmd
 
 import (
-	"github.com/defenseunicorns/uds-cli/src/config/lang"
-	"github.com/defenseunicorns/zarf/src/cmd/common"
 	"os"
 	"strings"
+
+	"github.com/defenseunicorns/zarf/src/cmd/common"
+
+	"github.com/defenseunicorns/uds-cli/src/config/lang"
 
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/spf13/viper"

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -5,10 +5,12 @@
 package config
 
 import (
-	"github.com/defenseunicorns/uds-cli/src/types"
+	"runtime"
+
 	zarfConfig "github.com/defenseunicorns/zarf/src/config"
 	zarfTypes "github.com/defenseunicorns/zarf/src/types"
-	"runtime"
+
+	"github.com/defenseunicorns/uds-cli/src/types"
 )
 
 const (

--- a/src/pkg/bundle/publish.go
+++ b/src/pkg/bundle/publish.go
@@ -10,10 +10,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/defenseunicorns/uds-cli/src/config"
 	oci "github.com/defenseunicorns/zarf/src/pkg/oci"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	av3 "github.com/mholt/archiver/v3"
+
+	"github.com/defenseunicorns/uds-cli/src/config"
 )
 
 // Publish publishes a bundle to a remote OCI registry

--- a/src/pkg/bundle/pull.go
+++ b/src/pkg/bundle/pull.go
@@ -11,13 +11,14 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/defenseunicorns/uds-cli/src/config"
 	zarfConfig "github.com/defenseunicorns/zarf/src/config"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/oci"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/mholt/archiver/v4"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/defenseunicorns/uds-cli/src/config"
 )
 
 // Pull pulls a bundle and saves it locally + caches it
@@ -36,6 +37,9 @@ func (b *Bundler) Pull() error {
 	// pull the bundle's metadata + sig
 	loadedMetadata, err := provider.LoadBundleMetadata()
 	if err != nil {
+		return err
+	}
+	if err := utils.ReadYaml(loadedMetadata[config.BundleYAML], &b.bundle); err != nil {
 		return err
 	}
 
@@ -62,24 +66,21 @@ func (b *Bundler) Pull() error {
 		return err
 	}
 
-	// make an index.json specifically for this bundle
+	// make an index.json for this bundle and write to tmp
 	index := ocispec.Index{}
 	index.SchemaVersion = 2
-	index.MediaType = ocispec.MediaTypeImageIndex
+	ref := fmt.Sprintf("%s-%s", b.bundle.Metadata.Version, b.bundle.Metadata.Architecture)
+	annotations := map[string]string{
+		ocispec.AnnotationRefName: ref,
+	}
+	rootDesc.Annotations = annotations // maintain the tag
 	index.Manifests = append(index.Manifests, rootDesc)
-
-	// write the index.json to tmp
 	bytes, err := json.MarshalIndent(index, "", "  ")
 	if err != nil {
 		return err
 	}
 	indexJSONPath := filepath.Join(b.tmp, "index.json")
 	if err := utils.WriteFile(indexJSONPath, bytes); err != nil {
-		return err
-	}
-
-	// read the metadata into memory
-	if err := utils.ReadYaml(loaded[config.BundleYAML], &b.bundle); err != nil {
 		return err
 	}
 
@@ -105,7 +106,7 @@ func (b *Bundler) Pull() error {
 	pathMap := make(PathMap)
 
 	// put the index.json and oci-layout at the root of the tarball
-	pathMap[indexJSONPath] = "index.json"
+	pathMap[filepath.Join(b.tmp, "index.json")] = "index.json"
 	pathMap[filepath.Join(cacheDir, "oci-layout")] = "oci-layout"
 
 	// re-map the paths to be relative to the cache directory

--- a/src/pkg/bundler/remote.go
+++ b/src/pkg/bundler/remote.go
@@ -11,8 +11,6 @@ import (
 	"io"
 	"path/filepath"
 
-	"github.com/defenseunicorns/uds-cli/src/config"
-	"github.com/defenseunicorns/uds-cli/src/types"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/oci"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
@@ -20,6 +18,9 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
 	ocistore "oras.land/oras-go/v2/content/oci"
+
+	"github.com/defenseunicorns/uds-cli/src/config"
+	"github.com/defenseunicorns/uds-cli/src/types"
 )
 
 // RemoteBundler contains methods for pulling remote Zarf packages into a bundle

--- a/src/pkg/bundler/tarball.go
+++ b/src/pkg/bundler/tarball.go
@@ -9,7 +9,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/defenseunicorns/uds-cli/src/config"
+	"io"
+	"os"
+	"path/filepath"
+
 	"github.com/defenseunicorns/zarf/src/pkg/oci"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	zarfTypes "github.com/defenseunicorns/zarf/src/types"
@@ -18,12 +21,11 @@ import (
 	av4 "github.com/mholt/archiver/v4"
 	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"io"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/file"
 	ocistore "oras.land/oras-go/v2/content/oci"
-	"os"
-	"path/filepath"
+
+	"github.com/defenseunicorns/uds-cli/src/config"
 )
 
 // LocalBundler contains methods for loading local Zarf packages into a bundle
@@ -208,14 +210,14 @@ func generatePkgManifest(store *ocistore.Store, descs []ocispec.Descriptor, conf
 			SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
 		},
 		Config:    configDesc,
-		MediaType: ocispec.MediaTypeImageManifest,
+		MediaType: oci.ZarfLayerMediaTypeBlob,
 		Layers:    descs,
 	}
 	manifestJSON, err := json.Marshal(manifest)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("failed to marshal manifest: %w", err)
 	}
-	manifestDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, manifestJSON)
+	manifestDesc := content.NewDescriptorFromBytes(oci.ZarfLayerMediaTypeBlob, manifestJSON)
 
 	// push manifest
 	if err := store.Push(ctx, manifestDesc, bytes.NewReader(manifestJSON)); err != nil {

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -5,6 +5,8 @@
 package utils
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -13,11 +15,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/defenseunicorns/uds-cli/src/config"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
+	"github.com/defenseunicorns/zarf/src/pkg/oci"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pterm/pterm"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+
+	"github.com/defenseunicorns/uds-cli/src/config"
 )
 
 // MergeVariables merges the variables from the config file and the CLI
@@ -75,4 +82,50 @@ func UseLogFile() {
 			message.Note(msg)
 		}
 	}
+}
+
+// CreateCopyOpts creates the ORAS CopyOpts struct to use when copying OCI artifacts
+func CreateCopyOpts(layersToPull []ocispec.Descriptor, concurrency int) (oras.CopyOptions, int64, error) {
+	var copyOpts oras.CopyOptions
+	copyOpts.Concurrency = concurrency
+	estimatedBytes := int64(0)
+	var shas []string
+	for _, layer := range layersToPull {
+		if len(layer.Digest.String()) > 0 {
+			estimatedBytes += layer.Size
+			shas = append(shas, layer.Digest.Encoded())
+		}
+	}
+	copyOpts.FindSuccessors = func(ctx context.Context, fetcher content.Fetcher, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		var nodes []ocispec.Descriptor
+		if desc.MediaType == oci.ZarfLayerMediaTypeBlob && desc.Annotations == nil {
+			layerBytes, err := content.FetchAll(ctx, fetcher, desc)
+			if err != nil {
+				return nil, err
+			}
+			var manifest oci.ZarfOCIManifest
+			if err := json.Unmarshal(layerBytes, &manifest); err != nil {
+				return nil, err
+			}
+			if manifest.Subject != nil {
+				nodes = append(nodes, *manifest.Subject)
+			}
+			nodes = append(nodes, manifest.Config)
+			nodes = append(nodes, manifest.Layers...)
+		} else {
+			successors, err := content.Successors(ctx, fetcher, desc)
+			if err != nil {
+				return nil, err
+			}
+			nodes = append(nodes, successors...)
+		}
+		var ret []ocispec.Descriptor
+		for _, node := range nodes {
+			if node.Size != 0 && helpers.SliceContains(shas, node.Digest.Encoded()) {
+				ret = append(ret, node)
+			}
+		}
+		return ret, nil
+	}
+	return copyOpts, estimatedBytes, nil
 }


### PR DESCRIPTION
- Restores OCI concurrency by refactoring "pull" and "publish" bundle ops to use `oras.Copy()`
- Edits imports to have goimports style syntax