### PR TITLE
feat: add --set option for task runner variables

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -50,6 +50,7 @@ var runCmd = &cobra.Command{
 }
 
 func init() {
+	initViper()
 	rootCmd.AddCommand(runCmd)
 	runFlags := runCmd.Flags()
 	runFlags.StringVarP(&config.TaskFileLocation, "file", "f", config.TasksYAML, lang.CmdRunFlag)

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -54,5 +54,5 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 	runFlags := runCmd.Flags()
 	runFlags.StringVarP(&config.TaskFileLocation, "file", "f", config.TasksYAML, lang.CmdRunFlag)
-	runFlags.StringToStringVar(&config.SetVariables, "set", v.GetStringMapString(common.VPkgCreateSet), lang.CmdPackageCreateFlagSet)
+runFlags.StringToStringVar(&config.SetVariables, "set", v.GetStringMapString(common.VPkgCreateSet), lang.CmdRunSetVarFlag)
 }

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"os"
+	"strings"
 
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
@@ -14,6 +15,8 @@ import (
 	"github.com/defenseunicorns/uds-cli/src/config/lang"
 	"github.com/defenseunicorns/uds-cli/src/pkg/runner"
 	"github.com/defenseunicorns/uds-cli/src/types"
+	"github.com/defenseunicorns/zarf/src/cmd/common"
+	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
 )
 
 // runCmd represents the run command
@@ -28,6 +31,11 @@ var runCmd = &cobra.Command{
 		if _, err := os.Stat(config.TaskFileLocation); os.IsNotExist(err) {
 			message.Fatalf(err, "%s not found", config.TaskFileLocation)
 		}
+		
+		// Ensure uppercase keys from viper
+		v := common.GetViper()
+		config.SetVariables = helpers.TransformAndMergeMap(
+			v.GetStringMapString(common.VPkgCreateSet), config.SetVariables, strings.ToUpper)
 
 		err := utils.ReadYaml(config.TaskFileLocation, &tasksFile)
 		if err != nil {
@@ -35,7 +43,7 @@ var runCmd = &cobra.Command{
 		}
 
 		taskName := args[0]
-		if err := runner.Run(tasksFile, taskName); err != nil {
+		if err := runner.Run(tasksFile, taskName, config.SetVariables); err != nil {
 			message.Fatalf(err, "Failed to run action: %s", err)
 		}
 	},
@@ -45,4 +53,5 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 	runFlags := runCmd.Flags()
 	runFlags.StringVarP(&config.TaskFileLocation, "file", "f", config.TasksYAML, lang.CmdRunFlag)
+	runFlags.StringToStringVar(&config.SetVariables, "set", v.GetStringMapString(common.VPkgCreateSet), lang.CmdPackageCreateFlagSet)
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -63,6 +63,9 @@ var (
 
 	// TaskFileLocation is the location of the tasks file to run
 	TaskFileLocation string
+
+	// SetVariables is a map of the run time variables defined using --set
+	SetVariables map[string]string
 )
 
 // GetArch returns the arch based on a priority list with options for overriding.

--- a/src/config/lang/lang.go
+++ b/src/config/lang/lang.go
@@ -65,5 +65,5 @@ const (
 
 	// uds run
 	CmdRunFlag = "Name and location of task file to run"
-	CmdPackageCreateFlagSet = "Specify package variables to set on the command line (KEY=value)"
+CmdRunSetVarFlag = "Set a runner variable from the command line (KEY=value)"
 )

--- a/src/config/lang/lang.go
+++ b/src/config/lang/lang.go
@@ -65,4 +65,5 @@ const (
 
 	// uds run
 	CmdRunFlag = "Name and location of task file to run"
+	CmdPackageCreateFlagSet = "Specify package variables to set on the command line (KEY=value)"
 )

--- a/src/test/e2e/runner_test.go
+++ b/src/test/e2e/runner_test.go
@@ -170,4 +170,13 @@ func TestUseCLI(t *testing.T) {
 		require.Error(t, err, stdOut, stdErr)
 		require.Contains(t, stdErr, "task loop detected")
 	})
+
+	t.Run("run cmd-set-variable with --set", func(t *testing.T) {
+		t.Parallel()
+
+		stdOut, stdErr, err := e2e.RunTasksWithFile("run", "cmd-set-variable", "--set", "REPLACE_ME=replacedWith--setvar", "--set", "UNICORNS=defense")
+		require.NoError(t, err, stdOut, stdErr)
+		require.Contains(t, stdErr, "I'm set from a runner var - replacedWith--setvar")
+		require.Contains(t, stdErr, "I'm set from a new --set var - defense")
+	})
 }

--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -56,6 +56,8 @@ tasks:
             sensitive: true
       - cmd: echo "I'm set from setVariables - ${ACTION_VAR}"
       - cmd: echo "I'm set from a runner var - ${REPLACE_ME}"
+      - cmd: echo "I'm set from a --set var - ${REPLACE_ME}"
+      - cmd: echo "I'm set from a new --set var - ${UNICORNS}"
   - name: reference
     actions:
       - task: referenced


### PR DESCRIPTION
## Description

Addresses #146 adding the --set option to set variables when calling `uds run`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed