### PR TITLE
fix: task call to uds zarf tools wait-for

### DIFF
--- a/src/pkg/runner/runner.go
+++ b/src/pkg/runner/runner.go
@@ -546,7 +546,7 @@ func convertWaitToCmd(wait zarfTypes.ZarfComponentActionWait, timeout *int) (str
 		}
 
 		// Build a call to the uds tools wait-for command.
-		return fmt.Sprintf("./uds tools wait-for %s %s %s %s %s",
+		return fmt.Sprintf("./uds zarf tools wait-for %s %s %s %s %s",
 			cluster.Kind, cluster.Identifier, cluster.Condition, ns, timeoutString), nil
 	}
 
@@ -561,7 +561,7 @@ func convertWaitToCmd(wait zarfTypes.ZarfComponentActionWait, timeout *int) (str
 		}
 
 		// Build a call to the uds tools wait-for command.
-		return fmt.Sprintf("./uds tools wait-for %s %s %d %s",
+		return fmt.Sprintf("./uds zarf tools wait-for %s %s %d %s",
 			network.Protocol, network.Address, network.Code, timeoutString), nil
 	}
 

--- a/src/test/e2e/runner_test.go
+++ b/src/test/e2e/runner_test.go
@@ -282,4 +282,10 @@ func TestUseCLI(t *testing.T) {
 		require.Contains(t, stdErr, "copy-exec")
 		require.Contains(t, stdErr, "copy-verify")
 	})
+
+	t.Run("test call to zarf tools wait-for", func(t *testing.T) {
+		t.Parallel()
+		_, stdErr, _ := e2e.RunTasksWithFile("run", "wait")
+		require.Contains(t, stdErr, "Waiting for")
+	})
 }

--- a/src/test/tasks/tasks.yaml
+++ b/src/test/tasks/tasks.yaml
@@ -105,3 +105,11 @@ tasks:
   - name: more-foo
     actions:
       - task: foo:fooybar
+  - name: wait
+    actions:
+      - maxTotalSeconds: 1
+        wait:
+          cluster:
+            kind: StatefulSet
+            name: cool-name
+            namespace: tasks


### PR DESCRIPTION
## Description

Update runner to call `uds zarf tools wait-for` vs `uds tools wait-for` since zarf is now vendored in as part of uds-cli.

## Related Issue

Fixes bug palassis found

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
