### PR TITLE
chore: bump Go version to 1.21.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/defenseunicorns/uds-cli
 
-go 1.21.8
+go 1.21.10
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
## Description

Bumps Go version to 1.21.10 in light of https://nvd.nist.gov/vuln/detail/CVE-2024-24787
