### PR TITLE
feat: caching and OCI concurrency for remote packages during bundle create and deploy

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -6,10 +6,10 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/defenseunicorns/zarf/src/cmd/common"
 	"github.com/defenseunicorns/zarf/src/cmd/tools"
-	zarfConfig "github.com/defenseunicorns/zarf/src/config"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/utils/exec"
 	"github.com/spf13/cobra"
@@ -83,14 +83,16 @@ func init() {
 	v.SetDefault(V_NO_LOG_FILE, false)
 	v.SetDefault(V_NO_PROGRESS, false)
 	v.SetDefault(V_INSECURE, false)
-	v.SetDefault(V_ZARF_CACHE, zarfConfig.ZarfDefaultCachePath)
 	v.SetDefault(V_TMP_DIR, "")
+
+	homeDir, _ := os.UserHomeDir()
+	v.SetDefault(V_UDS_CACHE, filepath.Join(homeDir, config.UDSCache))
 
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", v.GetString(V_LOG_LEVEL), lang.RootCmdFlagLogLevel)
 	rootCmd.PersistentFlags().StringVarP(&config.CLIArch, "architecture", "a", v.GetString(common.VArchitecture), lang.RootCmdFlagArch)
 	rootCmd.PersistentFlags().BoolVar(&config.SkipLogFile, "no-log-file", v.GetBool(V_NO_LOG_FILE), lang.RootCmdFlagSkipLogFile)
 	rootCmd.PersistentFlags().BoolVar(&message.NoProgress, "no-progress", v.GetBool(V_NO_PROGRESS), lang.RootCmdFlagNoProgress)
-	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.CachePath, "zarf-cache", v.GetString(V_ZARF_CACHE), lang.RootCmdFlagCachePath)
+	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.CachePath, "uds-cache", v.GetString(V_UDS_CACHE), lang.RootCmdFlagCachePath)
 	rootCmd.PersistentFlags().StringVar(&config.CommonOptions.TempDirectory, "tmpdir", v.GetString(V_TMP_DIR), lang.RootCmdFlagTempDir)
 	rootCmd.PersistentFlags().BoolVar(&config.CommonOptions.Insecure, "insecure", v.GetBool(V_INSECURE), lang.RootCmdFlagInsecure)
 

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/defenseunicorns/zarf/src/cmd/common"
 	"github.com/defenseunicorns/zarf/src/cmd/tools"
+	zarfConfig "github.com/defenseunicorns/zarf/src/config"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/utils/exec"
 	"github.com/spf13/cobra"

--- a/src/cmd/uds.go
+++ b/src/cmd/uds.go
@@ -258,7 +258,8 @@ func configureZarf() {
 		TempDirectory:  config.CommonOptions.TempDirectory,
 		OCIConcurrency: config.CommonOptions.OCIConcurrency,
 		Confirm:        config.CommonOptions.Confirm,
-		CachePath:      config.CommonOptions.CachePath,
+		// todo: decouple Zarf cache?
+		CachePath: config.CommonOptions.CachePath,
 	}
 }
 

