### PR TITLE
chore: cleans up lang file and docs, use PRs for brew releases

### DIFF
--- a/.github/actions/save-logs/action.yaml
+++ b/.github/actions/save-logs/action.yaml
@@ -1,20 +1,10 @@
 name: save-logs
 description: "Save debug logs"
 
-inputs:
-  name:
-    description: "unique name to put in log file"
-    required: true
-
 runs:
   using: composite
   steps:
-    - name: Fix log permissions
-      run: |
-        sudo chown $USER /tmp/uds-${{ inputs.name }}.log || echo ""
-      shell: bash
-
     - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: debug-log
-        path: /tmp/uds-${{ inputs.name }}.log
+        path: /tmp/uds-*.log

--- a/.github/actions/save-logs/action.yaml
+++ b/.github/actions/save-logs/action.yaml
@@ -1,9 +1,19 @@
 name: save-logs
 description: "Save debug logs"
 
+inputs:
+  name:
+    description: "unique name to put in log file"
+    required: true
+
 runs:
   using: composite
   steps:
+    - name: Fix log permissions
+      run: |
+        sudo chown $USER /tmp/uds-${{ inputs.name }}.log || echo ""
+      shell: bash
+
     - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: debug-log

--- a/.github/actions/save-logs/action.yaml
+++ b/.github/actions/save-logs/action.yaml
@@ -17,4 +17,4 @@ runs:
     - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: debug-log
-        path: /tmp/uds-*.log
+        path: /tmp/uds-${{ inputs.name }}.log

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,11 +149,12 @@ jobs:
 
       - name: Get Brew tap repo token
         id: brew-tap-token
-        uses: peter-murray/workflow-application-token-action@dc0413987a085fa17d19df9e47d4677cf81ffef3 # v3.0.0
+        uses: actions/create-github-app-token@c8f55efbd427e7465d6da1106e7979bc8aaee856 # v1.10.1
         with:
-          application_id: ${{ secrets.HOMEBREW_TAP_WORKFLOW_GITHUB_APP_ID }}
-          application_private_key: ${{ secrets.HOMEBREW_TAP_WORKFLOW_GITHUB_APP_SECRET }}
-          organization: defenseunicorns
+          app-id: ${{ secrets.HOMEBREW_TAP_WORKFLOW_GITHUB_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_WORKFLOW_GITHUB_APP_SECRET }}
+          owner: defenseunicorns
+          repositories: homebrew-tap
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0

--- a/.github/workflows/test-e2e-pr.yaml
+++ b/.github/workflows/test-e2e-pr.yaml
@@ -61,11 +61,13 @@ jobs:
 
       - name: Run e2e bundle tests
         run: |
-          build/uds run test:run-bundle-test --no-progress
+          build/uds run test:bundle --no-progress
 
       - name: Save logs
         if: always()
         uses: ./.github/actions/save-logs
+        with:
+          name: build
 
   test-dev:
     runs-on: ubuntu-latest
@@ -81,11 +83,13 @@ jobs:
 
       - name: Run e2e dev tests
         run: |
-          build/uds run test:run-dev-test --no-progress
+          build/uds run test:dev --no-progress
 
       - name: Save logs
         if: always()
         uses: ./.github/actions/save-logs
+        with:
+          name: test-dev
 
   test-variables:
     runs-on: ubuntu-latest
@@ -101,11 +105,13 @@ jobs:
 
       - name: Run e2e variable tests
         run: |
-          build/uds run test:run-variable-test --no-progress
+          build/uds run test:variable --no-progress
 
       - name: Save logs
         if: always()
         uses: ./.github/actions/save-logs
+        with:
+          name: test-variables
 
   test-optional-bundle:
     runs-on: ubuntu-latest
@@ -121,11 +127,13 @@ jobs:
 
       - name: Run e2e optional bundle tests
         run: |
-          build/uds run test:run-optional-bundle-tests --no-progress
+          build/uds run test:optional-bundle --no-progress
 
       - name: Save logs
         if: always()
         uses: ./.github/actions/save-logs
+        with:
+          name: test-optional-bundle
 
   test-vendor:
     runs-on: ubuntu-latest
@@ -141,8 +149,10 @@ jobs:
 
       - name: Run e2e vendor tests
         run: |
-          build/uds run test:run-vendor-tests --no-progress
+          build/uds run test:vendor --no-progress
 
       - name: Save logs
         if: always()
         uses: ./.github/actions/save-logs
+        with:
+          name: test-vendor

