### PR TITLE
feat: remove q for canceling deploy

### DIFF
--- a/src/pkg/bundle/tui/deploy/model.go
+++ b/src/pkg/bundle/tui/deploy/model.go
@@ -205,7 +205,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					quitMsg := tea.Println(tui.IndentStyle.Render("\n👋 Deployment cancelled"))
 					return m, tea.Sequence(quitMsg, tea.Println(), tea.Quit)
 				}
-			case "ctrl+c", "q":
+			case "ctrl+c":
 				return m, tea.Sequence(tea.Quit)
 
 			case "up":


### PR DESCRIPTION
## Description

Remove `q` for canceling deployments (too easy to accidentally kill a deployment with a single key)

