### PR TITLE
fix: bumps retries to 3 by default to match Zarf

### DIFF
--- a/src/cmd/uds.go
+++ b/src/cmd/uds.go
@@ -294,7 +294,7 @@ func init() {
 	deployCmd.Flags().BoolVarP(&config.CommonOptions.Confirm, "confirm", "c", false, lang.CmdBundleDeployFlagConfirm)
 	deployCmd.Flags().StringArrayVarP(&bundleCfg.DeployOpts.Packages, "packages", "p", []string{}, lang.CmdBundleDeployFlagPackages)
 	deployCmd.Flags().BoolVarP(&bundleCfg.DeployOpts.Resume, "resume", "r", false, lang.CmdBundleDeployFlagResume)
-	deployCmd.Flags().IntVar(&bundleCfg.DeployOpts.Retries, "retries", 1, lang.CmdBundleDeployFlagRetries)
+	deployCmd.Flags().IntVar(&bundleCfg.DeployOpts.Retries, "retries", 3, lang.CmdBundleDeployFlagRetries)
 
 	// inspect cmd flags
 	rootCmd.AddCommand(inspectCmd)


### PR DESCRIPTION
## Description

bumps retries to 3 by default to match Zarf