### PR TITLE
chore: ensure nginx shorthand in dev tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Recommended installation method is with Brew:
 ```
 brew tap defenseunicorns/tap && brew install uds
 ```
-UDS CLI Binaries are also included with each [Github Release](https://github.com/defenseunicorns/uds-cli/releases)
+UDS CLI binaries are also included with each [Github Release](https://github.com/defenseunicorns/uds-cli/releases)
 
 ## Official Documentation
 Official documentation is located at [uds.defenseunicorns.com/cli](https://uds.defenseunicorns.com/cli/)

--- a/hack/push-test-artifacts.sh
+++ b/hack/push-test-artifacts.sh
@@ -10,18 +10,18 @@ set -e
 
 # create the nginx and podinfo Zarf packages
 cd ./../src/test/packages/nginx
-zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a amd64
-zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a arm64
+uds zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a amd64
+uds zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a arm64
 cd ./refs
-zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a amd64
-zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a arm64
+uds zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a amd64
+uds zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a arm64
 
 cd ../../podinfo
-zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a amd64
-zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a arm64
+uds zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a amd64
+uds zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a arm64
 cd ./refs
-zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a amd64
-zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a arm64
+uds zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a amd64
+uds zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a arm64
 
 # create ghcr-test bundle
 cd ../../bundles/06-ghcr

--- a/src/test/packages/nginx/refs/zarf.yaml
+++ b/src/test/packages/nginx/refs/zarf.yaml
@@ -14,8 +14,6 @@ components:
           - deployment.yaml
     actions:
       onDeploy:
-      # the following checks were computed by viewing the success state of the package deployment
-      # and creating `wait` actions that match
         after:
           - wait:
               cluster:
@@ -23,7 +21,5 @@ components:
                 name: nginx-deployment
                 namespace: nginx
                 condition: available
-    # image discovery is supported in all manifests and charts using:
-    # zarf prepare find-images
     images:
-      - docker.io/library/nginx:1.26.0
+      - nginx:1.26.0 # use shorthand for nginx!


### PR DESCRIPTION
## Description

- use nginx shorthand in dev deploy tests
- use `uds zarf` for push artifacts script
- (note we ran the push artifacts script to update nginx in the remote repos)

