### PR TITLE
fix: override validation with multiple components

### DIFF
--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -278,6 +278,7 @@ func validateOverrides(pkg types.Package, zarfYAML zarfTypes.ZarfPackage) error 
 		for _, component := range zarfYAML.Components {
 			if component.Name == componentName {
 				foundComponent = &component
+				break
 			}
 		}
 		if foundComponent == nil {
@@ -289,6 +290,7 @@ func validateOverrides(pkg types.Package, zarfYAML zarfTypes.ZarfPackage) error 
 			for _, chart := range foundComponent.Charts {
 				if chart.Name == chartName {
 					foundChart = &chart
+					break
 				}
 			}
 			if foundChart == nil {

--- a/src/pkg/bundle/common_test.go
+++ b/src/pkg/bundle/common_test.go
@@ -94,6 +94,20 @@ func Test_validateOverrides(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:        "validOverrideMultipleComponents",
+			description: "Respective components and charts exist for override when multiple charts and components are present",
+			args: args{
+				bundlePackage: types.Package{
+					Name: "foo", Overrides: map[string]map[string]types.BundleChartOverrides{"component-a": {"chart-1": {}}}},
+				zarfPackage: zarfTypes.ZarfPackage{
+					Components: []zarfTypes.ZarfComponent{
+						{Name: "component-a", Charts: []zarfTypes.ZarfChart{{Name: "chart-1"}, {Name: "chart-2"}}},
+						{Name: "component-b", Charts: []zarfTypes.ZarfChart{{Name: "chart-b"}}},
+					},
+				}},
+			wantErr: false,
+		},
+		{
 			name:        "invalidComponentOverride",
 			description: "Component does not exist for override",
 			args: args{


### PR DESCRIPTION
## Description

Fixes issue where bundle validation was not identifying the correct chart/component when multiple were present (due to the use of pointers). Break added to exit the loops when the match is found.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
