### PR TITLE
fix: add support for zarf dev lint

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,4 +17,4 @@ Relates to #
 ## Checklist before merging
 
 - [ ] Test, docs, adr added or updated as needed
-- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
+- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed

--- a/main.go
+++ b/main.go
@@ -4,8 +4,17 @@
 // Package main is the entrypoint for the uds binary.
 package main
 
-import "github.com/defenseunicorns/uds-cli/src/cmd"
+import (
+	"embed"
+
+	"github.com/defenseunicorns/uds-cli/src/cmd"
+	"github.com/defenseunicorns/zarf/src/pkg/packager/lint"
+)
+
+//go:embed zarf.schema.json
+var zarfSchema embed.FS
 
 func main() {
+	lint.ZarfSchema = zarfSchema
 	cmd.Execute()
 }

--- a/src/test/e2e/zarf_test.go
+++ b/src/test/e2e/zarf_test.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The UDS Authors
+
+// Package test provides e2e tests for UDS.
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// NOTE: These tests test that the embedded `zarf` commands are imported properly and function as expected
+
+// TestZarfLint tests to ensure that the `zarf dev lint` command functions (which requires the zarf schema to be embedded in main.go)
+
+func TestZarfLint(t *testing.T) {
+	cmd := strings.Split("zarf dev lint src/test/packages/podinfo", " ")
+	_, stdErr, err := e2e.UDS(cmd...)
+	require.NoError(t, err)
+	require.Contains(t, stdErr, "Image not pinned with digest - ghcr.io/stefanprodan/podinfo:6.4.0")
+}

--- a/src/test/e2e/zarf_test.go
+++ b/src/test/e2e/zarf_test.go
@@ -14,7 +14,6 @@ import (
 // NOTE: These tests test that the embedded `zarf` commands are imported properly and function as expected
 
 // TestZarfLint tests to ensure that the `zarf dev lint` command functions (which requires the zarf schema to be embedded in main.go)
-
 func TestZarfLint(t *testing.T) {
 	cmd := strings.Split("zarf dev lint src/test/packages/podinfo", " ")
 	_, stdErr, err := e2e.UDS(cmd...)


### PR DESCRIPTION
## Description

This adds the zarf schema in the repo to the uds binary so that it can be used by Zarf during zarf dev lint.

## Related Issue

Fixes #359 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed
