### PR TITLE
fix: nil check pkg components in TUI

### DIFF
--- a/src/pkg/bundle/tui/deploy/handlers.go
+++ b/src/pkg/bundle/tui/deploy/handlers.go
@@ -173,7 +173,9 @@ func (m *Model) handleDeployTick() (tea.Model, tea.Cmd) {
 		// check component progress
 		for j := range deployedPkg.DeployedComponents {
 			// check numComponents bc there is a slight delay between rendering the TUI and updating this value
-			if p.numComponents > 0 && deployedPkg.DeployedComponents[j].Status == zarfTypes.ComponentStatusSucceeded {
+			// also nil check the componentStatuses to avoid panic
+			componentSucceeded := deployedPkg.DeployedComponents[j].Status == zarfTypes.ComponentStatusSucceeded
+			if p.numComponents > 0 && len(p.componentStatuses) >= j && componentSucceeded {
 				m.packages[i].componentStatuses[j] = true
 			}
 		}


### PR DESCRIPTION
## Description

`uds deploy k3d-core-istio-dev:0.16.1` fails 1/10 times due a race condition with the deploy ticker, this PR adds an additional check to ensure we don't seg fault

![Screenshot 2024-03-28 at 11 23 31 AM](https://github.com/defenseunicorns/uds-cli/assets/42304551/6cfac4be-0293-46a9-b450-0b927ac8540e)
