### PR TITLE
fix: properly parse config files missing `variables`

### DIFF
--- a/src/cmd/uds.go
+++ b/src/cmd/uds.go
@@ -5,7 +5,6 @@
 package cmd
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -183,15 +182,8 @@ func loadViperConfig() error {
 		return err
 	}
 
-	// unmarshal config file at key
-	// need to use goyaml because Viper doesn't preserve case: https://github.com/spf13/viper/issues/1014
-	pathString, err := goyaml.PathString("$.variables")
-	if err != nil {
-		return err
-	}
-
 	// read relevant config into DeployOpts.Variables
-	err = pathString.Read(bytes.NewReader(configFile), &bundleCfg.DeployOpts.Variables)
+	err = goyaml.Unmarshal(configFile, &bundleCfg.DeployOpts)
 	if err != nil {
 		return err
 	}

--- a/src/test/bundles/01-uds-bundle/uds-config.yaml
+++ b/src/test/bundles/01-uds-bundle/uds-config.yaml
@@ -1,0 +1,2 @@
+options:
+  log_level: debug

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -160,6 +160,8 @@ func TestBundle(t *testing.T) {
 	create(t, bundleDir) // todo: allow creating from both the folder containing and direct reference to uds-bundle.yaml
 	inspect(t, bundlePath)
 	inspectAndSBOMExtract(t, bundlePath)
+	// Test with an "options only" config file
+	os.Setenv("UDS_CONFIG", filepath.Join("src/test/bundles/01-uds-bundle", "uds-config.yaml"))
 	deploy(t, bundlePath)
 	remove(t, bundlePath)
 }

--- a/src/types/bundler.go
+++ b/src/types/bundler.go
@@ -29,7 +29,7 @@ type BundlerDeployOptions struct {
 	Source        string
 	Packages      []string
 	PublicKeyPath string
-	Variables     map[string]map[string]interface{}
+	Variables     map[string]map[string]interface{} `yaml:"variables,omitempty"`
 }
 
 // BundlerInspectOptions is the options for the bundler.Inspect() function


### PR DESCRIPTION
## Description

Switches to unmashal with goyaml + `omitempty` on `variables`.

Also added a sample uds-config that just uses options (no variables) on the 01 test to hopefully catch this in the future, can turn it into a separate test case if desired.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-cli/issues/276

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
