### PR TITLE
fix: don't error out when a cluster isn't available

### DIFF
--- a/src/pkg/bundle/remote.go
+++ b/src/pkg/bundle/remote.go
@@ -307,7 +307,7 @@ func ValidateArch(arch string) error {
 	var clusterArchs []string
 	c, err := cluster.NewCluster()
 	if err != nil {
-		return err
+		message.Debugf("error creating cluster object: %s", err)
 	}
 	if c != nil {
 		clusterArchs, err = c.GetArchitectures()


### PR DESCRIPTION
## Description
Fixes bug that prevented a UDS Bundle from deploying without a cluster

## Related Issue

Fixes https://github.com/defenseunicorns/uds-cli/issues/397

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)
