### PR TITLE
fix: Install k3d for uds smoke test.

### DIFF
--- a/.github/workflows/nightly-uds-core.yaml
+++ b/.github/workflows/nightly-uds-core.yaml
@@ -31,6 +31,10 @@ jobs:
         run: |
           chmod +x build/uds
 
+      - name: Setup k3d
+        run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+        shell: bash
+
       - name: Deploy UDS Core bundle
         # renovate: datasource=github-tags depName=defenseunicorns/uds-core versioning=semver
         run: build/uds deploy ghcr.io/defenseunicorns/packages/uds/bundles/k3d-core-istio-dev:0.13.1 --confirm --no-progress


### PR DESCRIPTION
## Description

[This test](https://github.com/defenseunicorns/uds-cli/actions/runs/8152265515/job/22281459930) failed on missing `k3d`.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
