### PR TITLE
fix: vendored in zarf version tag

### DIFF
--- a/src/cmd/vendored.go
+++ b/src/cmd/vendored.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"os"
 	"runtime/debug"
-	"strings"
 
 	runnerCLI "github.com/defenseunicorns/maru-runner/src/cmd"
 	runnerConfig "github.com/defenseunicorns/maru-runner/src/config"
@@ -57,7 +56,7 @@ func init() {
 	if buildInfo, ok := debug.ReadBuildInfo(); ok {
 		for _, dep := range buildInfo.Deps {
 			if dep.Path == "github.com/defenseunicorns/zarf" {
-				zarfConfig.CLIVersion = strings.Split(dep.Version, "v")[1]
+				zarfConfig.CLIVersion = dep.Version
 			}
 		}
 	}


### PR DESCRIPTION
## Description
Fixes ->

Running uds zarf version returns 0.32.4
Running zarf version returns v0.32.4

this causes an issue when attempting to run uds zarf init it attempts to pull the package from oci://ghcr.io/defenseunicorns/packages/init:0.32.4 which is incorrect. It should be oci://ghcr.io/defenseunicorns/packages/init:v0.32.4

## Related Issue

Fixes #517

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)