### PR TITLE
docs: remove out of place quotation

### DIFF
--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -312,7 +312,7 @@ metadata:
 packages:
    - name: helm-overrides-package
      path: "../../packages/helm"
-     ref: 0.0.1"
+     ref: 0.0.1
      overrides:
         podinfo-component:
           unicorn-podinfo:


### PR DESCRIPTION
## Description

Removes and extraneous quotation in the overrides docs. Noticed this because of weird syntax highlighting on https://uds.defenseunicorns.com/cli/overrides/#namespace

## Related Issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
