### PR TITLE
fix: fixes bad media type when using create -o with GHCR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,6 @@ clean: ## Clean up build artifacts
 
 clean-test-artifacts: ## removes bundles and zarf packages that have been created from previous test runs
 	find src/test -type f -name '*.tar.zst' -delete
+
+push-test-artifacts: ## Push artifacts that UDS CLI tests rely on to GHCR
+	cd hack && ./push-test-artifacts.sh

--- a/hack/push-test-artifacts.sh
+++ b/hack/push-test-artifacts.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+
+# script to push the UDS bundle and Zarf artifacts that we use for testing GHCR
+# ensure you have the proper creds and are logged in to GHCR for defenseunicorns
+
+set -e
+
+# create the nginx and podinfo Zarf packages
+cd ./../src/test/packages/nginx
+zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a amd64
+zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a arm64
+
+cd ../podinfo
+zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a amd64
+zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a arm64
+
+# create ghcr-test bundle
+cd ../../bundles/06-ghcr
+uds create . -o ghcr.io/defenseunicorns/packages/uds-cli/test/create-remote --confirm -a amd64
+uds create . -o ghcr.io/defenseunicorns/packages/uds-cli/test/create-remote --confirm -a arm64
+
+uds create . -o ghcr.io/defenseunicorns/packages/uds-cli/test/publish --confirm -a amd64
+uds create . -o ghcr.io/defenseunicorns/packages/uds-cli/test/publish --confirm -a arm64
+
+uds create . -o ghcr.io/defenseunicorns/packages/uds/bundles --confirm -a amd64
+uds create . -o ghcr.io/defenseunicorns/packages/uds/bundles --confirm -a arm64
+
+uds create . -o ghcr.io/defenseunicorns/packages/delivery --confirm -a amd64
+uds create . -o ghcr.io/defenseunicorns/packages/delivery --confirm -a arm64
+
+# change name of bundle for testing purposes
+sed -i'' -e 's/ghcr-test/ghcr-delivery-test/g' uds-bundle.yaml
+uds create . -o ghcr.io/defenseunicorns/packages/delivery --confirm -a amd64
+uds create . -o ghcr.io/defenseunicorns/packages/delivery --confirm -a arm64
+sed -i'' -e 's/ghcr-delivery-test/ghcr-test/g' uds-bundle.yaml
+
+echo "Finished pushing test artifacts to GHCR."

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: 2023-Present The UDS Authorspackage config
+// SPDX-FileCopyrightText: 2023-Present The UDS Authors
 
 // Package config contains configuration strings for UDS-CLI
 package config

--- a/src/pkg/bundle/bundle.go
+++ b/src/pkg/bundle/bundle.go
@@ -218,8 +218,8 @@ func CreateAndPublish(remoteDst *oci.OrasRemote, bundle *types.UDSBundle, signat
 			return err
 		}
 
-		// hack the media type to be a manifest and append to bundle root manifest
-		zarfManifestDesc.MediaType = ocispec.MediaTypeImageManifest
+		// ensure media type is a Zarf blob and append to bundle root manifest
+		zarfManifestDesc.MediaType = oci.ZarfLayerMediaTypeBlob
 		message.Debugf("Pushed %s sub-manifest into %s: %s", url, dstRef, message.JSONValue(zarfManifestDesc))
 		rootManifest.Layers = append(rootManifest.Layers, zarfManifestDesc)
 

--- a/src/test/bundles/06-ghcr/uds-bundle.yaml
+++ b/src/test/bundles/06-ghcr/uds-bundle.yaml
@@ -1,13 +1,13 @@
 kind: UDSBundle
 metadata:
   name: ghcr-test
-  description: building from local and remote Zarf pkgs
+  description: testing a bundle of pkgs from ghcr
   version: 0.0.1
 
 packages:
+  - name: podinfo
+    repository: ghcr.io/defenseunicorns/uds-cli/podinfo
+    ref: 0.0.1
   - name: nginx
     repository: ghcr.io/defenseunicorns/uds-cli/nginx
-    ref: 0.0.1
-  - name: podinfo
-    path: "../../packages/podinfo"
     ref: 0.0.1

--- a/src/test/e2e/commands_test.go
+++ b/src/test/e2e/commands_test.go
@@ -39,6 +39,12 @@ func createRemote(t *testing.T, bundlePath string, registry string) {
 	require.NoError(t, err)
 }
 
+func createRemoteSecure(t *testing.T, bundlePath string, registry string) {
+	cmd := strings.Split(fmt.Sprintf("create %s -o %s --confirm", bundlePath, registry), " ")
+	_, _, err := e2e.UDS(cmd...)
+	require.NoError(t, err)
+}
+
 func inspectRemote(t *testing.T, ref string) {
 	cmd := strings.Split(fmt.Sprintf("inspect %s --insecure --sbom", ref), " ")
 	_, _, err := e2e.UDS(cmd...)

--- a/src/test/e2e/ghcr_test.go
+++ b/src/test/e2e/ghcr_test.go
@@ -14,12 +14,11 @@ import (
 
 func TestBundleDeployFromOCIFromGHCR(t *testing.T) {
 	deployZarfInit(t)
-	e2e.CreateZarfPkg(t, "src/test/packages/podinfo")
 
 	bundleDir := "src/test/bundles/06-ghcr"
 	bundlePath := filepath.Join(bundleDir, fmt.Sprintf("uds-bundle-ghcr-test-%s-0.0.1.tar.zst", e2e.Arch))
 
-	registryURL := "oci://ghcr.io/defenseunicorns/packages/uds/bundles/uds-cli/test"
+	registryURL := "oci://ghcr.io/defenseunicorns/packages/uds-cli/test/publish"
 
 	tarballPath := filepath.Join("build", fmt.Sprintf("uds-bundle-ghcr-test-%s-0.0.1.tar.zst", e2e.Arch))
 	bundleRef := registry.Reference{
@@ -33,11 +32,29 @@ func TestBundleDeployFromOCIFromGHCR(t *testing.T) {
 	inspect(t, bundlePath)
 	publish(t, bundlePath, registryURL)
 	// test without oci prefix
-	registryURL = "ghcr.io/defenseunicorns/packages/uds/bundles/uds-cli/test"
+	registryURL = "ghcr.io/defenseunicorns/packages/uds-cli/test/publish"
 	publish(t, bundlePath, registryURL)
 	pull(t, bundleRef.String(), tarballPath)
 	deploy(t, bundleRef.String())
 	remove(t, bundlePath)
+}
+
+// test the create -o path
+func TestBundleCreateAndDeployOCI(t *testing.T) {
+	deployZarfInit(t)
+
+	bundleDir := "src/test/bundles/06-ghcr"
+	registryURL := "ghcr.io/defenseunicorns/packages/uds-cli/test/create-remote"
+	bundleRef := registry.Reference{
+		Registry: registryURL,
+		// this info is derived from the bundle's metadata
+		Repository: "ghcr-test",
+		Reference:  fmt.Sprintf("0.0.1-%s", e2e.Arch),
+	}
+	createRemoteSecure(t, bundleDir, registryURL)
+	inspect(t, bundleRef.String())
+	deploy(t, bundleRef.String())
+	remove(t, bundleRef.String())
 }
 
 // This test requires the following to be published (based on src/test/bundles/06-ghcr/uds-bundle.yaml):


### PR DESCRIPTION
## Description
Fixes a bug where the bundle couldn't get pulled from GHCR due to using the wrong media type

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
