### PR TITLE
fix: updates Zarf version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ metadata:
 packages:
   - name: init
     repository: ghcr.io/defenseunicorns/packages/init
-    ref: v0.31.4
+    ref: v0.32.3
     optionalComponents:
       - git-server
   - name: podinfo


### PR DESCRIPTION
## Description
Updates Zarf version in Quickstart section of README. Versions of Zarf <0.32.x are not compatible with UDS CLI
