### PR TITLE
fix: ensures runner cmds are templated

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -4,6 +4,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/spf13/cobra"
@@ -23,13 +25,16 @@ var runCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		var tasksFile types.TasksFile
 
-		err := utils.ReadYaml(config.TaskFileLocation, &tasksFile)
-		if err != nil {
+		if _, err := os.Stat(config.TaskFileLocation); os.IsNotExist(err) {
 			message.Fatalf(err, "%s not found", config.TaskFileLocation)
 		}
 
-		taskName := args[0]
+		err := utils.ReadYaml(config.TaskFileLocation, &tasksFile)
+		if err != nil {
+			message.Fatalf(err, "Cannot unmarshal %s", config.TaskFileLocation)
+		}
 
+		taskName := args[0]
 		if err := runner.Run(tasksFile, taskName); err != nil {
 			message.Fatalf(err, "Failed to run action: %s", err)
 		}

--- a/src/pkg/runner/runner.go
+++ b/src/pkg/runner/runner.go
@@ -283,6 +283,9 @@ func (r *Runner) performZarfAction(action *zarfTypes.ZarfComponentAction) error 
 		spinner.Errorf(err, "Error mutating command: %s", cmdEscaped)
 	}
 
+	// template cmd string
+	cmd = r.templateString(cmd)
+
 	duration := time.Duration(cfg.MaxTotalSeconds) * time.Second
 	timeout := time.After(duration)
 
@@ -365,12 +368,12 @@ func (r *Runner) performZarfAction(action *zarfTypes.ZarfComponentAction) error 
 	}
 }
 
-func (r *Runner) templateString(filename string) string {
+func (r *Runner) templateString(s string) string {
 	// Create a regular expression to match ${...}
 	re := regexp.MustCompile(`\${(.*?)}`)
 
 	// template string using values from the template map
-	result := re.ReplaceAllStringFunc(filename, func(matched string) string {
+	result := re.ReplaceAllStringFunc(s, func(matched string) string {
 		if value, ok := r.TemplateMap[matched]; ok {
 			return value.Value
 		}

--- a/src/test/e2e/runner_test.go
+++ b/src/test/e2e/runner_test.go
@@ -151,7 +151,8 @@ func TestUseCLI(t *testing.T) {
 
 		stdOut, stdErr, err := e2e.RunTasksWithFile("run", "cmd-set-variable")
 		require.NoError(t, err, stdOut, stdErr)
-		require.Contains(t, stdErr, "unique-value")
+		require.Contains(t, stdErr, "I'm set from setVariables - unique-value")
+		require.Contains(t, stdErr, "I'm set from a runner var - replaced")
 	})
 
 	t.Run("run reference", func(t *testing.T) {

--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -54,7 +54,8 @@ tasks:
         setVariables:
           - name: ACTION_VAR
             sensitive: true
-      - cmd: echo ${ACTION_VAR}
+      - cmd: echo "I'm set from setVariables - ${ACTION_VAR}"
+      - cmd: echo "I'm set from a runner var - ${REPLACE_ME}"
   - name: reference
     actions:
       - task: referenced


### PR DESCRIPTION
Fixes issue where runner cmds weren't being templated with vars