### PR TITLE
feat: task runner - grab defaults from env vars if not specified

### DIFF
--- a/docs/runner.md
+++ b/docs/runner.md
@@ -223,7 +223,7 @@ Note that variables also have the following attributes:
 
 - `sensitive`: boolean value indicating if a variable should be visible in output
 - `default`: default value of a variable
-  - If a default is not specified for a variable, the UDS runner will look at your environment variables for a match prefixed with `UDS_`. In the example above, if `FOO` did not have a default, and you have an environment variable `UDS_FOO=bar`, the default would get set to `bar`.
+  - In the example above, if `FOO` did not have a default, and you have an environment variable `UDS_FOO=bar`, the default would get set to `bar`.
 
 ### Environment Variables
 
@@ -241,6 +241,8 @@ tasks:
     actions:
       - cmd: echo differnt task $FOO
 ```
+
+If a default is not specified for a variable, the UDS runner will look at your environment variables for a match prefixed with `UDS_`.
 
 ### Files
 

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -223,7 +223,7 @@ Note that variables also have the following attributes:
 
 - `sensitive`: boolean value indicating if a variable should be visible in output
 - `default`: default value of a variable
-  - If a default is not specified for a variable, the UDS runner will look at your environment variables for a match pre-fixed with `UDS_`. In the example above, if `FOO` did not have a default, and you have an environment variable `UDS_FOO=bar`, the default would get set to `bar`.
+  - If a default is not specified for a variable, the UDS runner will look at your environment variables for a match prefixed with `UDS_`. In the example above, if `FOO` did not have a default, and you have an environment variable `UDS_FOO=bar`, the default would get set to `bar`.
 
 ### Environment Variables
 

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -223,6 +223,7 @@ Note that variables also have the following attributes:
 
 - `sensitive`: boolean value indicating if a variable should be visible in output
 - `default`: default value of a variable
+  - If a default is not specified for a variable, the UDS runner will look at your environment variables for a match pre-fixed with `UDS_`. In the example above, if `FOO` did not have a default, and you have an environment variable `UDS_FOO=bar`, the default would get set to `bar`.
 
 ### Environment Variables
 

--- a/src/pkg/runner/runner.go
+++ b/src/pkg/runner/runner.go
@@ -264,9 +264,9 @@ func (r *Runner) populateTemplateMap(zarfVariables []zarfTypes.ZarfPackageVariab
 		if strings.HasPrefix(envVar, config.EnvVarPrefix) {
 			varNameNoPrefix := envVar[len(config.EnvVarPrefix):]
 			parts := strings.Split(varNameNoPrefix, "=")
-			key := parts[0]
-			value := parts[1]
-			defaultEnvs[key] = value
+			envVarKey := parts[0]
+			envVarValue := parts[1]
+			defaultEnvs[envVarKey] = envVarValue
 		}
 	}
 

--- a/src/test/e2e/runner_test.go
+++ b/src/test/e2e/runner_test.go
@@ -327,7 +327,7 @@ func TestTaskRunner(t *testing.T) {
 		require.Contains(t, stdErr, "overwritten env var - 8080")
 	})
 
-	t.Run("run echo-env-var", func(t *testing.T) {
+	t.Run("test that env vars get used for variables that do not have a default set", func(t *testing.T) {
 		t.Parallel()
 		os.Setenv("UDS_REPLACE_ME", "env-var")
 		os.Setenv("UDS_NO_DEFAULT", "no-problem")

--- a/src/test/e2e/runner_test.go
+++ b/src/test/e2e/runner_test.go
@@ -326,4 +326,15 @@ func TestTaskRunner(t *testing.T) {
 		require.Contains(t, stdErr, "env var from calling task - not-a-secret")
 		require.Contains(t, stdErr, "overwritten env var - 8080")
 	})
+
+	t.Run("run echo-env-var", func(t *testing.T) {
+		t.Parallel()
+		os.Setenv("UDS_REPLACE_ME", "env-var")
+		os.Setenv("UDS_NO_DEFAULT", "no-problem")
+		stdOut, stdErr, err := e2e.UDS("run", "echo-env-var", "--file", "src/test/tasks/tasks.yaml")
+		require.NoError(t, err, stdOut, stdErr)
+		require.Contains(t, stdErr, "replaced")
+		require.NotContains(t, stdErr, "env-var")
+		require.Contains(t, stdErr, "no-problem")
+	})
 }

--- a/src/test/tasks/tasks.yaml
+++ b/src/test/tasks/tasks.yaml
@@ -17,6 +17,7 @@ tasks:
     actions:
       - cmd: echo "This is the default task"
   - name: echo-env-var
+    description: Test that env vars get used for variables that do not have a default set
     actions:
         - cmd: echo "${REPLACE_ME}"
         - cmd: echo "${NO_DEFAULT}"

--- a/src/test/tasks/tasks.yaml
+++ b/src/test/tasks/tasks.yaml
@@ -9,12 +9,17 @@ variables:
     default: replaced
   - name: FOO_VAR
     default: default
+  - name: NO_DEFAULT
 
 tasks:
   - name: default
     description: Run Default Task
     actions:
       - cmd: echo "This is the default task"
+  - name: echo-env-var
+    actions:
+        - cmd: echo "${REPLACE_ME}"
+        - cmd: echo "${NO_DEFAULT}"
   - name: copy
     description: "This is a copy task"
     files:


### PR DESCRIPTION
## Description
In a task file, if a default is not set for a variable, the UDS runner will now look to see if an environment variable (prefixed with `UDS_`) is set for that bundle variable and set that as the default.

## Related Issue

Relates to #257 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ X Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
