### PR TITLE
fix: add a wait to the registry startup during tests

### DIFF
--- a/src/test/common.go
+++ b/src/test/common.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/defenseunicorns/zarf/src/pkg/message"
 	"github.com/defenseunicorns/zarf/src/pkg/utils/exec"
@@ -93,6 +94,8 @@ func (e2e *UDSE2ETest) SetupDockerRegistry(t *testing.T, port int) {
 	// spin up a local registry
 	registryImage := "registry:2.8.3"
 	err := exec.CmdWithPrint("docker", "run", "-d", "--restart=always", "-p", fmt.Sprintf("%d:5000", port), "--name", fmt.Sprintf("registry-%d", port), registryImage)
+	// wait for a half a second to ensure the registry is up and running
+	time.Sleep(500 * time.Millisecond)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
## Description

Our tests are flaky as the dickens (see error below), here's a simple test to see if the registry simply isn't ready

![Screenshot 2024-03-12 at 9 21 13 AM](https://github.com/defenseunicorns/uds-cli/assets/42304551/bfc3d455-e909-4d63-9ade-561c9887cebb)
