### PR TITLE
fix: add shorthand instructions for publish command

### DIFF
--- a/src/cmd/uds.go
+++ b/src/cmd/uds.go
@@ -143,7 +143,7 @@ var removeCmd = &cobra.Command{
 var publishCmd = &cobra.Command{
 	Use:     "publish [BUNDLE_TARBALL] [OCI_REF]",
 	Aliases: []string{"p"},
-	Short:   lang.CmdBundlePullShort,
+	Short:   lang.CmdPublishShort,
 	Args:    cobra.ExactArgs(2),
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if _, err := os.Stat(args[0]); err != nil {

--- a/src/config/lang/lang.go
+++ b/src/config/lang/lang.go
@@ -41,6 +41,9 @@ const (
 	CmdBundleRemoveShort       = "Remove a bundle that has been deployed already"
 	CmdBundleRemoveFlagConfirm = "REQUIRED. Confirm the removal action to prevent accidental deletions"
 
+	// bundle publish
+	CmdPublishShort = "Publish a bundle from the local file system to a remote registry"
+
 	// bundle pull
 	CmdBundlePullShort      = "Pull a bundle from a remote registry and save to the local file system"
 	CmdBundlePullFlagOutput = "Specify the output directory for the pulled bundle"
@@ -64,6 +67,6 @@ const (
 	CmdInternalConfigSchemaErr   = "Unable to generate the uds-bundle.yaml schema"
 
 	// uds run
-	CmdRunFlag = "Name and location of task file to run"
-CmdRunSetVarFlag = "Set a runner variable from the command line (KEY=value)"
+	CmdRunFlag       = "Name and location of task file to run"
+	CmdRunSetVarFlag = "Set a runner variable from the command line (KEY=value)"
 )


### PR DESCRIPTION
## Description

The `uds publish` command's help message was printing the `uds pull` command's message. Added new verbiage for publish

## Related Issue

n/a

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed