### PR TITLE
feat: removes --with, expands variables for inputs

### DIFF
--- a/docs/runner.md
+++ b/docs/runner.md
@@ -339,16 +339,6 @@ In this example, the `echo-var` task takes an input called `hello-input` and pri
 
 Note that the `deprecated-input` input has a `deprecatedMessage` attribute. This is used to indicate that the input is deprecated and should not be used. If a task is run with a deprecated input, a warning will be printed to the console.
 
-#### Specifying Task Inputs using`--with`
-If you want to run the `echo-var` task directly, such as when doing dev work, you can use the `--with` flag to pass in inputs via the CLI
-
-```bash
-uds run echo-var --with hello-input=hello-cli
-```
-
-This command passes the string `"hello-cli"` to the `hello-input` input of the `echo-var` task.
-
-
 #### Templates
 
 When creating a task with `inputs` you can use [Go templates](https://pkg.go.dev/text/template#hdr-Functions) in that task's `actions`. For example:

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -15,7 +15,6 @@ UDS runner.
       - [Task](#task)
       - [Cmd](#cmd)
     - [Variables](#variables)
-    - [Environment Variables](#environment-variables)
     - [Files](#files)
     - [Wait](#wait)
     - [Includes](#includes)
@@ -187,7 +186,7 @@ Command blocks can have several other properties including:
 
 ### Variables
 
-Variables can be defined in 3 ways:
+Variables can be defined in several ways:
 
 1. At the top of the `tasks.yaml`
 
@@ -215,17 +214,19 @@ Variables can be defined in 3 ways:
          - cmd: echo ${FOO}
    ```
 
+1. As an environment variable prefixed with `UDS_`. In the example above, if you create an env var `UDS_FOO=bar`, then the`FOO` variable would be set to `bar`.
+
 1. Using the `--set` flag in the CLI : `uds run foo --set FOO=bar`
 
 To use a variable, reference it using `${VAR_NAME}`
 
-Note that variables also have the following attributes:
+Note that variables also have the following attributes when setting them with YAML:
 
 - `sensitive`: boolean value indicating if a variable should be visible in output
 - `default`: default value of a variable
   - In the example above, if `FOO` did not have a default, and you have an environment variable `UDS_FOO=bar`, the default would get set to `bar`.
 
-### Environment Variables
+#### Environment Variable Files
 
 To include a file containing environment variables that you'd like to load into a task, use the `envPath` key in the task. This will load all of the environment variables in the file into the task being called and its child tasks.
 
@@ -239,10 +240,17 @@ tasks:
   - name: echo-env
     envPath: ./path/to/.env
     actions:
-      - cmd: echo differnt task $FOO
+      - cmd: echo different task $FOO
 ```
 
-If a default is not specified for a variable, the UDS runner will look at your environment variables for a match prefixed with `UDS_`.
+
+#### Variable Precedence
+Variable precedence is as follows, from least to most specific:
+- Variable defaults set in YAML
+- Environment variables prefixed with `UDS_`
+- Variables set with the `--set` flag in the CLI
+
+That is to say, variables set via the `--set` flag take precedence over all other variables. The exception to this precedence order is when a variable is modified using `setVariable`, which will change the value of the variable during runtime.
 
 ### Files
 

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -85,7 +85,7 @@ var runCmd = &cobra.Command{
 		if len(args) > 0 {
 			taskName = args[0]
 		}
-		if err := runner.Run(tasksFile, taskName, config.SetRunnerVariables, config.WithInputs); err != nil {
+		if err := runner.Run(tasksFile, taskName, config.SetRunnerVariables); err != nil {
 			message.Fatalf(err, "Failed to run action: %s", err)
 		}
 	},
@@ -98,5 +98,4 @@ func init() {
 	runFlags.StringVarP(&config.TaskFileLocation, "file", "f", config.TasksYAML, lang.CmdRunFlag)
 	runFlags.BoolVar(&config.ListTasks, "list", false, lang.CmdRunList)
 	runFlags.StringToStringVar(&config.SetRunnerVariables, "set", nil, lang.CmdRunSetVarFlag)
-	runFlags.StringToStringVar(&config.WithInputs, "with", v.GetStringMapString("runner.with"), lang.CmdRunWithVarFlag)
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -82,9 +82,6 @@ var (
 	// SetRunnerVariables is a map of the run time variables defined using --set
 	SetRunnerVariables map[string]string
 
-	// WithInputs is a map of the values provided as inputs defined using --with
-	WithInputs map[string]string
-
 	// HelmTimeout is the default timeout for helm deploys
 	HelmTimeout = 15 * time.Minute
 )

--- a/src/pkg/runner/runner.go
+++ b/src/pkg/runner/runner.go
@@ -379,6 +379,11 @@ func (r *Runner) performAction(action types.Action) error {
 			return err
 		}
 
+		// template the withs with variables
+		for k, v := range action.With {
+			action.With[k] = r.templateString(v)
+		}
+
 		referencedTask.Actions, err = templateTaskActionsWithInputs(referencedTask, action.With)
 		if err != nil {
 			return err
@@ -704,6 +709,7 @@ func (r *Runner) performZarfAction(action *zarfTypes.ZarfComponentAction) error 
 	}
 }
 
+// templateString replaces ${...} with the value from the template map
 func (r *Runner) templateString(s string) string {
 	// Create a regular expression to match ${...}
 	re := regexp.MustCompile(`\${(.*?)}`)

--- a/src/test/e2e/runner_inputs_test.go
+++ b/src/test/e2e/runner_inputs_test.go
@@ -5,6 +5,7 @@
 package test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -92,5 +93,20 @@ func TestRunnerInputs(t *testing.T) {
 		require.NoError(t, err, stdOut, stdErr)
 		require.Contains(t, stdErr, "WARNING")
 		require.Contains(t, stdErr, "This input has been marked deprecated: This is a deprecated message")
+	})
+
+	t.Run("test that variables can be used as inputs", func(t *testing.T) {
+		t.Parallel()
+
+		stdOut, stdErr, err := e2e.UDS("run", "variable-as-input", "--file", "src/test/tasks/inputs/tasks.yaml", "--set", "foo=im a variable")
+		require.NoError(t, err, stdOut, stdErr)
+		require.Contains(t, stdErr, "im a variable")
+	})
+
+	t.Run("test that env vars can be used as inputs", func(t *testing.T) {
+		os.Setenv("UDS_FOO", "im an env var")
+		stdOut, stdErr, err := e2e.UDS("run", "variable-as-input", "--file", "src/test/tasks/inputs/tasks.yaml")
+		require.NoError(t, err, stdOut, stdErr)
+		require.Contains(t, stdErr, "im an env var")
 	})
 }

--- a/src/test/e2e/runner_inputs_test.go
+++ b/src/test/e2e/runner_inputs_test.go
@@ -103,10 +103,17 @@ func TestRunnerInputs(t *testing.T) {
 		require.Contains(t, stdErr, "im a variable")
 	})
 
-	t.Run("test that env vars can be used as inputs", func(t *testing.T) {
+	t.Run("test that env vars can be used as inputs and take precedence over default vals", func(t *testing.T) {
 		os.Setenv("UDS_FOO", "im an env var")
 		stdOut, stdErr, err := e2e.UDS("run", "variable-as-input", "--file", "src/test/tasks/inputs/tasks.yaml")
 		require.NoError(t, err, stdOut, stdErr)
 		require.Contains(t, stdErr, "im an env var")
+	})
+
+	t.Run("test that a --set var has the greatest precedence for inputs", func(t *testing.T) {
+		os.Setenv("UDS_FOO", "im an env var")
+		stdOut, stdErr, err := e2e.UDS("run", "variable-as-input", "--file", "src/test/tasks/inputs/tasks.yaml", "--set", "foo=most specific")
+		require.NoError(t, err, stdOut, stdErr)
+		require.Contains(t, stdErr, "most specific")
 	})
 }

--- a/src/test/e2e/runner_inputs_test.go
+++ b/src/test/e2e/runner_inputs_test.go
@@ -93,11 +93,4 @@ func TestRunnerInputs(t *testing.T) {
 		require.Contains(t, stdErr, "WARNING")
 		require.Contains(t, stdErr, "This input has been marked deprecated: This is a deprecated message")
 	})
-
-	t.Run("test --with flag", func(t *testing.T) {
-		t.Parallel()
-		stdOut, stdErr, err := e2e.UDS("run", "has-default", "--file", "src/test/tasks/inputs/tasks-with-inputs.yaml", "--with", "has-default=setting-with-flag")
-		require.NoError(t, err, stdOut, stdErr)
-		require.Contains(t, stdErr, "setting-with-flag")
-	})
 }

--- a/src/test/e2e/runner_test.go
+++ b/src/test/e2e/runner_test.go
@@ -336,12 +336,10 @@ func TestTaskRunner(t *testing.T) {
 
 	t.Run("test that env vars get used for variables that do not have a default set", func(t *testing.T) {
 		t.Parallel()
-		os.Setenv("UDS_REPLACE_ME", "env-var")
-		os.Setenv("UDS_NO_DEFAULT", "no-problem")
+		os.Setenv("UDS_TO_BE_OVERWRITTEN", "env-var")
 		stdOut, stdErr, err := e2e.UDS("run", "echo-env-var", "--file", "src/test/tasks/tasks.yaml")
 		require.NoError(t, err, stdOut, stdErr)
-		require.Contains(t, stdErr, "replaced")
-		require.NotContains(t, stdErr, "env-var")
-		require.Contains(t, stdErr, "no-problem")
+		require.NotContains(t, stdErr, "default")
+		require.Contains(t, stdErr, "env-var")
 	})
 }

--- a/src/test/tasks/inputs/tasks.yaml
+++ b/src/test/tasks/inputs/tasks.yaml
@@ -1,6 +1,10 @@
 includes:
   - with: ./tasks-with-inputs.yaml
 
+variables:
+  - name: FOO
+    default: bar
+
 tasks:
   - name: has-default-empty
     actions:
@@ -48,3 +52,10 @@ tasks:
       - task: with:deprecated-message
         with:
           deprecated-message: deprecated-value
+
+  - name: variable-as-input
+    description: demonstrates that variables can be passed into tasks as 'with' inputs
+    actions:
+      - task: with:no-default
+        with:
+          no-default: ${FOO}

--- a/src/test/tasks/inputs/tasks.yaml
+++ b/src/test/tasks/inputs/tasks.yaml
@@ -3,7 +3,7 @@ includes:
 
 variables:
   - name: FOO
-    default: bar
+    default: default-value
 
 tasks:
   - name: has-default-empty

--- a/src/test/tasks/tasks.yaml
+++ b/src/test/tasks/tasks.yaml
@@ -9,7 +9,8 @@ variables:
     default: replaced
   - name: FOO_VAR
     default: default
-  - name: NO_DEFAULT
+  - name: TO_BE_OVERWRITTEN
+    default: default
   - name: COOL_DIR
     default: src/test/tasks
   - name: COOL_FILE
@@ -22,10 +23,9 @@ tasks:
     actions:
       - cmd: echo "This is the default task"
   - name: echo-env-var
-    description: Test that env vars get used for variables that do not have a default set
+    description: Test that env vars take precedence over var defaults
     actions:
-        - cmd: echo "${REPLACE_ME}"
-        - cmd: echo "${NO_DEFAULT}"
+        - cmd: echo "${TO_BE_OVERWRITTEN}"
   - name: copy
     description: "This is a copy task"
     files:


### PR DESCRIPTION
## Description

The `--with` flag was meant to be used for testing tasks with `inputs` from the CLI. This feature ended up being confusing for users so we'd like to remove it. We believe this will encourage better testing patterns because it forces users to test their `inputs` with actual tasks instead of through the CLI.

Furthermore, we expanded the use of runner variables to ensure they can be passed into tasks using `with`