--- a/.github/workflows/test-e2e-pr.yaml
+++ b/.github/workflows/test-e2e-pr.yaml
@@ -66,8 +66,6 @@ jobs:
       - name: Save logs
         if: always()
         uses: ./.github/actions/save-logs
-        with:
-          name: build
 
   test-dev:
     runs-on: ubuntu-latest
@@ -88,8 +86,6 @@ jobs:
       - name: Save logs
         if: always()
         uses: ./.github/actions/save-logs
-        with:
-          name: test-dev
 
   test-variables:
     runs-on: ubuntu-latest
@@ -110,8 +106,6 @@ jobs:
       - name: Save logs
         if: always()
         uses: ./.github/actions/save-logs
-        with:
-          name: test-variables
 
   test-optional-bundle:
     runs-on: ubuntu-latest
@@ -132,8 +126,6 @@ jobs:
       - name: Save logs
         if: always()
         uses: ./.github/actions/save-logs
-        with:
-          name: test-optional-bundle
 
   test-vendor:
     runs-on: ubuntu-latest
@@ -154,5 +146,3 @@ jobs:
       - name: Save logs
         if: always()
         uses: ./.github/actions/save-logs
-        with:
-          name: test-vendor

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,6 +49,13 @@ brews:
       owner: defenseunicorns
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      branch: "{{ .ProjectName }}-{{ .Tag }}"
+      pull_request:
+        enabled: true
+        base:
+          branch: main
+          owner: defenseunicorns
+          name: homebrew-tap
     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     homepage: "https://github.com/defenseunicorns/uds-cli"
     description: "CLI for Unicorn Delivery Service"
@@ -60,6 +67,13 @@ brews:
       owner: defenseunicorns
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      branch: "{{ .ProjectName }}-{{ .Tag }}"
+      pull_request:
+        enabled: true
+        base:
+          branch: main
+          owner: defenseunicorns
+          name: homebrew-tap
     commit_msg_template: "Brew formula update for {{ .ProjectName }} versioned release {{ .Tag }}"
     homepage: "https://github.com/defenseunicorns/uds-cli"
     description: "CLI for Unicorn Delivery Service"

--- a/README.md
+++ b/README.md
@@ -7,38 +7,24 @@
 
 ## Table of Contents
 
