### PR TITLE
fix: handle multiple nested includes

### DIFF
--- a/src/pkg/runner/runner.go
+++ b/src/pkg/runner/runner.go
@@ -62,9 +62,9 @@ func (r *Runner) processIncludes(task types.Task, tasksFile types.TasksFile) err
 	for _, a := range task.Actions {
 		if strings.Contains(a.TaskReference, ":") {
 			taskReferenceName := strings.Split(a.TaskReference, ":")[0]
-			for _, b := range tasksFile.Includes {
-				if b[taskReferenceName] != "" {
-					referencedIncludes := []map[string]string{b}
+			for _, include := range tasksFile.Includes {
+				if include[taskReferenceName] != "" {
+					referencedIncludes := []map[string]string{include}
 					err := r.importTasks(referencedIncludes, config.TaskFileLocation)
 					if err != nil {
 						return err

--- a/src/pkg/runner/runner.go
+++ b/src/pkg/runner/runner.go
@@ -47,7 +47,6 @@ func Run(tasksFile types.TasksFile, taskName string, setVariables map[string]str
 		return err
 	}
 
-	// only process includes if the task requires them
 	runner.processIncludes(task, tasksFile)
 
 	if err = runner.checkForTaskLoops(task, tasksFile); err != nil {

--- a/src/pkg/runner/runner.go
+++ b/src/pkg/runner/runner.go
@@ -48,28 +48,33 @@ func Run(tasksFile types.TasksFile, taskName string, setVariables map[string]str
 	}
 
 	// only process includes if the task requires them
-	for _, a := range task.Actions {
-		if strings.Contains(a.TaskReference, ":") {
-			taskReferenceName := strings.Split(a.TaskReference, ":")[0]
-			for _, include := range tasksFile.Includes {
-				if include[taskReferenceName] != "" {
-					referencedIncludes := []map[string]string{include}
-					err = runner.importTasks(referencedIncludes, config.TaskFileLocation)
-					break
-				}
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
+	runner.processIncludes(task, tasksFile)
 
-	if err = runner.checkForTaskLoops(task); err != nil {
+	if err = runner.checkForTaskLoops(task, tasksFile); err != nil {
 		return err
 	}
 
 	err = runner.executeTask(task)
 	return err
+}
+
+func (r *Runner) processIncludes(task types.Task, tasksFile types.TasksFile) error {
+	for _, a := range task.Actions {
+		if strings.Contains(a.TaskReference, ":") {
+			taskReferenceName := strings.Split(a.TaskReference, ":")[0]
+			for _, b := range tasksFile.Includes {
+				if b[taskReferenceName] != "" {
+					referencedIncludes := []map[string]string{b}
+					err := r.importTasks(referencedIncludes, config.TaskFileLocation)
+					if err != nil {
+						return err
+					}
+					break
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (r *Runner) importTasks(includes []map[string]string, dir string) error {
@@ -302,7 +307,7 @@ func (r *Runner) performAction(action types.Action) error {
 	return nil
 }
 
-func (r *Runner) checkForTaskLoops(task types.Task) error {
+func (r *Runner) checkForTaskLoops(task types.Task, tasksFile types.TasksFile) error {
 	// Filtering unique task actions allows for rerunning tasks in the same execution
 	uniqueTaskActions := getUniqueTaskActions(task.Actions)
 	for _, action := range uniqueTaskActions {
@@ -316,7 +321,9 @@ func (r *Runner) checkForTaskLoops(task types.Task) error {
 			if err != nil {
 				return err
 			}
-			if err = r.checkForTaskLoops(newTask); err != nil {
+			// check new task includes
+			r.processIncludes(newTask, tasksFile)
+			if err = r.checkForTaskLoops(newTask, tasksFile); err != nil {
 				return err
 			}
 		}

--- a/src/test/e2e/runner_test.go
+++ b/src/test/e2e/runner_test.go
@@ -241,4 +241,20 @@ func TestUseCLI(t *testing.T) {
 		require.Contains(t, stdErr, "echo bar")
 		require.Contains(t, stdErr, "defenseunicorns is a pretty ok company")
 	})
+
+	t.Run("test action with multiple nested include tasks", func(t *testing.T) {
+		t.Parallel()
+		gitRev, err := e2e.GetGitRevision()
+		if err != nil {
+			return
+		}
+		setVar := fmt.Sprintf("GIT_REVISION=%s", gitRev)
+
+		stdOut, stdErr, err := e2e.RunTasksWithFile("run", "extra-foobar", "--set", setVar)
+		require.NoError(t, err, stdOut, stdErr)
+		require.Contains(t, stdErr, "echo foo")
+		require.Contains(t, stdErr, "echo bar")
+		require.Contains(t, stdErr, "defenseunicorns")
+		require.Contains(t, stdErr, "defenseunicorns is a pretty ok company")
+	})
 }

--- a/src/test/tasks/tasks.yaml
+++ b/src/test/tasks/tasks.yaml
@@ -96,3 +96,6 @@ tasks:
     actions:
       - task: foo:foobar
       - task: remote:echo-var
+  - name: extra-foobar
+    actions:
+      - task: more-foobar


### PR DESCRIPTION
## Description

Issue was found where if you reference a task with multiple includes from another task, it errors out not being able to pull in those includes. Not able to process includes of "sibling"

## Related Issue

Fixes #283 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
