### PR TITLE
fix: ensure we are pulling all components

### DIFF
--- a/src/pkg/bundler/fetcher/fetcher.go
+++ b/src/pkg/bundler/fetcher/fetcher.go
@@ -52,6 +52,7 @@ func NewPkgFetcher(pkg types.Package, fetcherConfig Config) (Fetcher, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		fetcher = &remoteFetcher{
 			pkg:             pkg,
 			cfg:             fetcherConfig,

--- a/src/pkg/bundler/fetcher/remote.go
+++ b/src/pkg/bundler/fetcher/remote.go
@@ -101,7 +101,7 @@ func (f *remoteFetcher) Fetch() ([]ocispec.Descriptor, error) {
 func (f *remoteFetcher) layersToLocalBundle(spinner *message.Spinner, currentPackageIter int, totalPackages int) ([]ocispec.Descriptor, error) {
 	spinner.Updatef("Fetching %s package layer metadata (package %d of %d)", f.pkg.Name, currentPackageIter, totalPackages)
 	// get only the layers that are required by the components
-	layersToCopy, err := utils.GetZarfLayers(*f.remote, f.pkgRootManifest)
+	layersToCopy, err := utils.GetZarfLayers(*f.remote, f.pkgRootManifest, f.pkg.OptionalComponents)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/bundler/pusher/remote.go
+++ b/src/pkg/bundler/pusher/remote.go
@@ -88,7 +88,7 @@ func (p *RemotePusher) PushManifest() (ocispec.Descriptor, error) {
 func (p *RemotePusher) LayersToRemoteBundle(spinner *message.Spinner, currentPackageIter int, totalPackages int) ([]ocispec.Descriptor, error) {
 	spinner.Updatef("Fetching %s package layer metadata (package %d of %d)", p.pkg.Name, currentPackageIter, totalPackages)
 	// get only the layers that are required by the components
-	layersToCopy, err := utils.GetZarfLayers(p.cfg.RemoteSrc, p.cfg.PkgRootManifest)
+	layersToCopy, err := utils.GetZarfLayers(p.cfg.RemoteSrc, p.cfg.PkgRootManifest, p.pkg.OptionalComponents)
 	if err != nil {
 		return nil, err
 	}

--- a/src/test/bundles/13-composable-component/uds-bundle.yaml
+++ b/src/test/bundles/13-composable-component/uds-bundle.yaml
@@ -1,0 +1,14 @@
+kind: UDSBundle
+metadata:
+  name: with-composed
+  description: |
+    test bundle with a remote pkg with a:
+      - docker distribution manifest media type (quay images)
+      - composed component with only images
+  version: 0.0.1
+
+packages:
+  - name: prometheus
+    # remote pkg ensures we're testing pulling composed components from OCI
+    repository: localhost:888/prometheus
+    ref: 0.0.1

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -481,6 +481,22 @@ func validateMultiArchIndex(t *testing.T, index ocispec.Index) {
 	require.True(t, checkedARM)
 }
 
+func TestBundleWithComposedPkgComponent(t *testing.T) {
+	e2e.SetupDockerRegistry(t, 888)
+	defer e2e.TeardownRegistry(t, 888)
+	zarfPkgPath := "src/test/packages/prometheus"
+	pkg := filepath.Join(zarfPkgPath, fmt.Sprintf("zarf-package-prometheus-%s-0.0.1.tar.zst", e2e.Arch))
+	e2e.CreateZarfPkg(t, zarfPkgPath, false)
+	zarfPublish(t, pkg, "localhost:888")
+
+	bundleDir := "src/test/bundles/13-composable-component"
+	bundleName := "with-composed"
+	bundlePath := filepath.Join(bundleDir, fmt.Sprintf("uds-bundle-%s-%s-0.0.1.tar.zst", bundleName, e2e.Arch))
+	createLocal(t, bundleDir, e2e.Arch)
+	deploy(t, bundlePath)
+	remove(t, bundlePath)
+}
+
 func TestBundleTmpDir(t *testing.T) {
 	deployZarfInit(t)
 	e2e.CreateZarfPkg(t, "src/test/packages/podinfo", false)

--- a/src/test/packages/prometheus/images/zarf.yaml
+++ b/src/test/packages/prometheus/images/zarf.yaml
@@ -1,0 +1,13 @@
+kind: ZarfPackageConfig
+metadata:
+  name: prometheus-images
+  description: |
+    testing pkg component composition
+  version: 0.0.1
+
+components:
+  - name: upload
+    required: true
+    description: Push quay image to the zarf registry
+    images:
+      - quay.io/prometheus/node-exporter:v1.7.0

--- a/src/test/packages/prometheus/zarf.yaml
+++ b/src/test/packages/prometheus/zarf.yaml
@@ -1,0 +1,21 @@
+kind: ZarfPackageConfig
+metadata:
+  name: prometheus
+  description: |
+    test pkg with a docker distribution manifest media type (quay images) and a component with only images
+  version: 0.0.1
+
+components:
+  - name: upload-image
+    required: true
+    description: test composition
+    import:
+      path: images
+      name: upload
+  - name: deploy
+    required: true
+    charts:
+      - name: prometheus-node-exporter
+        url: https://prometheus-community.github.io/helm-charts
+        version: 4.32.0
+        namespace: prometheus


### PR DESCRIPTION
## Description

ensure we are pulling all Zarf pkg layers by grabbing them from the `zarf.yaml` instead of the pkg root manifest
