### PR TITLE
fix: allow comma separated string values for helm overrides

### DIFF
--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -289,6 +289,10 @@ func (b *Bundler) loadChartOverrides(pkg types.Package) (ZarfOverrideMap, error)
 
 		// Loop through each chart in the component
 		for chartName, chart := range component {
+			//escape commas (with \\) in values so helm v3 can process them
+			for i, value := range chart.Values {
+				chart.Values[i] = strings.ReplaceAll(value, ",", "\\,")
+			}
 			// Merge the chart values with Helm
 			data, err := chart.MergeValues(getter.Providers{})
 			if err != nil {

--- a/src/test/bundles/07-helm-overrides/uds-config.yaml
+++ b/src/test/bundles/07-helm-overrides/uds-config.yaml
@@ -4,7 +4,7 @@ options:
 variables:
   helm-overrides:
     # vars can be upper or lowercase
-    ui_color: green
+    ui_color: "green, yellow"
     UI_MSG: "Hello Unicorn"
     security_ctx:
       runAsUser: 2000

--- a/src/test/e2e/variable_test.go
+++ b/src/test/e2e/variable_test.go
@@ -83,7 +83,7 @@ func TestBundleWithHelmOverrides(t *testing.T) {
 	// check variables overrides
 	cmd = strings.Split("zarf tools kubectl get deploy -n podinfo unicorn-podinfo -o=jsonpath='{.spec.template.spec.containers[0].env[?(@.name==\"PODINFO_UI_COLOR\")].value}'", " ")
 	outputUIColor, _, err := e2e.UDS(cmd...)
-	require.Equal(t, "'green'", outputUIColor)
+	require.Equal(t, "'green, yellow'", outputUIColor)
 	require.NoError(t, err)
 
 	// check variables overrides, no default but set in config


### PR DESCRIPTION
## Description

Fixes error passing variable where value is a string of comma separated values to helm chart

## Related Issue

Fixes #348 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
