### PR TITLE
chore: ensure vendored tools versions print out

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,18 @@
 
 ARCH ?= amd64
 CLI_VERSION ?= $(if $(shell git describe --tags),$(shell git describe --tags),"UnknownVersion")
+K9S_VERSION=$(shell go list -f '{{.Version}}' -m github.com/derailed/k9s)
+CRANE_VERSION=$(shell go list -f '{{.Version}}' -m github.com/google/go-containerregistry)
+SYFT_VERSION=$(shell go list -f '{{.Version}}' -m github.com/anchore/syft)
+ARCHIVER_VERSION=$(shell go list -f '{{.Version}}' -m github.com/mholt/archiver/v3)
+HELM_VERSION=$(shell go list -f '{{.Version}}' -m helm.sh/helm/v3)
 BUILD_ARGS := -s -w -X 'github.com/defenseunicorns/uds-cli/src/config.CLIVersion=$(CLI_VERSION)' \
-				    -X 'github.com/defenseunicorns/zarf/src/config.ActionsCommandZarfPrefix=zarf'
+				    -X 'github.com/defenseunicorns/zarf/src/config.ActionsCommandZarfPrefix=zarf' \
+					-X 'github.com/derailed/k9s/cmd.version=$(K9S_VERSION)' \
+					-X 'github.com/google/go-containerregistry/cmd/crane/cmd.Version=$(CRANE_VERSION)' \
+					-X 'github.com/defenseunicorns/zarf/src/cmd/tools.syftVersion=$(SYFT_VERSION)' \
+					-X 'github.com/defenseunicorns/zarf/src/cmd/tools.archiverVersion=$(ARCHIVER_VERSION)' \
+					-X 'github.com/defenseunicorns/zarf/src/cmd/tools.helmVersion=$(HELM_VERSION)'
 
 .PHONY: help
 help: ## Display this help information

--- a/src/test/common.go
+++ b/src/test/common.go
@@ -159,7 +159,7 @@ func (e2e *UDSE2ETest) DownloadZarfInitPkg(t *testing.T, zarfVersion string) {
 	require.NoError(t, err)
 }
 
-// CreateZarfPkg creates a Zarf in the given path (todo: makefile?)
+// CreateZarfPkg creates a Zarf package in the given path (todo: makefile?)
 func (e2e *UDSE2ETest) CreateZarfPkg(t *testing.T, path string, forceCreate bool) {
 	//  check if pkg already exists
 	pattern := fmt.Sprintf("%s/*-%s-*.tar.zst", path, e2e.Arch)
@@ -174,6 +174,7 @@ func (e2e *UDSE2ETest) CreateZarfPkg(t *testing.T, path string, forceCreate bool
 	require.NoError(t, err)
 }
 
+// DeleteZarfPkg deletes a Zarf package from the given path
 func (e2e *UDSE2ETest) DeleteZarfPkg(t *testing.T, path string) {
 	//  check if pkg already exists
 	pattern := fmt.Sprintf("%s/*-%s-*.tar.zst", path, e2e.Arch)

--- a/src/test/e2e/zarf_test.go
+++ b/src/test/e2e/zarf_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/defenseunicorns/zarf/src/pkg/utils/exec"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,4 +20,23 @@ func TestZarfLint(t *testing.T) {
 	_, stdErr, err := e2e.UDS(cmd...)
 	require.NoError(t, err)
 	require.Contains(t, stdErr, "Image not pinned with digest - ghcr.io/stefanprodan/podinfo:6.4.0")
+}
+
+// K9S_VERSION=$(shell go list -f '{{.Version}}' -m github.com/derailed/k9s)
+// CRANE_VERSION=$(shell go list -f '{{.Version}}' -m github.com/google/go-containerregistry)
+// SYFT_VERSION=$(shell go list -f '{{.Version}}' -m github.com/anchore/syft)
+// ARCHIVER_VERSION=$(shell go list -f '{{.Version}}' -m github.com/mholt/archiver/v3)
+// HELM_VERSION=$(shell go list -f '{{.Version}}' -m helm.sh/helm/v3)
+
+// // vendored tool versions are set as build args
+func TestZarfToolsVersions(t *testing.T) {
+	cmd := strings.Split("zarf tools helm version", " ")
+	_, stderr, err := e2e.UDS(cmd...)
+	getHelmVersionCmd := strings.Split("list -f '{{.Version}}' -m helm.sh/helm/v3", " ")
+	versionRes, _, _ := exec.Cmd("go", getHelmVersionCmd...)
+	helmVersion := strings.Split(versionRes, "'")
+	version := strings.Split(stderr, "\n")
+	require.NoError(t, err)
+	require.Contains(t, version[4], "helm")
+	require.Contains(t, version[4], helmVersion[1])
 }

--- a/src/test/e2e/zarf_test.go
+++ b/src/test/e2e/zarf_test.go
@@ -39,36 +39,36 @@ func TestZarfToolsVersions(t *testing.T) {
 			args:        args{tool: "helm", toolRepo: "helm.sh/helm/v3"},
 		},
 		{
-			name:        "Crane Version",
+			name:        "CraneVersion",
 			description: "zarf tools crane version",
 			args:        args{tool: "crane", toolRepo: "github.com/google/go-containerregistry"},
 		},
 		{
-			name:        "Syft Version",
+			name:        "SyftVersion",
 			description: "zarf tools syft version",
 			args:        args{tool: "syft", toolRepo: "github.com/anchore/syft"},
 		},
 		{
-			name:        "Archiver Version",
+			name:        "ArchiverVersion",
 			description: "zarf tools archiver version",
 			args:        args{tool: "archiver", toolRepo: "github.com/mholt/archiver/v3"},
 		},
 	}
 
 	for _, tt := range tests {
-		cmdStr := fmt.Sprintf("zarf tools %s version", tt.args.tool)
-		res, stdErr, err := e2e.UDS(strings.Split(cmdStr, " ")...)
+		cmdArgs := fmt.Sprintf("zarf tools %s version", tt.args.tool)
+		res, stdErr, err := e2e.UDS(strings.Split(cmdArgs, " ")...)
 		require.NoError(t, err)
 
-		toolVerRepoStr := fmt.Sprintf("list -f '{{.Version}}' -m %s", tt.args.toolRepo)
-		verRes, _, verErr := exec.Cmd("go", strings.Split(toolVerRepoStr, " ")...)
+		toolRepoVerArgs := fmt.Sprintf("list -f '{{.Version}}' -m %s", tt.args.toolRepo)
+		verRes, _, verErr := exec.Cmd("go", strings.Split(toolRepoVerArgs, " ")...)
 		require.NoError(t, verErr)
 
-		toolVersion := strings.Split(verRes, "'")
-		toMatch := res
+		toolVersion := strings.Split(verRes, "'")[1]
+		output := res
 		if res == "" {
-			toMatch = stdErr
+			output = stdErr
 		}
-		require.Contains(t, toMatch, toolVersion[1])
+		require.Contains(t, output, toolVersion)
 	}
 }


### PR DESCRIPTION
## Description
Make sure that vendored zarf tools versions are outputted when running commands like `uds zarf tools helm version`

## Related Issue
resolves #357 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
