### PR TITLE
chore: refines renovate configs to pick up Zarf updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,6 @@
   "dependencyDashboard": true,
   "platform": "github",
   "onboarding": false,
-  "requireConfig": false,
   "dependencyDashboardTitle": "Renovate Dashboard 🤖",
   "rebaseWhen": "conflicted",
   "commitBodyTable": true,
@@ -23,13 +22,12 @@
   "regexManagers": [
     {
       "fileMatch": [
-        "(^|/)uds-bundle.yaml$",
-        "(^|/)action.yaml$"
+        "uds-bundle.yaml",
+        "action.yaml"
       ],
-      "matchStringsStrategy": "recursive",
+      "ignorePaths": [],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( registryUrl=(?<registryUrl>.*?))?\\s.*?version: (?<currentValue>.*)\\s",
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( registryUrl=(?<registryUrl>.*?))?\\s.*?ref: (?<currentValue>.*)\\s"
+        "# renovate: datasource=(?<datasource>.*) depName=(?<depName>.*)(versioning=(?<versioning>.*))?(registryUrl=(?<registryUrl>.*))?\\n\\s*(version|ref): (?<currentValue>.*)"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }

--- a/src/test/bundles/04-init/uds-bundle.yaml
+++ b/src/test/bundles/04-init/uds-bundle.yaml
@@ -14,8 +14,8 @@ zarf-packages:
     optional-components:
       - git-server
   - name: init
-    # renovate: datasource=github-tags depName=defenseunicorns/zarf
     repository: ghcr.io/defenseunicorns/packages/init
+    # renovate: datasource=github-tags depName=defenseunicorns/zarf
     ref: v0.31.2
     optional-components:
       - git-server


### PR DESCRIPTION
## Description
Renovate wasn't updating the proper files, tested locally with `RENOVATE_CONFIG_FILE=renovate.json npx renovate --token=<my_pat> --schedule="" --require-config=ignored --dry-run=full`