### PR TITLE
ci: pin k3s version in k3d action to sidestep containerd issue

### DIFF
--- a/.github/actions/k3d/action.yaml
+++ b/.github/actions/k3d/action.yaml
@@ -7,5 +7,5 @@ runs:
     - run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
       shell: bash
 
-    - run: k3d cluster delete && k3d cluster create
+    - run: k3d cluster delete && k3d cluster create --image="rancher/k3s:v1.28.4-k3s2"
       shell: bash


### PR DESCRIPTION
## Description

Related to this issue: https://github.com/containerd/containerd/issues/10014

This pins the version of k3s that k3d uses, avoiding an HTTP/HTTPS issue that causes zarf init packages to fail to deploy to the cluster.

## Related Issue

https://github.com/defenseunicorns/zarf/pull/2430

https://github.com/defenseunicorns/uds-cli/actions/runs/8623241720/job/23669501759?pr=554
https://github.com/defenseunicorns/uds-cli/actions/runs/8631062004/job/23658683639#step:6:12794

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
