### PR TITLE
fix: hotfix for broken pull operation

### DIFF
--- a/src/pkg/bundle/bundle.go
+++ b/src/pkg/bundle/bundle.go
@@ -110,9 +110,7 @@ func Create(b *Bundler, signature []byte) error {
 			}
 
 			zarfPkgDesc, err := localBundler.ToBundle(store, zarfPkg, artifactPathMap, b.tmp, pkgTmp)
-			zarfPkgDesc.Annotations = map[string]string{
-				ocispec.AnnotationTitle: pkg.Name,
-			}
+
 			if err != nil {
 				return err
 			}

--- a/src/pkg/bundle/remote.go
+++ b/src/pkg/bundle/remote.go
@@ -99,7 +99,7 @@ func (op *ociProvider) CreateBundleSBOM(extractSBOM bool) error {
 			return err
 		}
 		if sbomDesc.Annotations == nil {
-			message.Warnf("%s not found in Zarf pkg: %s", config.SBOMsTar, zarfManifest.Annotations[ocispec.AnnotationTitle])
+			message.Warnf("%s not found in Zarf pkg", config.SBOMsTar)
 		}
 		// grab sboms.tar and extract
 		sbomBytes, err := op.OrasRemote.FetchLayer(sbomDesc)


### PR DESCRIPTION
Removes annotation from root manifest layers to fix broken pull. Other logic in the codebase depends on those annotations and adding an additional one jacked up that logic