### PR TITLE
chore: ignore new hidden folder used to store release assets downloaded using the gh cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .env.*
 .idea/
 .image-cache/
+.release-downloads/
 .scratch/
 .vscode/
 .zarf*


### PR DESCRIPTION
ignore new hidden folder used to store release assets downloaded using the gh cli inside a local repo. This is just a convenience for devs that use gh cli in this way.