### PR TITLE
feat: enable bundle --resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ As an example: `uds deploy uds-bundle-<name>.tar.zst --packages init,nginx`
 #### `--resume`
 By default all the packages in the bundle are deployed, regardless of if they have already been deployed, but you can also choose to only deploy packages that have not already been deployed by using the `--resume` flag
 
-As an example: ``uds deploy uds-bundle-<name>.tar.zst --resume`
+As an example: `uds deploy uds-bundle-<name>.tar.zst --resume`
 
 ### Bundle Inspect
 Inspect the `uds-bundle.yaml` of a bundle

--- a/README.md
+++ b/README.md
@@ -71,9 +71,15 @@ There are 2 ways to deploy Bundles:
 1. From an OCI registry: `uds deploy oci://localhost:5000/<name>:<tag> --insecure`
 1. From your local filesystem: `uds deploy uds-bundle-<name>.tar.zst`
 
+#### `--packages`
 By default all the packages in the bundle are deployed, but you can also deploy only certain packages in the bundle by using the `--packages` flag.
 
 As an example: `uds deploy uds-bundle-<name>.tar.zst --packages init,nginx`
+
+#### `--resume`
+By default all the packages in the bundle are deployed, regardless of if they have already been deployed, but you can also choose to only deploy packages that have not already been deployed by using the `--resume` flag
+
+As an example: ``uds deploy uds-bundle-<name>.tar.zst --resume`
 
 ### Bundle Inspect
 Inspect the `uds-bundle.yaml` of a bundle

--- a/src/cmd/uds.go
+++ b/src/cmd/uds.go
@@ -217,6 +217,7 @@ func init() {
 	rootCmd.AddCommand(deployCmd)
 	deployCmd.Flags().BoolVarP(&config.CommonOptions.Confirm, "confirm", "c", false, lang.CmdBundleDeployFlagConfirm)
 	deployCmd.Flags().StringArrayVarP(&bundleCfg.DeployOpts.Packages, "packages", "p", []string{}, lang.CmdBundleDeployFlagPackages)
+	deployCmd.Flags().BoolVarP(&bundleCfg.DeployOpts.Resume, "resume", "r", false, lang.CmdBundleDeployFlagResume)
 
 	// inspect cmd flags
 	rootCmd.AddCommand(inspectCmd)

--- a/src/config/lang/lang.go
+++ b/src/config/lang/lang.go
@@ -31,6 +31,7 @@ const (
 	CmdBundleDeployShort        = "Deploy a bundle from a local tarball or oci:// URL"
 	CmdBundleDeployFlagConfirm  = "Confirms bundle deployment without prompting. ONLY use with bundles you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes."
 	CmdBundleDeployFlagPackages = "Specify which zarf packages you would like to deploy from the bundle. By default all zarf packages in the bundle are deployed."
+	CmdBundleDeployFlagResume = "Only deploys packages from the bundle which haven't already been deployed"
 
 	// bundle inspect
 	CmdBundleInspectShort            = "Display the metadata of a bundle"

--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -271,6 +271,7 @@ func ValidateBundleSignature(bundleYAMLPath, signaturePath, publicKeyPath string
 	return utils.CosignVerifyBlob(bundleYAMLPath, signaturePath, publicKeyPath)
 }
 
+// GetDeployedPackages returns packages that have been deployed 
 func GetDeployedPackages()([]zarfTypes.DeployedPackage, error){
 	cluster := cluster.NewClusterOrDie()
 	deployedPackages, errs := cluster.GetDeployedZarfPackages()
@@ -280,6 +281,7 @@ func GetDeployedPackages()([]zarfTypes.DeployedPackage, error){
 	return deployedPackages, nil
 }
 
+// GetDeployedPackageNames returns the names of the packages that have been deployed
 func GetDeployedPackageNames()[]string {
 	var deployedPackageNames []string
 	deployedPackages, _ := GetDeployedPackages()

--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -271,7 +271,7 @@ func ValidateBundleSignature(bundleYAMLPath, signaturePath, publicKeyPath string
 	return utils.CosignVerifyBlob(bundleYAMLPath, signaturePath, publicKeyPath)
 }
 
-// GetDeployedPackages returns packages that have been deployed 
+// GetDeployedPackages returns packages that have been deployed
 func GetDeployedPackages()([]zarfTypes.DeployedPackage, error){
 	cluster := cluster.NewClusterOrDie()
 	deployedPackages, errs := cluster.GetDeployedZarfPackages()

--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -12,9 +12,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/defenseunicorns/zarf/src/pkg/cluster"
 	"github.com/defenseunicorns/uds-cli/src/config"
 	"github.com/defenseunicorns/uds-cli/src/pkg/bundler"
 	"github.com/defenseunicorns/uds-cli/src/types"
+	"github.com/defenseunicorns/zarf/src/config/lang"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
@@ -267,4 +269,22 @@ func ValidateBundleSignature(bundleYAMLPath, signaturePath, publicKeyPath string
 
 	// The package is signed, and a public key was provided
 	return utils.CosignVerifyBlob(bundleYAMLPath, signaturePath, publicKeyPath)
+}
+
+func GetDeployedPackages()([]zarfTypes.DeployedPackage, error){
+	cluster := cluster.NewClusterOrDie()
+	deployedPackages, errs := cluster.GetDeployedZarfPackages()
+	if len(errs) > 0 {
+		return nil,lang.ErrUnableToGetPackages
+	}
+	return deployedPackages, nil
+}
+
+func GetDeployedPackageNames()[]string {
+	var deployedPackageNames []string
+	deployedPackages, _ := GetDeployedPackages()
+	for _,pkg := range deployedPackages{
+		deployedPackageNames = append(deployedPackageNames, pkg.Name)
+	}
+	return deployedPackageNames
 }

--- a/src/pkg/bundle/remove.go
+++ b/src/pkg/bundle/remove.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/defenseunicorns/zarf/src/pkg/cluster"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/packager"
 	"github.com/defenseunicorns/zarf/src/pkg/utils"
@@ -64,12 +63,7 @@ func (b *Bundler) Remove() error {
 func removePackages(packagesToRemove []types.BundleZarfPackage, b *Bundler) error {
 
 	// Get deployed packages
-	cluster := cluster.NewClusterOrDie()
-	deployedPackages, err := cluster.GetDeployedZarfPackages()
-	if err != nil {
-		return nil
-	}
-	deployedPackageNames := getDeployedPackageNames(deployedPackages)
+	deployedPackageNames := GetDeployedPackageNames()
 
 	for i := len(packagesToRemove) - 1; i >= 0; i-- {
 
@@ -108,12 +102,4 @@ func removePackages(packagesToRemove []types.BundleZarfPackage, b *Bundler) erro
 	}
 
 	return nil
-}
-
-func getDeployedPackageNames(deployedPackages []zarfTypes.DeployedPackage) []string {
-	var deployedPackageNames []string
-	for _,pkg := range deployedPackages{
-		deployedPackageNames = append(deployedPackageNames, pkg.Name)
-	}
-	return deployedPackageNames
 }

--- a/src/types/bundler.go
+++ b/src/types/bundler.go
@@ -25,6 +25,7 @@ type BundlerCreateOptions struct {
 
 // BundlerDeployOptions is the options for the bundler.Deploy() function
 type BundlerDeployOptions struct {
+	Resume               bool
 	Source               string
 	Packages             []string
 	PublicKeyPath        string


### PR DESCRIPTION
## Description

Enable the ability to resume bundle deploy. Ability to resume bundle remove, is already available with remove work that was previously done.

## Related Issue

Relates to #61 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