-- [UDS-CLI](#uds-cli)
-  - [Table of Contents](#table-of-contents)
-  - [Install](#install)
-  - [Contributing](#contributing)
-  - [Quickstart](#quickstart)
-    - [Declarative Syntax](#declarative-syntax)
-    - [First-class UDS Support](#first-class-uds-support)
-    - [Bundle Create](#bundle-create)
-    - [Bundle Deploy](#bundle-deploy)
-      - [Specifying Packages using `--packages`](#specifying-packages-using---packages)
-      - [Resuming Bundle Deploys using `--resume`](#resuming-bundle-deploys-using---resume)
-    - [Bundle Inspect](#bundle-inspect)
-      - [Viewing Images in a Bundle](#viewing-images-in-a-bundle)
-      - [Viewing SBOMs](#viewing-sboms)
-    - [Bundle Publish](#bundle-publish)
-    - [Bundle Remove](#bundle-remove)
+1. [Install](#install)
+1. [Contributing](CONTRIBUTING.md)
+1. [Quickstart](#quickstart)
+    - [Create](#bundle-create)
+    - [Deploy](#bundle-deploy)
+    - [Inspect](#bundle-inspect)
+    - [Publish](#bundle-publish)
+    - [Remove](#bundle-remove)
     - [Logs](#logs)
-  - [Bundle Architecture and Multi-Arch Support](#bundle-architecture-and-multi-arch-support)
-    - [Architecture Validation](#architecture-validation)
-  - [Configuration](#configuration)
-  - [Sharing Variables](#sharing-variables)
-    - [Importing/Exporting Variables](#importingexporting-variables)
-    - [Sharing Variables Across Multiple Packages](#sharing-variables-across-multiple-packages)
-    - [Variable Precedence and Specificity](#variable-precedence-and-specificity)
-  - [Duplicate Packages And Naming](#duplicate-packages-and-naming)
-  - [Zarf Integration](#zarf-integration)
-  - [Dev Mode](#dev-mode)
-  - [Scan](#scan)
-    - [Usage](#usage)
-    - [Required Parameters](#required-parameters)
-    - [Optional Parameters](#optional-parameters)
-    - [Example Usage](#example-usage)
+1. [Bundle Architecture and Multi-Arch Support](#bundle-architecture-and-multi-arch-support)
+1. [Variables and Configuration](#variables-and-configuration)
+1. [Duplicate Packages and Naming](#duplicate-packages-and-naming)
+1. [Zarf Integration](#zarf-integration)
+1. [Bundle Overrides](docs/overrides.md)
+1. [Bundle Anatomy](docs/anatomy.md)
+1. [Runner](docs/runner.md)
+1. [Dev Mode](#dev-mode)
+1. [Scan](#scan)
 
 ## Install
 
@@ -208,8 +194,7 @@ If, for example, you have a multi-arch remote bundle that you want to deploy fro
 e.g.
 `uds deploy -a amd64 <remote-multi-arch-bundle.tar.zst> --confirm`
 
-## Configuration
-
+## Variables and Configuration
 The UDS CLI can be configured with a `uds-config.yaml` file. This file can be placed in the current working directory or specified with an environment variable called `UDS_CONFIG`. The basic structure of the `uds-config.yaml` is as follows:
 
 ```yaml
@@ -239,10 +224,7 @@ variables:
 
 The `options` key contains UDS CLI options that are not specific to a particular Zarf package. The `variables` key contains variables that are specific to a particular Zarf package. If you want to share insensitive variables across multiple Zarf packages, you can use the `shared` key, where the key is the variable name and the value is the variable value.
 
-## Sharing Variables
-
-### Importing/Exporting Variables
-
+### Sharing Variables
 Zarf package variables can be passed between Zarf packages:
 
 ```yaml

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -152,7 +152,7 @@ The `value` is the value to set at the `path`. Values can be simple values such 
 ```
 
 #### Bundle Variables as Values
-Bundle and Zarf variables can be used to set override values and be override variable defaults using the syntax `${...}`. For example:
+Bundle and Zarf variables can be used to set override values by using the syntax `${...}`. For example:
 ```yaml
 # uds-config.yaml
 variables:
@@ -216,10 +216,6 @@ packages:
              path: "ui.color"
              description: "Set the color for podinfo's UI"
              default: "purple"
-           - name: UI_MSG
-             path: "podinfo.ui.message"
-             description: "Set the message for podinfo's UI"
-             default: ${UI_MSG} # templating also works for variable defaults!
 ```
 
 There are 3 ways to override the `UI_COLOR` variable:

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -150,7 +150,13 @@ The `value` is the value to set at the `path`. Values can be simple values such 
               value:
                 customAnnotation: "customValue"
 ```
-If using a variable that has been [exported](../README.md#importingexporting-variables) from another package, that variable can also be used to set a value, using the syntax `${...}`. In the example below the `COLOR` variable is being used to set the `podinfo.ui.color` value.
+Zarf variables can be used to set override values and be override variable defaults using the syntax `${...}`.
+```yaml
+# uds-config.yaml
+variables:
+  helm-overrides-package:
+    replica_count: 2
+```
 ```yaml
 kind: UDSBundle
 metadata:
@@ -174,10 +180,12 @@ packages:
         unicorn-podinfo:
           values:
             - path: "podinfo.replicaCount"
-              value: 1
+              value: ${REPLICA_COUNT}
             - path: "podinfo.ui.color"
               value: ${COLOR}
 ```
+
+In the example above `${REPLICA_COUNT}` is set in the `uds-config.yaml` file and `${COLOR}` is set as an export from the `output-var` package. Note that you could also set these values with environment variables prefixed with `UDS_` or with the `--set` flag during deployment.
 
 #### Value Precedence
 Value precedence is as follows:
@@ -206,6 +214,10 @@ packages:
              path: "ui.color"
              description: "Set the color for podinfo's UI"
              default: "purple"
+           - name: UI_MSG
+             path: "podinfo.ui.message"
+             description: "Set the message for podinfo's UI"
+             default: ${UI_MSG} # templating also works for variable defaults!
 ```
 
 There are 3 ways to override the `UI_COLOR` variable:

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -150,7 +150,9 @@ The `value` is the value to set at the `path`. Values can be simple values such 
               value:
                 customAnnotation: "customValue"
 ```
-Zarf variables can be used to set override values and be override variable defaults using the syntax `${...}`.
+
+#### Bundle Variables as Values
+Bundle and Zarf variables can be used to set override values and be override variable defaults using the syntax `${...}`. For example:
 ```yaml
 # uds-config.yaml
 variables:
@@ -185,7 +187,7 @@ packages:
               value: ${COLOR}
 ```
 
-In the example above `${REPLICA_COUNT}` is set in the `uds-config.yaml` file and `${COLOR}` is set as an export from the `output-var` package. Note that you could also set these values with environment variables prefixed with `UDS_` or with the `--set` flag during deployment.
+In the example above `${REPLICA_COUNT}` is set in the `uds-config.yaml` file and `${COLOR}` is set as an export from the `output-var` package. Note that you could also set these values with the `shared` key in a `uds-config.yaml`, environment variables prefixed with `UDS_` or with the `--set` flag during deployment.
 
 #### Value Precedence
 Value precedence is as follows:

--- a/src/cmd/uds.go
+++ b/src/cmd/uds.go
@@ -156,7 +156,7 @@ var pullCmd = &cobra.Command{
 var logsCmd = &cobra.Command{
 	Use:     "logs",
 	Aliases: []string{"l"},
-	Short:   "Display log file contents",
+	Short:   lang.CmdBundleLogsShort,
 	Run: func(_ *cobra.Command, _ []string) {
 		logFilePath := filepath.Join(config.CommonOptions.CachePath, config.CachedLogs)
 
@@ -185,7 +185,7 @@ func init() {
 
 	// create cmd flags
 	rootCmd.AddCommand(createCmd)
-	createCmd.Flags().BoolVarP(&config.CommonOptions.Confirm, "confirm", "c", false, lang.CmdBundleRemoveFlagConfirm)
+	createCmd.Flags().BoolVarP(&config.CommonOptions.Confirm, "confirm", "c", false, lang.CmdBundleCreateFlagConfirm)
 	createCmd.Flags().StringVarP(&bundleCfg.CreateOpts.Output, "output", "o", v.GetString(V_BNDL_CREATE_OUTPUT), lang.CmdBundleCreateFlagOutput)
 	createCmd.Flags().StringVarP(&bundleCfg.CreateOpts.SigningKeyPath, "signing-key", "k", v.GetString(V_BNDL_CREATE_SIGNING_KEY), lang.CmdBundleCreateFlagSigningKey)
 	createCmd.Flags().StringVarP(&bundleCfg.CreateOpts.SigningKeyPassword, "signing-key-password", "p", v.GetString(V_BNDL_CREATE_SIGNING_KEY_PASSWORD), lang.CmdBundleCreateFlagSigningKeyPassword)

--- a/src/config/lang/lang.go
+++ b/src/config/lang/lang.go
@@ -9,7 +9,7 @@ const (
 	RootCmdShort              = "CLI for UDS Bundles"
 	RootCmdFlagSkipLogFile    = "Disable log file creation"
 	RootCmdFlagNoProgress     = "Disable fancy UI progress bars, spinners, logos, etc"
-	RootCmdFlagCachePath      = "Specify the location of the Zarf cache directory"
+	RootCmdFlagCachePath      = "Specify the location of the UDS cache directory"
 	RootCmdFlagTempDir        = "Specify the temporary directory to use for intermediate files"
 	RootCmdFlagInsecure       = "Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture."
 	RootCmdFlagLogLevel       = "Log level when running UDS-CLI. Valid options are: warn, info, debug, trace"
@@ -20,12 +20,11 @@ const (
 	CmdBundleLogsShort = "View most recent UDS CLI logs"
 
 	// bundle
-	CmdBundleShort           = "Commands for creating, deploying, removing, pulling, and inspecting bundles"
 	CmdBundleFlagConcurrency = "Number of concurrent layer operations to perform when interacting with a remote bundle."
 
 	// bundle create
-	CmdBundleCreateShort = "Create a bundle from a given directory or the current directory"
-	//CmdBundleCreateFlagConfirm            = "Confirm bundle creation without prompting"
+	CmdBundleCreateShort                  = "Create a bundle from a given directory or the current directory"
+	CmdBundleCreateFlagConfirm            = "Confirm bundle creation without prompting"
 	CmdBundleCreateFlagOutput             = "Specify the output (an oci:// URL) for the created bundle"
 	CmdBundleCreateFlagSigningKey         = "Path to private key file for signing bundles"
 	CmdBundleCreateFlagSigningKeyPassword = "Password to the private key file used for signing bundles"
@@ -33,7 +32,7 @@ const (
 
 	// bundle deploy
 	CmdBundleDeployShort        = "Deploy a bundle from a local tarball or oci:// URL"
-	CmdBundleDeployFlagConfirm  = "Confirms bundle deployment without prompting. ONLY use with bundles you trust. Skips prompts to review SBOM, configure variables, select optional components and review potential breaking changes."
+	CmdBundleDeployFlagConfirm  = "Confirms bundle deployment without prompting. ONLY use with bundles you trust"
 	CmdBundleDeployFlagPackages = "Specify which zarf packages you would like to deploy from the bundle. By default all zarf packages in the bundle are deployed."
 	CmdBundleDeployFlagResume   = "Only deploys packages from the bundle which haven't already been deployed"
 	CmdBundleDeployFlagSet      = "Specify deployment variables to set on the command line (KEY=value)"

--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -502,8 +502,8 @@ func setTemplatedVariables(templatedVariables string, pkgVars map[string]string)
 	replacedValue := templatedVarRegex.ReplaceAllStringFunc(templatedVariables, func(match string) string {
 		// returns slice with the templated variable and the variable name
 		variableName := templatedVarRegex.FindStringSubmatch(match)[1]
-		// If we have a templated variable, get the value from pkgVars
-		if varValue, ok := pkgVars[variableName]; ok {
+		// If we have a templated variable, get the value from pkgVars (use uppercase for case-insensitive comparison)
+		if varValue, ok := pkgVars[strings.ToUpper(variableName)]; ok {
 			return varValue
 		}
 		return fmt.Sprintf("${%s_not_found}", variableName)

--- a/src/test/bundles/07-helm-overrides/uds-bundle.yaml
+++ b/src/test/bundles/07-helm-overrides/uds-bundle.yaml
@@ -14,7 +14,7 @@ packages:
         unicorn-podinfo:
           values:
             - path: "podinfo.replicaCount"
-              value: ${numReplicas}
+              value: ${numReplicas} # set from uds-config.yaml
             - path: "podinfo.tolerations"
               value:
                 - key: "unicorn"

--- a/src/test/bundles/07-helm-overrides/uds-bundle.yaml
+++ b/src/test/bundles/07-helm-overrides/uds-bundle.yaml
@@ -14,7 +14,7 @@ packages:
         unicorn-podinfo:
           values:
             - path: "podinfo.replicaCount"
-              value: 2
+              value: ${numReplicas}
             - path: "podinfo.tolerations"
               value:
                 - key: "unicorn"

--- a/src/test/bundles/07-helm-overrides/uds-config.yaml
+++ b/src/test/bundles/07-helm-overrides/uds-config.yaml
@@ -3,7 +3,8 @@ options:
 
 variables:
   helm-overrides:
-    # vars can be upper or lowercase
+    # vars are case-insensitive
+    numReplicas: 2
     ui_color: "green, yellow"
     UI_MSG: "Hello Unicorn"
     security_ctx:

--- a/tasks/tests.yaml
+++ b/tasks/tests.yaml
@@ -15,38 +15,38 @@ tasks:
   - name: e2e-no-ghcr-write
     description: run e2e tests without writing to GHCR
     actions:
-      - task: run-bundle-test
-      - task: run-dev-test
-      - task: run-variable-test
-      - task: run-optional-bundle-tests
-      - task: run-vendor-tests
+      - task: bundle
+      - task: dev
+      - task: variable
+      - task: optional-bundle
+      - task: vendor
 
   - name: e2e-ghcr
     description: run e2e tests that write to GHCR
     actions:
       - cmd: cd src/test/e2e && go test -failfast -v -timeout 30m -run ".*GHCR.*"
 
-  - name: run-bundle-test
+  - name: bundle
     description: only run tests in bundle_test.go
     actions:
       - cmd: cd src/test/e2e && go test -failfast -v -timeout 30m bundle_test.go commands_test.go main_test.go
 
-  - name: run-dev-test
+  - name: dev
     description: only run tests in dev.go
     actions:
       - cmd: cd src/test/e2e && go test -failfast -v -timeout 30m dev_test.go commands_test.go main_test.go
 
-  - name: run-variable-test
+  - name: variable
     description: only run tests in variable_test.go
     actions:
       - cmd: cd src/test/e2e && go test -failfast -v -timeout 30m variable_test.go commands_test.go main_test.go
 
-  - name: run-optional-bundle-tests
+  - name: optional-bundle
     description: only run tests in optional_bundle_test.go
     actions:
       - cmd: cd src/test/e2e && go test -failfast -v -timeout 30m optional_bundle_test.go commands_test.go main_test.go
 
-  - name: run-vendor-tests
+  - name: vendor
     description: only run tests in zarf_test.go and runner_test.go
     actions:
       - cmd: cd src/test/e2e && go test -failfast -v -timeout 30m zarf_test.go runner_test.go commands_test.go main_test.go


### PR DESCRIPTION
## Description

- clean up `lang.go`
- adds more docs for `${...}` usage https://github.com/defenseunicorns/uds-cli/issues/670
- make `test` task names shorter
- ensure we are doing PRs for brew releases
