### PR TITLE
fix: task runner dir using variables

### DIFF
--- a/src/pkg/runner/runner.go
+++ b/src/pkg/runner/runner.go
@@ -615,6 +615,9 @@ func (r *Runner) performZarfAction(action *zarfTypes.ZarfComponentAction) error 
 		spinner.Errorf(err, "Error mutating command: %s", cmdEscaped)
 	}
 
+	// Template dir string
+	cfg.Dir = r.templateString(cfg.Dir)
+
 	// template cmd string
 	cmd = r.templateString(cmd)
 

--- a/src/test/e2e/runner_test.go
+++ b/src/test/e2e/runner_test.go
@@ -326,4 +326,11 @@ func TestTaskRunner(t *testing.T) {
 		require.Contains(t, stdErr, "env var from calling task - not-a-secret")
 		require.Contains(t, stdErr, "overwritten env var - 8080")
 	})
+
+	t.Run("test that variables of type file and setting dir from a variable are processed correctly", func(t *testing.T) {
+		t.Parallel()
+		stdOut, stdErr, err := e2e.UDS("run", "file-and-dir", "--file", "src/test/tasks/tasks.yaml")
+		require.NoError(t, err, stdOut, stdErr)
+		require.Contains(t, stdErr, "SECRET_KEY=not-a-secret")
+	})
 }

--- a/src/test/tasks/tasks.yaml
+++ b/src/test/tasks/tasks.yaml
@@ -9,6 +9,11 @@ variables:
     default: replaced
   - name: FOO_VAR
     default: default
+  - name: COOL_DIR
+    default: src/test/tasks
+  - name: COOL_FILE
+    type: file
+    default: my-env
 
 tasks:
   - name: default
@@ -141,3 +146,8 @@ tasks:
     envPath: "./my-other-env"
     actions:
       - cmd: echo overwritten env var - $PORT
+  - name: file-and-dir
+    description: Tests variables of type file and setting dir from variable
+    actions:
+      - cmd: cat ${COOL_FILE}
+        dir: ${COOL_DIR}


### PR DESCRIPTION
## Description
Task runner will now support setting the `dir` using variables

## Related Issue

Fixes #411 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
