### PR TITLE
chore: remove draft status after releasing

### DIFF
--- a/.github/workflows/scan-codeql.yaml
+++ b/.github/workflows/scan-codeql.yaml
@@ -16,6 +16,7 @@ on:
       - "adr/**"
       - "docs/**"
       - "CODEOWNERS"
+      - "goreleaser.yml"
   schedule:
     - cron: "32 2 * * 5"
 

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -10,6 +10,7 @@ on:
       - "adr/**"
       - "docs/**"
       - "CODEOWNERS"
+      - "goreleaser.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -10,6 +10,7 @@ on:
       - "adr/**"
       - "docs/**"
       - "CODEOWNERS"
+      - "goreleaser.yml"
 
 permissions:
   contents: read

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,4 +71,4 @@ release:
     name: uds-cli
   prerelease: auto
   mode: append
-  draft: true
+  draft: false


### PR DESCRIPTION
## Description
When the release pipeline runs, don't put the Github Release in draft status, go ahead and release it automatically