### PR TITLE
chore: only use camelCase in yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ packages:
   - name: init
     repository: ghcr.io/defenseunicorns/packages/init
     ref: v0.31.4
-    optional-components:
+    optionalComponents:
       - git-server
   - name: podinfo
     repository: localhost:5000/podinfo
@@ -57,7 +57,7 @@ The above `UDSBundle` deploys the Zarf init package and podinfo.
 The packages referenced in `packages` can exist either locally or in an OCI registry. See [here](src/test/packages/03-local-and-remote) for an example that deploys both local and remote Zarf packages. More `UDSBundle` examples can be found in the [src/test/packages](src/test/packages) folder.
 
 #### Declarative Syntax
-The syntax of a `uds-bundle.yaml` is entirely declarative. As a result, the UDS CLI will not prompt users to deploy optional components in a Zarf package. If you want to deploy an optional Zarf component, it must be specified in the `optional-components` key of a particular `package`.
+The syntax of a `uds-bundle.yaml` is entirely declarative. As a result, the UDS CLI will not prompt users to deploy optional components in a Zarf package. If you want to deploy an optional Zarf component, it must be specified in the `optionalComponents` key of a particular `package`.
 
 #### First-class UDS Support
 When running `deploy`,`inspect`,`remove`, and `pull` commands, UDS CLI contains shorthand for interacting with the Defense Unicorns org on GHCR. Specifically, unless otherwise specified, paths will automatically be expanded to the Defense Unicorns org on GHCR. For example:

--- a/src/pkg/bundler/tarball.go
+++ b/src/pkg/bundler/tarball.go
@@ -103,7 +103,7 @@ func (b *LocalBundler) Load() (zarfTypes.ZarfPackage, error) {
 
 // ToBundle transfers a Zarf package to a given Bundle
 func (b *LocalBundler) ToBundle(bundleStore *ocistore.Store, pkg zarfTypes.ZarfPackage, artifactPathMap map[string]string, bundleTmpDir string, packageTmpDir string) (ocispec.Descriptor, error) {
-	// todo: only grab components that are required + specified in optional-components
+	// todo: only grab components that are required + specified in optionalComponents
 	ctx := b.ctx
 	src, err := file.New(packageTmpDir)
 	if err != nil {

--- a/src/test/bundles/04-init/uds-bundle.yaml
+++ b/src/test/bundles/04-init/uds-bundle.yaml
@@ -11,11 +11,11 @@ packages:
     path: "../../packages"
     # renovate: datasource=github-tags depName=defenseunicorns/zarf
     ref: v0.32.2
-    optional-components:
+    optionalComponents:
       - git-server
   - name: init
     repository: ghcr.io/defenseunicorns/packages/init
     # renovate: datasource=github-tags depName=defenseunicorns/zarf
     ref: v0.32.2
-    optional-components:
+    optionalComponents:
       - git-server

--- a/src/types/bundle.go
+++ b/src/types/bundle.go
@@ -18,8 +18,8 @@ type Package struct {
 	Repository         string                                     `json:"repository,omitempty" jsonschema:"description=The repository to import the package from"`
 	Path               string                                     `json:"path,omitempty" jsonschema:"description=The local path to import the package from"`
 	Ref                string                                     `json:"ref" jsonschema:"description=Ref (tag) of the Zarf package"`
-	OptionalComponents []string                                   `json:"optional-components,omitempty" jsonschema:"description=List of optional components to include from the package (required components are always included)"`
-	PublicKey          string                                     `json:"public-key,omitempty" jsonschema:"description=The public key to use to verify the package"`
+	OptionalComponents []string                                   `json:"optionalComponents,omitempty" jsonschema:"description=List of optional components to include from the package (required components are always included)"`
+	PublicKey          string                                     `json:"publicKey,omitempty" jsonschema:"description=The public key to use to verify the package"`
 	Imports            []BundleVariableImport                     `json:"imports,omitempty" jsonschema:"description=List of Zarf variables to import from another Zarf package"`
 	Exports            []BundleVariableExport                     `json:"exports,omitempty" jsonschema:"description=List of Zarf variables to export from the Zarf package"`
 	Overrides          map[string]map[string]BundleChartOverrides `json:"overrides,omitempty" jsonschema:"description=Map of Helm chart overrides to set. The format is <component>:, <chart-name>:"`

--- a/uds.schema.json
+++ b/uds.schema.json
@@ -117,14 +117,14 @@
           "type": "string",
           "description": "Ref (tag) of the Zarf package"
         },
-        "optional-components": {
+        "optionalComponents": {
           "items": {
             "type": "string"
           },
           "type": "array",
           "description": "List of optional components to include from the package (required components are always included)"
         },
-        "public-key": {
+        "publicKey": {
           "type": "string",
           "description": "The public key to use to verify the package"
         },


### PR DESCRIPTION
## Description
Swap `optional-components` to `optionalComponents`. Ensure we are only using camelCase in the `uds-bundle.yaml`
