### PR TITLE
fix: adds better err messaging when remote fails to resolve

### DIFF
--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -144,7 +144,10 @@ func (b *Bundle) ValidateBundleResources(bundle *types.UDSBundle, spinner *messa
 				return err
 			}
 			if err := remote.Repo().Reference.ValidateReferenceAsDigest(); err != nil {
-				manifestDesc, _ := remote.ResolveRoot()
+				manifestDesc, err := remote.ResolveRoot()
+				if err != nil {
+					return err
+				}
 				// todo: don't do this here, a "validate" fn shouldn't be modifying the bundle
 				bundle.Packages[idx].Ref = pkg.Ref + "@sha256:" + manifestDesc.Digest.Encoded()
 			}


### PR DESCRIPTION
## Description
Replace stack trace with proper err messaging when the remote can't be resolved in the case of:
- being disconnected
- not having a valid arch in the remote repo

## Related Issue

Fixes #459 