### PR TITLE
chore: improve bundle remove logic

### DIFF
--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -82,7 +82,7 @@ func (b *Bundler) Deploy() error {
 	var packagesToDeploy []types.BundleZarfPackage
 
 	if len(b.cfg.DeployOpts.Packages) != 0 {
-		userSpecifiedPackages := strings.Split(b.cfg.DeployOpts.Packages[0], ",")
+		userSpecifiedPackages := strings.Split(strings.ReplaceAll(b.cfg.DeployOpts.Packages[0], " ",""), ",")
 
 		for _, pkg := range b.bundle.ZarfPackages {
 			if slices.Contains(userSpecifiedPackages, pkg.Name) {

--- a/src/pkg/bundle/remove.go
+++ b/src/pkg/bundle/remove.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/packager"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	zarfTypes "github.com/defenseunicorns/zarf/src/types"
@@ -18,6 +19,9 @@ import (
 	"github.com/defenseunicorns/uds-cli/src/pkg/sources"
 	"github.com/defenseunicorns/uds-cli/src/types"
 )
+
+// Error string that gets thrown when attempting to remove a package that is not deployed
+var removeError = "unable to load the secret for the package we are attempting to remove:"
 
 // Remove removes packages deployed from a bundle
 func (b *Bundler) Remove() error {
@@ -87,7 +91,12 @@ func removePackages(packagesToRemove []types.BundleZarfPackage, b *Bundler) erro
 		defer pkgClient.ClearTempPaths()
 
 		if err := pkgClient.Remove(); err != nil {
-			return err
+			// Check if error is due to attempting to remove package that is not deployed
+			if(strings.Contains(err.Error(), removeError)){
+				message.Warn(err.Error())
+			}else{
+				return err
+			}
 		}
 	}
 

--- a/src/pkg/bundle/remove.go
+++ b/src/pkg/bundle/remove.go
@@ -47,7 +47,7 @@ func (b *Bundler) Remove() error {
 	var packagesToRemove []types.BundleZarfPackage
 
 	if len(b.cfg.RemoveOpts.Packages) != 0 {
-		userSpecifiedPackages := strings.Split(b.cfg.RemoveOpts.Packages[0], ",")
+		userSpecifiedPackages := strings.Split(strings.ReplaceAll(b.cfg.RemoveOpts.Packages[0]," ",""), ",")
 		for _, pkg := range b.bundle.ZarfPackages {
 			if slices.Contains(userSpecifiedPackages, pkg.Name) {
 				packagesToRemove = append(packagesToRemove, pkg)

--- a/src/pkg/bundle/remove.go
+++ b/src/pkg/bundle/remove.go
@@ -62,7 +62,7 @@ func (b *Bundler) Remove() error {
 }
 
 func removePackages(packagesToRemove []types.BundleZarfPackage, b *Bundler) error {
-	
+
 	// Get deployed packages
 	cluster := cluster.NewClusterOrDie()
 	deployedPackages, err := cluster.GetDeployedZarfPackages()
@@ -70,11 +70,11 @@ func removePackages(packagesToRemove []types.BundleZarfPackage, b *Bundler) erro
 		return nil
 	}
 	deployedPackageNames := getDeployedPackageNames(deployedPackages)
-	
+
 	for i := len(packagesToRemove) - 1; i >= 0; i-- {
-		
+
 		pkg := packagesToRemove[i]
-		
+
 		if(slices.Contains(deployedPackageNames, pkg.Name)) {
 			opts := zarfTypes.ZarfPackageOptions{
 				PackageSource: b.cfg.RemoveOpts.Source,
@@ -117,5 +117,3 @@ func getDeployedPackageNames(deployedPackages []zarfTypes.DeployedPackage) []str
 	}
 	return deployedPackageNames
 }
-
-

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -193,8 +193,7 @@ func TestPackagesFlag(t *testing.T) {
 	require.Contains(t, deployments, "podinfo")
 	require.NotContains(t, deployments, "nginx")
 
-	_, stderr := removeWithError(bundlePath)
-	require.Contains(t, stderr, "Failed to remove bundle:")
+	remove(t, bundlePath)
 
 	// Test both podinfo and nginx deploy
 	deployPackagesFlag(bundlePath, "podinfo,nginx")
@@ -215,7 +214,7 @@ func TestPackagesFlag(t *testing.T) {
 	require.NotContains(t, deployments, "nginx")
 
 	// Test invalid package deploy
-	_, stderr = deployPackagesFlag(bundlePath, "podinfo,nginx,peanuts")
+	_, stderr := deployPackagesFlag(bundlePath, "podinfo,nginx,peanuts")
 	require.Contains(t, stderr, "invalid zarf packages specified by --packages")
 
 	// Test invalid package remove
@@ -410,12 +409,6 @@ func deployFromOCI(t *testing.T, ref string) (stdout string, stderr string) {
 
 func deployPackagesFlag(tarballPath string, packages string) (stdout string, stderr string) {
 	cmd := strings.Split(fmt.Sprintf("deploy %s --confirm -l=debug --packages %s", tarballPath, packages), " ")
-	stdout, stderr, _ = e2e.UDS(cmd...)
-	return stdout, stderr
-}
-
-func removeWithError(tarballPath string) (stdout string, stderr string) {
-	cmd := strings.Split(fmt.Sprintf("remove %s --confirm --insecure", tarballPath), " ")
 	stdout, stderr, _ = e2e.UDS(cmd...)
 	return stdout, stderr
 }


### PR DESCRIPTION
## Description

Improves bundle remove logic, so it doesn't just die if attempting to remove a package that isn't deployed. Now it gives a warning and continues

## Related Issue

Relates to #236 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
