### PR TITLE
chore: refactor Annotations and SBOM logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test-e2e: ## Run End to End (e2e) tests
 	cd src/test/e2e && go test -failfast -v -timeout 30m
 
 test-e2e-no-ghcr: ## Run End to End (e2e) tests without GHCR
-	cd src/test/e2e && go test -failfast -v -timeout 30m -skip "TestBundleDeployFromOCIFromGHCR"
+	cd src/test/e2e && go test -failfast -v -timeout 30m -skip ".*GHCR.*"
 
 schema: ## Update JSON schema for uds-bundle.yaml
 	./hack/generate-schema.sh

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -71,12 +71,9 @@ packages:
 This bundle will deploy the `helm-overrides-package` Zarf package and override the `replicaCount` and `ui.color` values in the `podinfo` chart. The `values` can't be modified after the bundle has been created. However, at deploy time, users can override the `UI_COLOR` and other `variables` using a environment variable called `UDS_UI_COLOR` or by specifying it in a `uds-config.yaml` like so:
 
 ```yaml
-bundle:
-  deploy:
-    helm-overrides-package:
-       helm-overrides-component:
-        set:
-          UI_COLOR: green
+variables:
+ helm-overrides-package:
+   UI_COLOR: green
 ```
 
 ## Overrides

--- a/src/pkg/bundle/remote.go
+++ b/src/pkg/bundle/remote.go
@@ -222,6 +222,7 @@ func (op *ociProvider) LoadBundle(_ int) (PathMap, error) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go zarfUtils.RenderProgressBarForLocalDirWrite(op.dst, estimatedBytes, &wg, doneSaving, errChan, fmt.Sprintf("Pulling bundle: %s", bundle.Metadata.Name), fmt.Sprintf("Successfully pulled bundle: %s", bundle.Metadata.Name))
+	// note that in this case oras.Copy() copies using the bundle root manifest, not the packages directly
 	_, err = oras.Copy(op.ctx, op.Repo(), op.Repo().Reference.String(), store, op.Repo().Reference.String(), copyOpts)
 	if err != nil {
 		doneSaving <- 1

--- a/src/pkg/utils/oci.go
+++ b/src/pkg/utils/oci.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/defenseunicorns/uds-cli/src/config"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/oci"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -82,7 +83,7 @@ func CreateCopyOpts(layersToPull []ocispec.Descriptor, concurrency int) oras.Cop
 	}
 	copyOpts.FindSuccessors = func(ctx context.Context, fetcher content.Fetcher, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		var nodes []ocispec.Descriptor
-		if desc.MediaType == oci.ZarfLayerMediaTypeBlob && desc.Annotations == nil {
+		if desc.MediaType == oci.ZarfLayerMediaTypeBlob && desc.Annotations[ocispec.AnnotationTitle] == config.BundleYAML {
 			layerBytes, err := content.FetchAll(ctx, fetcher, desc)
 			if err != nil {
 				return nil, err

--- a/src/test/bundles/09-uds-bundle-yml/uds-bundle.yml
+++ b/src/test/bundles/09-uds-bundle-yml/uds-bundle.yml
@@ -6,8 +6,5 @@ metadata:
 
 packages:
   - name: nginx
-    repository: localhost:888/nginx
-    ref: 0.0.1
-  - name: podinfo
-    repository: localhost:889/podinfo
+    path: "../../packages/nginx"
     ref: 0.0.1

--- a/src/test/common.go
+++ b/src/test/common.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/utils/exec"
 	"github.com/defenseunicorns/zarf/src/pkg/utils/helpers"
 	"github.com/stretchr/testify/require"
@@ -128,18 +129,19 @@ func (e2e *UDSE2ETest) DownloadZarfInitPkg(t *testing.T, zarfVersion string) {
 		fmt.Println("Zarf init pkg already exists. Skipping download.")
 		return
 	}
-
+	downloadSpinner := message.NewProgressSpinner("Downloading Zarf init package %s", zarfVersion)
 	err := downloadFile(zarfReleaseURL, outputDir)
+	downloadSpinner.Successf("Downloaded Zarf init package %s", zarfVersion)
 	require.NoError(t, err)
 }
 
 // CreateZarfPkg creates a Zarf in the given path (todo: makefile?)
-func (e2e *UDSE2ETest) CreateZarfPkg(t *testing.T, path string) {
+func (e2e *UDSE2ETest) CreateZarfPkg(t *testing.T, path string, forceCreate bool) {
 	//  check if pkg already exists
 	pattern := fmt.Sprintf("%s/*-%s-*.tar.zst", path, e2e.Arch)
 	matches, err := filepath.Glob(pattern)
 	require.NoError(t, err)
-	if len(matches) > 0 {
+	if !forceCreate && len(matches) > 0 {
 		fmt.Println("Zarf pkg already exists, skipping create")
 		return
 	}

--- a/src/test/e2e/ghcr_test.go
+++ b/src/test/e2e/ghcr_test.go
@@ -12,6 +12,9 @@ import (
 	"oras.land/oras-go/v2/registry"
 )
 
+// NOTE: These tests need to have the string "GHCR" in their names
+//       to ensure they are not run by the test-e2e-no-ghcr make target
+
 func TestBundleDeployFromOCIFromGHCR(t *testing.T) {
 	deployZarfInit(t)
 
@@ -40,7 +43,7 @@ func TestBundleDeployFromOCIFromGHCR(t *testing.T) {
 }
 
 // test the create -o path
-func TestBundleCreateAndDeployOCI(t *testing.T) {
+func TestBundleCreateAndDeployGHCR(t *testing.T) {
 	deployZarfInit(t)
 
 	bundleDir := "src/test/bundles/06-ghcr"
@@ -67,7 +70,7 @@ func TestBundleCreateAndDeployOCI(t *testing.T) {
 // The default bundle location if no source path provided is defenseunicorns/packages/uds/bundles/"
 func TestGHCRPathExpansion(t *testing.T) {
 	deployZarfInit(t)
-	e2e.CreateZarfPkg(t, "src/test/packages/podinfo")
+	e2e.CreateZarfPkg(t, "src/test/packages/podinfo", false)
 
 	tarballPath := filepath.Join("build", fmt.Sprintf("uds-bundle-ghcr-test-%s-0.0.1.tar.zst", e2e.Arch))
 

--- a/src/test/e2e/variable_test.go
+++ b/src/test/e2e/variable_test.go
@@ -17,8 +17,8 @@ import (
 func TestBundleVariables(t *testing.T) {
 	zarfPkgPath1 := "src/test/packages/no-cluster/output-var"
 	zarfPkgPath2 := "src/test/packages/no-cluster/receive-var"
-	e2e.CreateZarfPkg(t, zarfPkgPath1)
-	e2e.CreateZarfPkg(t, zarfPkgPath2)
+	e2e.CreateZarfPkg(t, zarfPkgPath1, false)
+	e2e.CreateZarfPkg(t, zarfPkgPath2, false)
 
 	e2e.SetupDockerRegistry(t, 888)
 	defer e2e.TeardownRegistry(t, 888)
@@ -50,7 +50,7 @@ func TestBundleVariables(t *testing.T) {
 func TestBundleWithHelmOverrides(t *testing.T) {
 	deployZarfInit(t)
 	e2e.HelmDepUpdate(t, "src/test/packages/helm/unicorn-podinfo")
-	e2e.CreateZarfPkg(t, "src/test/packages/helm")
+	e2e.CreateZarfPkg(t, "src/test/packages/helm", false)
 	bundleDir := "src/test/bundles/07-helm-overrides"
 	bundlePath := filepath.Join(bundleDir, fmt.Sprintf("uds-bundle-helm-overrides-%s-0.0.1.tar.zst", e2e.Arch))
 	err := os.Setenv("UDS_CONFIG", filepath.Join("src/test/bundles/07-helm-overrides", "uds-config.yaml"))
@@ -120,7 +120,7 @@ func TestBundleWithEnvVarHelmOverrides(t *testing.T) {
 	// set up configs and env vars
 	deployZarfInit(t)
 	e2e.HelmDepUpdate(t, "src/test/packages/helm/unicorn-podinfo")
-	e2e.CreateZarfPkg(t, "src/test/packages/helm")
+	e2e.CreateZarfPkg(t, "src/test/packages/helm", false)
 	color := "purple"
 	b64Secret := "dGhhdCBhaW50IG15IHRydWNr"
 	err := os.Setenv("UDS_CONFIG", filepath.Join("src/test/bundles/07-helm-overrides", "uds-config.yaml"))
@@ -152,8 +152,8 @@ func TestVariablePrecedence(t *testing.T) {
 	// precedence rules: env var > uds-config.variables > uds-config.shared > default
 	deployZarfInit(t)
 	e2e.HelmDepUpdate(t, "src/test/packages/helm/unicorn-podinfo")
-	e2e.CreateZarfPkg(t, "src/test/packages/helm")
-	e2e.CreateZarfPkg(t, "src/test/packages/no-cluster/output-var")
+	e2e.CreateZarfPkg(t, "src/test/packages/helm", false)
+	e2e.CreateZarfPkg(t, "src/test/packages/no-cluster/output-var", false)
 	bundleDir := "src/test/bundles/08-var-precedence"
 	bundlePath := filepath.Join(bundleDir, fmt.Sprintf("uds-bundle-var-precedence-%s-0.0.1.tar.zst", e2e.Arch))
 	err := os.Setenv("UDS_CONFIG", filepath.Join("src/test/bundles/08-var-precedence", "uds-config.yaml"))


### PR DESCRIPTION
## Description
- refactors instances of `desc.Annotations == nil` to have more specific checks; this will allow us to add annotations (not title!) to the root manifest of bundles
- adds test for plain `uds` cmd
- refactors SBOM logic and provides better warnings
- docs fix
