### PR TITLE
feat: allow custom zarf package names for remote package refs

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -52,6 +52,10 @@ const (
 
 	// EnvVarPrefix is the prefix for environment variables to override bundle helm variables
 	EnvVarPrefix = "UDS_"
+
+	ZarfPackageNameAnnotation = "zarf.package.name"
+
+	UDSPackageNameAnnotation = "uds.package.name"
 )
 
 var (

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -53,8 +53,10 @@ const (
 	// EnvVarPrefix is the prefix for environment variables to override bundle helm variables
 	EnvVarPrefix = "UDS_"
 
+	// ZarfPackageNameAnnotation is the annotation key for the value that specifies the zarf package name
 	ZarfPackageNameAnnotation = "zarf.package.name"
 
+	// UDSPackageNameAnnotation is the annotation key for the value that specifies the name given to a zarf package in the uds-bundle.yaml
 	UDSPackageNameAnnotation = "uds.package.name"
 )
 

--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -152,6 +152,8 @@ func (b *Bundler) ValidateBundleResources(bundle *types.UDSBundle, spinner *mess
 			if pkg.Name == "init" {
 				fullPkgName = fmt.Sprintf("zarf-%s-%s-%s.tar.zst", pkg.Name, bundle.Metadata.Architecture, pkg.Ref)
 			} else {
+				// For local zarf packages, we get the package name using the package name provided in the bundle, since the zarf package artifact
+				// uses the actual zarf package name, these names must match
 				fullPkgName = fmt.Sprintf("zarf-package-%s-%s-%s.tar.zst", pkg.Name, bundle.Metadata.Architecture, pkg.Ref)
 			}
 			path := filepath.Join(pkg.Path, fullPkgName)
@@ -160,6 +162,7 @@ func (b *Bundler) ValidateBundleResources(bundle *types.UDSBundle, spinner *mess
 			if err != nil {
 				return err
 			}
+			// This will throw an error if the zarf package name in the bundle doesn't match the actual zarf package name
 			zarfYAML, err = p.GetMetadata(path, tmp)
 			if err != nil {
 				return err

--- a/src/pkg/bundle/provider.go
+++ b/src/pkg/bundle/provider.go
@@ -40,6 +40,9 @@ type Provider interface {
 	PublishBundle(bundle types.UDSBundle, remote *oci.OrasRemote) error
 
 	getBundleManifest() error
+
+	// ZarfPackageNameMap returns a map of the zarf package name specified in the uds-bundle.yaml to the actual zarf package name
+	ZarfPackageNameMap() (map[string]string, error)
 }
 
 // PathMap is a map of either absolute paths to relative paths or relative paths to absolute paths

--- a/src/pkg/bundle/remote.go
+++ b/src/pkg/bundle/remote.go
@@ -336,3 +336,33 @@ func EnsureOCIPrefix(source string) string {
 	}
 	return source
 }
+
+// get zarf package name mappings from oci provider
+func (op *ociProvider) ZarfPackageNameMap() (map[string]string, error) {
+	if err := op.getBundleManifest(); err != nil {
+		return nil, err
+	}
+
+	loaded, err := op.LoadBundleMetadata()
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := os.ReadFile(loaded[config.BundleYAML])
+	if err != nil {
+		return nil, err
+	}
+
+	var bundle types.UDSBundle
+	if err := goyaml.Unmarshal(b, &bundle); err != nil {
+		return nil, err
+	}
+
+	nameMap := make(map[string]string)
+	for _, pkg := range bundle.Packages {
+		sha := strings.Split(pkg.Ref, "@sha256:")[1] // this is where we use the SHA appended to the Zarf pkg inside the bundle
+		manifestDesc := op.manifest.Locate(sha)
+		nameMap[manifestDesc.Annotations[config.UDSPackageNameAnnotation]] = manifestDesc.Annotations[config.ZarfPackageNameAnnotation]
+	}
+	return nameMap, nil
+}

--- a/src/pkg/bundle/remote.go
+++ b/src/pkg/bundle/remote.go
@@ -337,7 +337,7 @@ func EnsureOCIPrefix(source string) string {
 	return source
 }
 
-// get zarf package name mappings from oci provider
+// ZarfPackageNameMap returns the uds bundle zarf package name to actual zarf package name mappings from the oci provider
 func (op *ociProvider) ZarfPackageNameMap() (map[string]string, error) {
 	if err := op.getBundleManifest(); err != nil {
 		return nil, err

--- a/src/pkg/bundle/tarball.go
+++ b/src/pkg/bundle/tarball.go
@@ -357,8 +357,7 @@ func (tp *tarballBundleProvider) ZarfPackageNameMap() (map[string]string, error)
 	for _, layer := range tp.manifest.Layers {
 		if layer.MediaType == oci.ZarfLayerMediaTypeBlob {
 			// only the uds bundle layer will have AnnotationTitle set
-			rel := layer.Annotations[ocispec.AnnotationTitle]
-			if rel == "" {
+			if layer.Annotations[ocispec.AnnotationTitle] != config.BundleYAML {
 				nameMap[layer.Annotations[config.UDSPackageNameAnnotation]] = layer.Annotations[config.ZarfPackageNameAnnotation]
 			}
 		}

--- a/src/pkg/bundle/tarball.go
+++ b/src/pkg/bundle/tarball.go
@@ -346,3 +346,22 @@ func (tp *tarballBundleProvider) PublishBundle(bundle types.UDSBundle, remote *o
 
 	return nil
 }
+
+// get zarf package name mappings from tarball provider
+func (tp *tarballBundleProvider) ZarfPackageNameMap() (map[string]string, error) {
+	if err := tp.getBundleManifest(); err != nil {
+		return nil, err
+	}
+
+	nameMap := make(map[string]string)
+	for _, layer := range tp.manifest.Layers {
+		if layer.MediaType == oci.ZarfLayerMediaTypeBlob {
+			// only the uds bundle layer will have AnnotationTitle set
+			rel := layer.Annotations[ocispec.AnnotationTitle]
+			if rel == "" {
+				nameMap[layer.Annotations[config.UDSPackageNameAnnotation]] = layer.Annotations[config.ZarfPackageNameAnnotation]
+			}
+		}
+	}
+	return nameMap, nil
+}

--- a/src/test/bundles/10-package-naming/uds-bundle.yaml
+++ b/src/test/bundles/10-package-naming/uds-bundle.yaml
@@ -1,0 +1,13 @@
+kind: UDSBundle
+metadata:
+  name: package-naming
+  description: test bundle package names being different than actual zarf package names
+  version: 0.0.1
+
+packages:
+  - name: nginxx
+    repository: localhost:888/nginx
+    ref: 0.0.1
+  - name: podinfox
+    repository: localhost:889/podinfo
+    ref: 0.0.1

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -221,6 +221,7 @@ func TestResumeFlag(t *testing.T) {
 
 func TestRemoteBundle(t *testing.T) {
 	deployZarfInit(t)
+	e2e.CreateZarfPkg(t, "src/test/packages/nginx", false)
 	e2e.CreateZarfPkg(t, "src/test/packages/podinfo", false)
 
 	e2e.SetupDockerRegistry(t, 888)
@@ -371,4 +372,8 @@ func TestPackageNaming(t *testing.T) {
 	pull(t, bundleRef.String(), tarballPath)
 	deploy(t, tarballPath)
 	remove(t, tarballPath)
+
+	// Test create -o with zarf package names that don't match the zarf package name in the bundle
+	createRemote(t, bundleDir, bundleRef.Registry)
+	deployAndRemoveRemote(t, bundleRef.String(), tarballPath)
 }


### PR DESCRIPTION
## Description

Allows you to use custom names when referencing a remote zarf package in your uds-bundle.yaml. This does not apply when referencing local zarf packages. When referencing local zarf packages, the bundle package name must still match the actual zarf package name

## Related Issue

Relates to #306 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
