### PR TITLE
flattens task yaml structure

### DIFF
--- a/.github/workflows/test-schema.yaml
+++ b/.github/workflows/test-schema.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: ./.github/actions/golang
 
       - name: Docs and schemas
-        run: "make test-schema"
+        run: "make schema test-schema"
 
       - name: Save logs
         if: always()

--- a/hack/test-generate-schema.sh
+++ b/hack/test-generate-schema.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env sh
 
-if [ -z "$(git status -s uds.schema.json)" ]; then
-    echo "Success!"
-    exit 0
-else
-    git status uds.schema.json
-    exit 1
-fi
+check_git_status() {
+    if [ -z "$(git status -s "$1")" ]; then
+        echo "Success!"
+    else
+        echo "Schema changes found, please regenerate $1"
+        git status "$1"
+        exit 1
+    fi
+}
 
-if [ -z "$(git status -s tasks.schema.json)" ]; then
-    echo "Success!"
-    exit 0
-else
-    git status tasks.schema.json
-    exit 1
-fi
+check_git_status uds.schema.json
+check_git_status tasks.schema.json
+
+exit 0

--- a/src/pkg/runner/runner.go
+++ b/src/pkg/runner/runner.go
@@ -183,8 +183,8 @@ func (r *Runner) placeFiles(files []zarfTypes.ZarfFile) error {
 }
 
 func (r *Runner) performAction(action types.Action) error {
-	if action.TaskReference != nil {
-		referencedTask, err := r.getTask(action.TaskReference.Name)
+	if action.TaskReference != "" {
+		referencedTask, err := r.getTask(action.TaskReference)
 		if err != nil {
 			return err
 		}
@@ -202,13 +202,13 @@ func (r *Runner) performAction(action types.Action) error {
 
 func (r *Runner) checkForTaskLoops(task types.Task) error {
 	for _, action := range task.Actions {
-		if action.TaskReference != nil {
-			exists := r.TaskNameMap[action.TaskReference.Name]
+		if action.TaskReference != "" {
+			exists := r.TaskNameMap[action.TaskReference]
 			if exists {
 				return fmt.Errorf("task loop detected")
 			}
-			r.TaskNameMap[action.TaskReference.Name] = true
-			newTask, err := r.getTask(action.TaskReference.Name)
+			r.TaskNameMap[action.TaskReference] = true
+			newTask, err := r.getTask(action.TaskReference)
 			if err != nil {
 				return err
 			}

--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -38,10 +38,8 @@ tasks:
         target: ${ZARF_VAR_CHECKSUMS}
   - name: remote
     actions:
-      - task:
-          name: pre-remote
-      - task:
-          name: pull-remote
+      - task: pre-remote
+      - task: pull-remote
   - name: template-file
     files:
       - source: raw
@@ -59,20 +57,16 @@ tasks:
       - cmd: echo ${ACTION_VAR}
   - name: reference
     actions:
-      - task:
-          name: referenced
+      - task: referenced
   - name: referenced
     actions:
       - cmd: echo "other-task"
   - name: recursive
     actions:
-      - task:
-          name: recursed
+      - task: recursed
   - name: recursed
     actions:
-      - task:
-          name: recursed1
+      - task: recursed1
   - name: recursed1
     actions:
-      - task:
-          name: recursive
+      - task: recursive

--- a/src/types/tasks.go
+++ b/src/types/tasks.go
@@ -27,7 +27,7 @@ type Task struct {
 // Action is a Zarf action inside a Task
 type Action struct {
 	*zarfTypes.ZarfComponentAction `yaml:",inline"`
-	TaskReference                  *TaskReference `json:"task,omitempty" jsonschema:"description=The task to run, mutually exclusive with cmd and wait"`
+	TaskReference                  string `json:"task,omitempty" jsonschema:"description=The task to run, mutually exclusive with cmd and wait"`
 }
 
 // TaskReference references the name of a task

--- a/tasks.schema.json
+++ b/tasks.schema.json
@@ -59,8 +59,7 @@
           "description": "Wait for a condition to be met before continuing. Must specify either cmd or wait for the action. See the 'zarf tools wait-for' command for more info."
         },
         "task": {
-          "$schema": "http://json-schema.org/draft-04/schema#",
-          "$ref": "#/definitions/TaskReference",
+          "type": "string",
           "description": "The task to run"
         }
       },
@@ -95,19 +94,6 @@
           },
           "type": "array",
           "description": "Actions to take when running the task"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "TaskReference": {
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Name of the task to run"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Removes `name` key under an `[]actions.task`, new syntax is:
```
actions:
  - task: name-of-task
```