### PR TITLE
chore: test getArch

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,13 @@ As an example: `uds remove uds-bundle-<name>.tar.zst --packages init,nginx`
 The `uds logs` command can be used to view the most recent logs of a bundle operation. Note that depending on your OS temporary directory and file settings, recent logs are purged after a certain amount of time, so this command may return an error if the logs are no longer available.
 
 ## Bundle Architecture and Multi-Arch Support
-There are several ways to specify the architecture of a bundle:
+There are several ways to specify the architecture of a bundle according to the following precedence:
 1. Setting `--architecture` or `-a` flag during `uds ...` operations: `uds create <dir> --architecture arm64`
-2. Setting the `metadata.architecture` key in a `uds-bundle.yaml`
-3. Setting a `UDS_ARCHITECTURE` environment variable
-4. Setting the `options.architecture` key in a `uds-config.yaml`
+2. Setting a `UDS_ARCHITECTURE` environment variable
+3. Setting the `options.architecture` key in a `uds-config.yaml`
+4. Setting the `metadata.architecture` key in a `uds-bundle.yaml`
 
-Note that the setting the `--architecture` flag takes precedence over all other methods of specifying the architecture.
+This means that setting the `--architecture` flag takes precedence over all other methods of specifying the architecture.
 
 UDS CLI supports multi-arch bundles. This means you can push bundles with different architectures to the same remote OCI repository, at the same tag. For example, you can push both an `amd64` and `arm64` bundle to `ghcr.io/<org>/<bundle name>:0.0.1`.
 

--- a/src/cmd/cmd_test.go
+++ b/src/cmd/cmd_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/defenseunicorns/uds-cli/src/config"
+	"github.com/defenseunicorns/uds-cli/src/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSettingArchitecture(t *testing.T) {
+	testCases := []struct {
+		name        string
+		cliArch     string
+		bundle      *types.UDSBundle
+		expectedVal string
+	}{
+		{
+			name:    "CLIArch takes precedence",
+			cliArch: "archFromFlag",
+			bundle: &types.UDSBundle{
+				Metadata: types.UDSMetadata{
+					Architecture: "setFromMetadata",
+				},
+			},
+			expectedVal: "archFromFlag",
+		},
+		{
+			name:    "Metadata.Arch",
+			cliArch: "",
+			bundle: &types.UDSBundle{
+				Metadata: types.UDSMetadata{
+					Architecture: "setFromMetadata",
+				},
+			},
+			expectedVal: "setFromMetadata",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := tc.bundle
+			config.CLIArch = tc.cliArch
+			b.Build.Architecture = config.GetArch(b.Metadata.Architecture)
+			require.Equal(t, tc.expectedVal, b.Build.Architecture)
+		})
+	}
+}


### PR DESCRIPTION
## Description
Testing that getArch(), which is used for calculating build info, returns the correct architecture. 

Due to complications unit testing how the config.CLIArch var gets set (via viper config loading and a cmd flag) we opted for just testing that, between CLIArch and bundle.Metadata.Architecture, CLIArch should take precedence.
...

## Related Issue

Resolves #360 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
