### PR TITLE
chore: ensures all Zarf deps get updated together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,12 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["defenseunicorns/zarf", "github.com/defenseunicorns/zarf"],
+      "groupName": "zarf"
+    }
+  ],
   "regexManagers": [
     {
       "fileMatch": [


### PR DESCRIPTION
## Description
- Had a chicken/egg scenario where the Zarf Golang dep depended on the Zarf version used in the test suite, which broke Renovate. This PR ensures that Zarf update PRs from Renovate combine Go mod update with the test suite update