### PR TITLE
feat: import local tasks into runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ __debug_bin
 sboms
 bundle-sboms
 node_modules
+checksums.txt

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -11,12 +11,13 @@ import (
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/spf13/cobra"
 
+	"github.com/defenseunicorns/zarf/src/cmd/common"
+	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
+
 	"github.com/defenseunicorns/uds-cli/src/config"
 	"github.com/defenseunicorns/uds-cli/src/config/lang"
 	"github.com/defenseunicorns/uds-cli/src/pkg/runner"
 	"github.com/defenseunicorns/uds-cli/src/types"
-	"github.com/defenseunicorns/zarf/src/cmd/common"
-	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
 )
 
 // runCmd represents the run command
@@ -31,7 +32,7 @@ var runCmd = &cobra.Command{
 		if _, err := os.Stat(config.TaskFileLocation); os.IsNotExist(err) {
 			message.Fatalf(err, "%s not found", config.TaskFileLocation)
 		}
-		
+
 		// Ensure uppercase keys from viper
 		v := common.GetViper()
 		config.SetVariables = helpers.TransformAndMergeMap(
@@ -54,5 +55,5 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 	runFlags := runCmd.Flags()
 	runFlags.StringVarP(&config.TaskFileLocation, "file", "f", config.TasksYAML, lang.CmdRunFlag)
-runFlags.StringToStringVar(&config.SetVariables, "set", v.GetStringMapString(common.VPkgCreateSet), lang.CmdRunSetVarFlag)
+	runFlags.StringToStringVar(&config.SetVariables, "set", v.GetStringMapString(common.VPkgCreateSet), lang.CmdRunSetVarFlag)
 }

--- a/src/pkg/bundler/remote.go
+++ b/src/pkg/bundler/remote.go
@@ -38,6 +38,7 @@ type RemoteBundler struct {
 }
 
 // NewRemoteBundler creates a bundler to pull remote Zarf pkgs
+// todo: document this fn better or break out into multiple constructors
 func NewRemoteBundler(pkg types.BundleZarfPackage, url string, localDst *ocistore.Store, remoteDst *oci.OrasRemote, tmpDir string) (RemoteBundler, error) {
 	src, err := oci.NewOrasRemote(url)
 	if err != nil {
@@ -170,7 +171,7 @@ func (b *RemoteBundler) remoteToLocal(layersToCopy []ocispec.Descriptor) ([]ocis
 		if layer.Digest == "" {
 			continue
 		}
-		// check if layer already exists; todo: this is VERY slow
+		// check if layer already exists
 		if exists, _ := b.localDst.Exists(b.ctx, layer); exists {
 			continue
 		} else if cache.Exists(layer.Digest.Encoded()) {

--- a/src/pkg/cache/cache.go
+++ b/src/pkg/cache/cache.go
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-Present The UDS Authors
 
+// Package cache provides a primitive cache mechanism for bundle layers
 package cache
 
 import (

--- a/src/test/common.go
+++ b/src/test/common.go
@@ -56,7 +56,7 @@ func (e2e *UDSE2ETest) UDS(args ...string) (string, string, error) {
 
 // RunTasksWithFile executes a UDS run command. with the --file flag set to the test/tasks.yaml file.
 func (e2e *UDSE2ETest) RunTasksWithFile(args ...string) (string, string, error) {
-	args = append(args, "--file", "src/test/tasks.yaml")
+	args = append(args, "--file", "src/test/tasks/tasks.yaml")
 	fmt.Println(args)
 	return exec.CmdWithContext(context.TODO(), exec.PrintCfg(), e2e.UDSBinPath, args...)
 }

--- a/src/test/tasks/even-more-tasks-to-import.yaml
+++ b/src/test/tasks/even-more-tasks-to-import.yaml
@@ -1,0 +1,8 @@
+tasks:
+  - name: set-var
+    actions:
+      - cmd: |
+          echo "defenseunicorns"
+        setVariables:
+          - name: PRETTY_OK_COMPANY
+            sensitive: false

--- a/src/test/tasks/more-tasks-to-import.yaml
+++ b/src/test/tasks/more-tasks-to-import.yaml
@@ -1,0 +1,8 @@
+includes:
+  - even-more: even-more-tasks-to-import.yaml
+
+tasks:
+  # single task that is imported with name collision
+  - name: set-var
+    actions:
+      - task: even-more:set-var

--- a/src/test/tasks/tasks-to-import.yaml
+++ b/src/test/tasks/tasks-to-import.yaml
@@ -1,0 +1,16 @@
+includes:
+  - common: "./more-tasks-to-import.yaml"
+
+variables:
+  - name: CHECKSUMS
+    default: checksums.txt
+
+tasks:
+  - name: fetch-checksums
+    actions:
+      - task: common:set-var
+      - task: curl
+  - name: curl
+    files:
+      - source: https://github.com/${PRETTY_OK_COMPANY}/zarf/releases/download/v0.30.1/${CHECKSUMS}
+        target: ${CHECKSUMS}

--- a/src/test/tasks/tasks.yaml
+++ b/src/test/tasks/tasks.yaml
@@ -1,8 +1,9 @@
+includes:
+  - imported: ./tasks-to-import.yaml
+
 variables:
   - name: REPLACE_ME
     default: replaced
-  - name: CHECKSUMS
-    default: checksums.txt
 
 tasks:
   - name: copy
@@ -25,21 +26,10 @@ tasks:
         target: symcopy
         symlinks:
           - "testlink"
-  - name: pre-remote
-    actions:
-      - cmd: |
-          echo "defenseunicorns"
-        setVariables:
-          - name: PRETTY_OK_COMPANY
-            sensitive: false
-  - name: pull-remote
-    files:
-      - source: https://github.com/${PRETTY_OK_COMPANY}/zarf/releases/download/v0.30.1/${CHECKSUMS}
-        target: ${CHECKSUMS}
   - name: remote
     actions:
-      - task: pre-remote
-      - task: pull-remote
+      # tasks imported from imported-tasks.yaml
+      - task: imported:fetch-checksums
   - name: template-file
     files:
       - source: raw

--- a/src/types/tasks.go
+++ b/src/types/tasks.go
@@ -10,6 +10,7 @@ import (
 
 // TasksFile represents the contents of a tasks file
 type TasksFile struct {
+	Includes  []map[string]string             `json:"includes,omitempty" jsonschema:"description=List of local task files to include"`
 	Variables []zarfTypes.ZarfPackageVariable `json:"variables,omitempty" jsonschema:"description=Definitions and default values for variables used in run.yaml"`
 	Tasks     []Task                          `json:"tasks" jsonschema:"description=The list of tasks that can be run"`
 }

--- a/tasks.schema.json
+++ b/tasks.schema.json
@@ -104,6 +104,18 @@
         "tasks"
       ],
       "properties": {
+        "includes": {
+          "items": {
+            "patternProperties": {
+              ".*": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array",
+          "description": "List of local task files to include"
+        },
         "variables": {
           "items": {
             "$schema": "http://json-schema.org/draft-04/schema#",


### PR DESCRIPTION
Adds ability to import local task files into the runner using syntax:
```yaml
includes:
  - foo: ./tasks-to-import.yaml
tasks:
  - name: the-task
    actions:
      - task: foo:imported-task
```
Where `imported-task` exists in the `tasks-to-import.yaml`