### PR TITLE
feat: add ability to uds create to local output path

### DIFF
--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -76,6 +76,14 @@ func (b *Bundle) ClearPaths() {
 	_ = os.RemoveAll(b.tmp)
 }
 
+// Checks if string is an oci url
+func (b *Bundle) isURL(s string) bool {
+	if strings.Contains(s, "://") || strings.Contains(s, ".") && len(s) > 1 {
+		return true
+	}
+	return false
+}
+
 // ValidateBundleResources validates the bundle's metadata and package references
 func (b *Bundle) ValidateBundleResources(bundle *types.UDSBundle, spinner *message.Spinner) error {
 	// TODO: need to validate arch of local OS
@@ -154,7 +162,7 @@ func (b *Bundle) ValidateBundleResources(bundle *types.UDSBundle, spinner *messa
 			}
 		} else {
 			// atm we don't support outputting a bundle with local pkgs outputting to OCI
-			if b.cfg.CreateOpts.Output != "" {
+			if b.isURL(b.cfg.CreateOpts.Output) {
 				return fmt.Errorf("detected local Zarf package: %s, outputting to an OCI registry is not supported when using local Zarf packages", pkg.Name)
 			}
 			var fullPkgName string

--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/defenseunicorns/uds-cli/src/config"
 	"github.com/defenseunicorns/uds-cli/src/pkg/bundler/fetcher"
+	"github.com/defenseunicorns/uds-cli/src/pkg/utils"
 	"github.com/defenseunicorns/uds-cli/src/types"
 	"github.com/defenseunicorns/zarf/src/pkg/cluster"
 	"github.com/defenseunicorns/zarf/src/pkg/message"
@@ -74,14 +75,6 @@ func NewOrDie(cfg *types.BundleConfig) *Bundle {
 // ClearPaths closes any files and clears out the paths used by Bundle
 func (b *Bundle) ClearPaths() {
 	_ = os.RemoveAll(b.tmp)
-}
-
-// Checks if string is an oci url
-func (b *Bundle) isURL(s string) bool {
-	if strings.Contains(s, "://") || strings.Contains(s, ".") && len(s) > 1 {
-		return true
-	}
-	return false
 }
 
 // ValidateBundleResources validates the bundle's metadata and package references
@@ -162,7 +155,7 @@ func (b *Bundle) ValidateBundleResources(bundle *types.UDSBundle, spinner *messa
 			}
 		} else {
 			// atm we don't support outputting a bundle with local pkgs outputting to OCI
-			if b.isURL(b.cfg.CreateOpts.Output) {
+			if utils.IsRegistryURL(b.cfg.CreateOpts.Output) {
 				return fmt.Errorf("detected local Zarf package: %s, outputting to an OCI registry is not supported when using local Zarf packages", pkg.Name)
 			}
 			var fullPkgName string

--- a/src/pkg/bundler/bundler.go
+++ b/src/pkg/bundler/bundler.go
@@ -5,6 +5,8 @@
 package bundler
 
 import (
+	"strings"
+
 	"github.com/defenseunicorns/uds-cli/src/types"
 )
 
@@ -39,17 +41,25 @@ func NewBundler(opts *Options) *Bundler {
 	return &b
 }
 
+// Checks if string is an oci url
+func isURL(s string) bool {
+	if strings.Contains(s, "://") || strings.Contains(s, ".") && len(s) > 1 {
+		return true
+	}
+	return false
+}
+
 // Create creates a bundle
 func (b *Bundler) Create() error {
-	if b.output == "" {
-		localBundle := NewLocalBundle(&LocalBundleOpts{Bundle: b.bundle, TmpDstDir: b.tmpDstDir, SourceDir: b.sourceDir})
-		err := localBundle.create(nil)
+	if isURL(b.output) {
+		remoteBundle := NewRemoteBundle(&RemoteBundleOpts{Bundle: b.bundle, Output: b.output})
+		err := remoteBundle.create(nil)
 		if err != nil {
 			return err
 		}
 	} else {
-		remoteBundle := NewRemoteBundle(&RemoteBundleOpts{Bundle: b.bundle, Output: b.output})
-		err := remoteBundle.create(nil)
+		localBundle := NewLocalBundle(&LocalBundleOpts{Bundle: b.bundle, TmpDstDir: b.tmpDstDir, SourceDir: b.sourceDir, OutputDir: b.output})
+		err := localBundle.create(nil)
 		if err != nil {
 			return err
 		}

--- a/src/pkg/bundler/bundler.go
+++ b/src/pkg/bundler/bundler.go
@@ -5,8 +5,7 @@
 package bundler
 
 import (
-	"strings"
-
+	"github.com/defenseunicorns/uds-cli/src/pkg/utils"
 	"github.com/defenseunicorns/uds-cli/src/types"
 )
 
@@ -41,17 +40,9 @@ func NewBundler(opts *Options) *Bundler {
 	return &b
 }
 
-// Checks if string is an oci url
-func isURL(s string) bool {
-	if strings.Contains(s, "://") || strings.Contains(s, ".") && len(s) > 1 {
-		return true
-	}
-	return false
-}
-
 // Create creates a bundle
 func (b *Bundler) Create() error {
-	if isURL(b.output) {
+	if utils.IsRegistryURL(b.output) {
 		remoteBundle := NewRemoteBundle(&RemoteBundleOpts{Bundle: b.bundle, Output: b.output})
 		err := remoteBundle.create(nil)
 		if err != nil {

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/defenseunicorns/uds-cli/src/config"
@@ -137,4 +138,49 @@ func ToLocalFile(t any, filePath string) error {
 // IsRemotePkg returns true if the Zarf package is remote
 func IsRemotePkg(pkg types.Package) bool {
 	return pkg.Repository != ""
+}
+
+func hasScheme(s string) bool {
+	return strings.Contains(s, "://")
+}
+
+func hasDomain(s string) bool {
+	return strings.Contains(s, ".") && len(s) > 1
+}
+
+func hasPort(s string) bool {
+	// look for colon and port (e.g localhost:31999)
+	colonIndex := strings.Index(s, ":")
+	firstSlashIndex := strings.Index(s, "/")
+	endIndex := firstSlashIndex
+	if firstSlashIndex == -1 {
+		endIndex = len(s) - 1
+	}
+	if colonIndex != -1 {
+		port := s[colonIndex+1 : endIndex]
+
+		// port valid number ?
+		_, err := strconv.Atoi(port)
+		if err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// Checks if string is an oci url
+func IsRegistryURL(s string) bool {
+	if hasScheme(s) {
+		return true
+	}
+
+	if hasDomain(s) {
+		return true
+	}
+
+	if hasPort(s) {
+		return true
+	}
+
+	return false
 }

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -144,8 +144,14 @@ func hasScheme(s string) bool {
 	return strings.Contains(s, "://")
 }
 
+// hasDomain checks if a string contains a domain.
+// It assumes the domain is at the beginning of a URL and there is no scheme (e.g., oci://).
 func hasDomain(s string) bool {
-	return strings.Contains(s, ".") && len(s) > 1
+	dotIndex := strings.Index(s, ".")
+	firstSlashIndex := strings.Index(s, "/")
+
+	// dot exists; dot is not first char; not preceded by any / if / exists
+	return dotIndex != -1 && dotIndex != 0 && (firstSlashIndex == -1 || firstSlashIndex > dotIndex)
 }
 
 func hasPort(s string) bool {

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -174,17 +174,9 @@ func hasPort(s string) bool {
 	return false
 }
 
-// Checks if string is an oci url
+// IsRegistryURL checks if a string is a URL
 func IsRegistryURL(s string) bool {
-	if hasScheme(s) {
-		return true
-	}
-
-	if hasDomain(s) {
-		return true
-	}
-
-	if hasPort(s) {
+	if hasScheme(s) || hasDomain(s) || hasPort(s) {
 		return true
 	}
 

--- a/src/pkg/utils/utils_test.go
+++ b/src/pkg/utils/utils_test.go
@@ -1,0 +1,92 @@
+package utils
+
+import (
+	"testing"
+)
+
+func Test_IsRegistryURL(t *testing.T) {
+	type args struct {
+		output string
+	}
+	tests := []struct {
+		name        string
+		description string
+		args        args
+		wantResult  bool
+	}{
+		{
+			name:        "HasScheme",
+			description: "Output has a scheme ://",
+			args:        args{output: "oci://ghcr.io/defenseunicorns/dev"},
+			wantResult:  true,
+		},
+		{
+			name:        "HasDomain",
+			description: "Output has no scheme but has domain",
+			args:        args{output: "ghcr.io/defenseunicorns/dev"},
+			wantResult:  true,
+		},
+		{
+			name:        "HasMultiDomain",
+			description: "Output has no scheme but has domain in form of example.example.com",
+			args:        args{output: "registry.example.io/defenseunicorns/dev"},
+			wantResult:  true,
+		},
+		{
+			name:        "HasDomainAndNoPath",
+			description: "Output has no scheme but has domain in form of example.example.com",
+			args:        args{output: "registry.example.io"},
+			wantResult:  true,
+		},
+		{
+			name:        "HasPort",
+			description: "Output has no scheme or domain (with .) but has port",
+			args:        args{output: "localhost:31999"},
+			wantResult:  true,
+		},
+		{
+			name:        "HasPortWithTrailingSlash",
+			description: "Output has no scheme or domain (with .) but has port with trailing /",
+			args:        args{output: "localhost:31999/path"},
+			wantResult:  true,
+		},
+		{
+			name:        "IsLocalPath",
+			description: "Output is to local path",
+			args:        args{output: "local/path"},
+			wantResult:  false,
+		},
+		{
+			name:        "IsCurrentDirectory",
+			description: "Output is current directory",
+			args:        args{output: "."},
+			wantResult:  false,
+		},
+		{
+			name:        "IsHiddenDirectory",
+			description: "Output is a hidden directory",
+			args:        args{output: ".dev"},
+			wantResult:  false,
+		},
+		{
+			name:        "IsHiddenDirectoryWithSlashPrefix",
+			description: "Output is a hidden directory nested in path",
+			args:        args{output: "/pathto/.dev"},
+			wantResult:  false,
+		},
+		{
+			name:        "HasRareDotInLocalDirectoryPath",
+			description: "Output is a hidden directory nested in path",
+			args:        args{output: "/pathto/test.dev/"},
+			wantResult:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if result := IsRegistryURL(tt.args.output); result != tt.wantResult {
+				t.Errorf("IsRegistryURL() result = %v, wantResult %v", result, tt.wantResult)
+			}
+		})
+	}
+}

--- a/src/pkg/utils/utils_test.go
+++ b/src/pkg/utils/utils_test.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_IsRegistryURL(t *testing.T) {
@@ -84,9 +86,8 @@ func Test_IsRegistryURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if result := IsRegistryURL(tt.args.output); result != tt.wantResult {
-				t.Errorf("IsRegistryURL() result = %v, wantResult %v", result, tt.wantResult)
-			}
+			actualResult := IsRegistryURL(tt.args.output)
+			require.Equal(t, tt.wantResult, actualResult)
 		})
 	}
 }

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -320,6 +320,22 @@ func TestBundleWithYmlFile(t *testing.T) {
 	remove(t, bundlePath)
 }
 
+func TestLocalBundleWithOutput(t *testing.T) {
+	path := "src/test/packages/nginx"
+	args := strings.Split(fmt.Sprintf("zarf package create %s -o %s --confirm", path, path), " ")
+	_, _, err := e2e.UDS(args...)
+	require.NoError(t, err)
+
+	bundleDir := "src/test/bundles/09-uds-bundle-yml"
+	destDir := "src/test/test/"
+	bundlePath := filepath.Join(destDir, fmt.Sprintf("uds-bundle-yml-example-%s-0.0.1.tar.zst", e2e.Arch))
+	createLocalWithOuputFlag(t, bundleDir, destDir, e2e.Arch)
+
+	cmd := strings.Split(fmt.Sprintf("inspect %s", bundlePath), " ")
+	_, _, err = e2e.UDS(cmd...)
+	require.NoError(t, err)
+}
+
 func TestLocalBundleWithNoSBOM(t *testing.T) {
 	path := "src/test/packages/nginx"
 	args := strings.Split(fmt.Sprintf("zarf package create %s -o %s --skip-sbom --confirm", path, path), " ")

--- a/src/test/e2e/commands_test.go
+++ b/src/test/e2e/commands_test.go
@@ -36,6 +36,12 @@ func createLocalError(bundlePath string, arch string) (stderr string) {
 	return stderr
 }
 
+func createLocalWithOuputFlag(t *testing.T, bundlePath string, destPath string, arch string) {
+	cmd := strings.Split(fmt.Sprintf("create %s -o %s --insecure --confirm -a %s", bundlePath, destPath, arch), " ")
+	_, _, err := e2e.UDS(cmd...)
+	require.NoError(t, err)
+}
+
 func createRemoteInsecure(t *testing.T, bundlePath, registry, arch string) {
 	cmd := strings.Split(fmt.Sprintf("create %s -o %s --confirm --insecure -a %s", bundlePath, registry, arch), " ")
 	_, _, err := e2e.UDS(cmd...)


### PR DESCRIPTION
## Description
Adds the ability to pass a local output path to `uds create`.

## Related Issue

resolves #461 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
