### PR TITLE
chore: add docs on how to use the schemas in VS Code

### DIFF
--- a/docs/anatomy.md
+++ b/docs/anatomy.md
@@ -1,4 +1,0 @@
-## Bundle Anatomy
-A UDS Bundle is an OCI artifact with the following form:
-
-![](.images/uds-bundle.png)

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -1,0 +1,24 @@
+## Bundle Anatomy
+A UDS Bundle is an OCI artifact with the following form:
+
+![](.images/uds-bundle.png)
+
+## Schema Validation
+
+When working with UDS Bundle definitions it can be useful to setup your IDE to know about the schema that UDS Runner uses.
+
+### VS Code
+
+To do this in VS Code you can install the [YAML Extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) and add the following to your `settings.json` (pinning `main` to your UDE runner version if desired):
+
+```json
+    "yaml.schemas": {
+        "https://raw.githubusercontent.com/defenseunicorns/uds-cli/main/uds.schema.json": "uds-bundle.yaml"
+    },
+```
+
+You can also add the following line to the top of a yaml file as well:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/uds-cli/main/uds.schema.json
+```

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -9,7 +9,7 @@ When working with UDS Bundle definitions it can be useful to setup your IDE to k
 
 ### VS Code
 
-To do this in VS Code you can install the [YAML Extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) and add the following to your `settings.json` (pinning `main` to your UDE runner version if desired):
+To do this in VS Code you can install the [YAML Extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) and add the following to your `settings.json` (pinning `main` to your UDS CLI version if desired):
 
 ```json
     "yaml.schemas": {

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -1,7 +1,7 @@
 ## Bundle Anatomy
 A UDS Bundle is an OCI artifact with the following form:
 
-![](.images/uds-bundle.png)
+![UDS Bundle OCI Layout Diagram](.images/uds-bundle.png)
 
 ## Schema Validation
 

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -71,6 +71,26 @@ You can also view the tasks that are available to run using the `list` flag:
 uds run -f tmp/tasks.yaml --list
 ```
 
+## Schema Validation
+
+When working with runner task files and going through the key concepts below it can be useful to setup your IDE to know about the schema that UDS Runner uses.
+
+### VS Code
+
+To do this in VS Code you can install the [YAML Extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) and add the following to your `settings.json` (pinning `main` to your IDE runner version if desired, and changing the `tasks` subdirectory to your chosen pattern for imported task files):
+
+```json
+    "yaml.schemas": {
+        "https://raw.githubusercontent.com/defenseunicorns/uds-cli/main/tasks.schema.json": ["tasks.yaml", "tasks/*.y*ml"]
+    },
+```
+
+You can also add the following line to the top of a yaml file as well:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/uds-cli/main/tasks.schema.json
+```
+
 ## Key Concepts
 
 ### Tasks

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -77,7 +77,7 @@ When working with runner task files and going through the key concepts below it 
 
 ### VS Code
 
-To do this in VS Code you can install the [YAML Extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) and add the following to your `settings.json` (pinning `main` to your IDE runner version if desired, and changing the `tasks` subdirectory to your chosen pattern for imported task files):
+To do this in VS Code you can install the [YAML Extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) and add the following to your `settings.json` (pinning `main` to your UDS Runner version if desired, and changing the `tasks` subdirectory to your chosen pattern for imported task files):
 
 ```json
     "yaml.schemas": {


### PR DESCRIPTION
## Description

This adds some docs to uds-cli to talk about how to use the schema json files in VS Code (since this is not the same as zarf for tasks)

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