--- a/src/cmd/viper.go
+++ b/src/cmd/viper.go
@@ -23,7 +23,7 @@ const (
 	V_ARCHITECTURE = "architecture"
 	V_NO_LOG_FILE  = "no_log_file"
 	V_NO_PROGRESS  = "no_progress"
-	V_ZARF_CACHE   = "zarf_cache"
+	V_UDS_CACHE    = "uds_cache"
 	V_TMP_DIR      = "tmp_dir"
 	V_INSECURE     = "insecure"
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -44,6 +44,9 @@ const (
 	// ChecksumsTxt is the name of the checksums.txt file in a Zarf pkg
 	ChecksumsTxt = "checksums.txt"
 
+	// UDSCache is the directory containing cached bundle layers
+	UDSCache = ".uds-cache"
+
 	// TasksYAML is the default name of the uds run cmd file
 	TasksYAML = "tasks.yaml"
 )

--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -131,7 +131,7 @@ func (b *Bundler) ValidateBundleResources(bundle *types.UDSBundle, spinner *mess
 			if strings.Contains(pkg.Ref, "@sha256:") {
 				url = fmt.Sprintf("%s:%s", pkg.Repository, pkg.Ref)
 			}
-			remotePkg, err := bundler.NewRemoteBundler(pkg, url, nil, nil)
+			remotePkg, err := bundler.NewRemoteBundler(pkg, url, nil, nil, b.tmp)
 			if err != nil {
 				return err
 			}

--- a/src/pkg/bundle/remote.go
+++ b/src/pkg/bundle/remote.go
@@ -133,6 +133,7 @@ func (op *ociProvider) CreateBundleSBOM(extractSBOM bool) error {
 // LoadBundle loads a bundle from a remote source
 func (op *ociProvider) LoadBundle(_ int) (PathMap, error) {
 	var layersToPull []ocispec.Descriptor
+	estimatedBytes := int64(0)
 
 	if err := op.getBundleManifest(); err != nil {
 		return nil, err
@@ -172,6 +173,7 @@ func (op *ociProvider) LoadBundle(_ int) (PathMap, error) {
 		for _, layer := range manifest.Layers {
 			ok, err := op.Repo().Blobs().Exists(op.ctx, layer)
 			progressBar.Add(1)
+			estimatedBytes += layer.Size
 			if err != nil {
 				return nil, err
 			}
@@ -194,10 +196,7 @@ func (op *ociProvider) LoadBundle(_ int) (PathMap, error) {
 	layersToPull = append(layersToPull, rootDesc)
 
 	// copy bundle
-	copyOpts, estimatedBytes, err := utils.CreateCopyOpts(layersToPull, config.CommonOptions.OCIConcurrency)
-	if err != nil {
-		return nil, err
-	}
+	copyOpts := utils.CreateCopyOpts(layersToPull, config.CommonOptions.OCIConcurrency)
 
 	// Create a thread to update a progress bar as we save the package to disk
 	doneSaving := make(chan int)
@@ -223,6 +222,5 @@ func (op *ociProvider) LoadBundle(_ int) (PathMap, error) {
 
 func (op *ociProvider) PublishBundle(_ types.UDSBundle, _ *oci.OrasRemote) error {
 	// todo: implement moving bundles from one registry to another
-	message.Warnf("moving bundles in between remote registries not yet supported")
-	return nil
+	return fmt.Errorf("moving bundles in between remote registries not yet supported")
 }

--- a/src/pkg/cache/cache.go
+++ b/src/pkg/cache/cache.go
@@ -25,6 +25,7 @@ func expandTilde(cachePath string) string {
 	return cachePath
 }
 
+// Add adds a file to the cache
 func Add(filePathToAdd string) error {
 	// ensure cache dir exists
 	cacheDir := config.CommonOptions.CachePath
@@ -53,6 +54,7 @@ func Add(filePathToAdd string) error {
 	return err
 }
 
+// Exists checks if a layer exists in the cache
 func Exists(layerDigest string) bool {
 	cacheDir := config.CommonOptions.CachePath
 	layerCachePath := filepath.Join(expandTilde(cacheDir), "images", layerDigest)
@@ -63,6 +65,7 @@ func Exists(layerDigest string) bool {
 	return false
 }
 
+// Use copies a layer from the cache to the dst dir
 func Use(layerDigest, dstDir string) error {
 	cacheDir := config.CommonOptions.CachePath
 	layerCachePath := filepath.Join(expandTilde(cacheDir), "images", layerDigest)

--- a/src/pkg/sources/remote.go
+++ b/src/pkg/sources/remote.go
@@ -149,7 +149,7 @@ func (r *RemoteBundle) downloadPkgFromRemoteBundle() ([]ocispec.Descriptor, erro
 	if oci.IsEmptyDescriptor(pkgManifestDesc) {
 		return nil, fmt.Errorf("package %s does not exist in this bundle", r.PkgManifestSHA)
 	}
-	// hack to Zarf media type so that FetchManifest works
+	// hack Zarf media type so that FetchManifest works
 	pkgManifestDesc.MediaType = oci.ZarfLayerMediaTypeBlob
 	pkgManifest, err := r.Remote.FetchManifest(pkgManifestDesc)
 	if err != nil || pkgManifest == nil {
@@ -204,16 +204,11 @@ func (r *RemoteBundle) downloadPkgFromRemoteBundle() ([]ocispec.Descriptor, erro
 		doneSaving <- 1
 		return nil, err
 	}
-
-	// todo: only use Zarf blobs from cache bc using cached image manifests causes oras.Copy() to not follow the DAG
-	// todo: only cache Zarf blobs?
-
 	doneSaving <- 1
 	wg.Wait()
 
 	if len(pkgManifest.Layers) > len(layersInBundle) {
 		r.isPartial = true
 	}
-
 	return layersInBundle, nil
 }

--- a/src/pkg/utils/oci.go
+++ b/src/pkg/utils/oci.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The UDS Authors
+
+// Package utils provides utility fns for UDS-CLI
+package utils
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/defenseunicorns/zarf/src/pkg/message"
+	"github.com/defenseunicorns/zarf/src/pkg/oci"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+	ocistore "oras.land/oras-go/v2/content/oci"
+)
+
+// FetchLayerAndStore fetches a remote layer and copies it to a local store
+func FetchLayerAndStore(layerDesc ocispec.Descriptor, remoteRepo *oci.OrasRemote, localStore *ocistore.Store) error {
+	layerBytes, err := remoteRepo.FetchLayer(layerDesc)
+	if err != nil {
+		return err
+	}
+	rootPkgDescBytes := content.NewDescriptorFromBytes(oci.ZarfLayerMediaTypeBlob, layerBytes)
+	if err = localStore.Push(context.TODO(), rootPkgDescBytes, bytes.NewReader(layerBytes)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ToOCIStore takes an arbitrary type, typically a struct, marshals it into JSON and store it in a local OCI store
+func ToOCIStore(t any, mediaType string, store *ocistore.Store) (ocispec.Descriptor, error) {
+	b, err := json.Marshal(t)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	desc := content.NewDescriptorFromBytes(mediaType, b)
+	if err := store.Push(context.TODO(), desc, bytes.NewReader(b)); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	return desc, nil
+}
+
+// ToOCIRemote takes an arbitrary type, typically a struct, marshals it into JSON and store it in a remote OCI store
+func ToOCIRemote(t any, mediaType string, remote *oci.OrasRemote) (ocispec.Descriptor, error) {
+	b, err := json.Marshal(t)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	var layerDesc ocispec.Descriptor
+	// if image manifest media type, push to Manifests(), otherwise normal pushLayer()
+	if mediaType == ocispec.MediaTypeImageManifest {
+		layerDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, b)
+		if err := remote.Repo().Manifests().PushReference(context.TODO(), layerDesc, bytes.NewReader(b), remote.Repo().Reference.String()); err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("failed to push manifest: %w", err)
+		}
+	} else {
+		layerDesc, err = remote.PushLayer(b, mediaType)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+	}
+
+	message.Successf("Published %s [%s]", remote.Repo().Reference.String(), layerDesc.MediaType)
+	return layerDesc, nil
+}
+
+// CreateCopyOpts creates the ORAS CopyOpts struct to use when copying OCI artifacts
+func CreateCopyOpts(layersToPull []ocispec.Descriptor, concurrency int) oras.CopyOptions {
+	var copyOpts oras.CopyOptions
+	copyOpts.Concurrency = concurrency
+	estimatedBytes := int64(0)
+	var shas []string
+	for _, layer := range layersToPull {
+		if len(layer.Digest.String()) > 0 {
+			estimatedBytes += layer.Size
+			shas = append(shas, layer.Digest.Encoded())
+		}
+	}
+	copyOpts.FindSuccessors = func(ctx context.Context, fetcher content.Fetcher, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		var nodes []ocispec.Descriptor
+		if desc.MediaType == oci.ZarfLayerMediaTypeBlob && desc.Annotations == nil {
+			layerBytes, err := content.FetchAll(ctx, fetcher, desc)
+			if err != nil {
+				return nil, err
+			}
+			var manifest oci.ZarfOCIManifest
+			if err := json.Unmarshal(layerBytes, &manifest); err != nil {
+				return nil, err
+			}
+			if manifest.Subject != nil {
+				nodes = append(nodes, *manifest.Subject)
+			}
+			nodes = append(nodes, manifest.Config)
+			nodes = append(nodes, manifest.Layers...)
+		} else {
+			successors, err := content.Successors(ctx, fetcher, desc)
+			if err != nil {
+				return nil, err
+			}
+			nodes = append(nodes, successors...)
+		}
+		var ret []ocispec.Descriptor
+		for _, node := range nodes {
+			if node.Size != 0 && slices.Contains(shas, node.Digest.Encoded()) {
+				ret = append(ret, node)
+			}
+		}
+		return ret, nil
+	}
+	return copyOpts
+}

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -87,7 +87,7 @@ func UseLogFile() {
 }
 
 // CreateCopyOpts creates the ORAS CopyOpts struct to use when copying OCI artifacts
-func CreateCopyOpts(layersToPull []ocispec.Descriptor, concurrency int) (oras.CopyOptions, int64, error) {
+func CreateCopyOpts(layersToPull []ocispec.Descriptor, concurrency int) oras.CopyOptions {
 	var copyOpts oras.CopyOptions
 	copyOpts.Concurrency = concurrency
 	estimatedBytes := int64(0)
@@ -129,7 +129,7 @@ func CreateCopyOpts(layersToPull []ocispec.Descriptor, concurrency int) (oras.Co
 		}
 		return ret, nil
 	}
-	return copyOpts, estimatedBytes, nil
+	return copyOpts
 }
 
 // ExtractJSON extracts and unmarshals a tarballed JSON file into a type

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -12,19 +12,14 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"strings"
 	"time"
 
 	"github.com/defenseunicorns/zarf/src/pkg/message"
-	"github.com/defenseunicorns/zarf/src/pkg/oci"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
 	av4 "github.com/mholt/archiver/v4"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pterm/pterm"
-	"oras.land/oras-go/v2"
-	"oras.land/oras-go/v2/content"
 
 	"github.com/defenseunicorns/uds-cli/src/config"
 )
@@ -86,52 +81,6 @@ func UseLogFile() {
 	}
 }
 
-// CreateCopyOpts creates the ORAS CopyOpts struct to use when copying OCI artifacts
-func CreateCopyOpts(layersToPull []ocispec.Descriptor, concurrency int) oras.CopyOptions {
-	var copyOpts oras.CopyOptions
-	copyOpts.Concurrency = concurrency
-	estimatedBytes := int64(0)
-	var shas []string
-	for _, layer := range layersToPull {
-		if len(layer.Digest.String()) > 0 {
-			estimatedBytes += layer.Size
-			shas = append(shas, layer.Digest.Encoded())
-		}
-	}
-	copyOpts.FindSuccessors = func(ctx context.Context, fetcher content.Fetcher, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-		var nodes []ocispec.Descriptor
-		if desc.MediaType == oci.ZarfLayerMediaTypeBlob && desc.Annotations == nil {
-			layerBytes, err := content.FetchAll(ctx, fetcher, desc)
-			if err != nil {
-				return nil, err
-			}
-			var manifest oci.ZarfOCIManifest
-			if err := json.Unmarshal(layerBytes, &manifest); err != nil {
-				return nil, err
-			}
-			if manifest.Subject != nil {
-				nodes = append(nodes, *manifest.Subject)
-			}
-			nodes = append(nodes, manifest.Config)
-			nodes = append(nodes, manifest.Layers...)
-		} else {
-			successors, err := content.Successors(ctx, fetcher, desc)
-			if err != nil {
-				return nil, err
-			}
-			nodes = append(nodes, successors...)
-		}
-		var ret []ocispec.Descriptor
-		for _, node := range nodes {
-			if node.Size != 0 && slices.Contains(shas, node.Digest.Encoded()) {
-				ret = append(ret, node)
-			}
-		}
-		return ret, nil
-	}
-	return copyOpts
-}
-
 // ExtractJSON extracts and unmarshals a tarballed JSON file into a type
 func ExtractJSON(j any) func(context.Context, av4.File) error {
 	return func(_ context.Context, file av4.File) error {
@@ -147,4 +96,22 @@ func ExtractJSON(j any) func(context.Context, av4.File) error {
 		}
 		return json.Unmarshal(fileBytes, &j)
 	}
+}
+
+// ToLocalFile takes an arbitrary type, typically a struct, marshals it into JSON and stores it as a local file
+func ToLocalFile(t any, filePath string) error {
+	b, err := json.Marshal(t)
+	if err != nil {
+		return err
+	}
+	tFile, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer tFile.Close()
+	_, err = tFile.Write(b)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
- Implements caching and OCI concurrency for pulling remote Zarf packages during bundle create and deploy operations
- Refactors some really common OCI logic into functions now in `utils/oci.go`