### PR TITLE
fix: ensure manifest config is included with pulls

### DIFF
--- a/src/pkg/bundle/remote.go
+++ b/src/pkg/bundle/remote.go
@@ -166,6 +166,9 @@ func (op *ociProvider) LoadBundle(opts types.BundlePullOptions, _ int) (*types.U
 		return nil, nil, err
 	}
 
+	// grab root manifest config
+	layersToPull = append(layersToPull, rootManifest.Config)
+
 	for _, pkg := range bundle.Packages {
 
 		// grab sha of zarf image manifest and pull it down

--- a/src/test/e2e/commands_test.go
+++ b/src/test/e2e/commands_test.go
@@ -136,7 +136,13 @@ func removePackagesFlag(tarballPath string, packages string) (stdout string, std
 	return stdout, stderr
 }
 
-func deployAndRemoveRemote(t *testing.T, ref string, tarballPath string) {
+func deployAndRemoveRemoteInsecure(t *testing.T, ref string) {
+	cmd := strings.Split(fmt.Sprintf("deploy %s --insecure --oci-concurrency=10 --confirm", ref), " ")
+	_, _, err := e2e.UDS(cmd...)
+	require.NoError(t, err)
+}
+
+func deployAndRemoveLocalAndRemoteInsecure(t *testing.T, ref string, tarballPath string) {
 	var cmd []string
 	// test both paths because we want to test that the pulled tarball works as well
 	t.Run(


### PR DESCRIPTION
## Description

Fixes bug where the bundle root manifest config was missing after pulls. This prevented publishing to other OCI repos