### PR TITLE
fix(engine): use k8s timestamps instead of pepr timestamps

### DIFF
--- a/src/cmd/monitor/pepr.go
+++ b/src/cmd/monitor/pepr.go
@@ -5,6 +5,7 @@
 package monitor
 
 import (
+	"context"
 	"os"
 	"time"
 
@@ -63,7 +64,7 @@ var peprCmd = &cobra.Command{
 		}
 
 		// Create a new stream for the Pepr logs
-		peprReader := pepr.NewStreamReader(timestamps, namespace, "")
+		peprReader := pepr.NewStreamReader(namespace, "")
 		peprStream := stream.NewStream(os.Stderr, peprReader, "pepr-system")
 
 		// Set the stream flags
@@ -71,9 +72,10 @@ var peprCmd = &cobra.Command{
 		peprReader.FilterStream = streamKind
 		peprStream.Follow = follow
 		peprStream.Since = since
+		peprStream.Timestamps = timestamps
 
 		// Start the stream
-		if err := peprStream.Start(); err != nil {
+		if err := peprStream.Start(context.TODO()); err != nil {
 			message.Fatalf(err, "Error streaming Pepr logs")
 		}
 	},

--- a/src/pkg/engine/pepr/stream.go
+++ b/src/pkg/engine/pepr/stream.go
@@ -142,7 +142,7 @@ func (p *StreamReader) PodFilter(pods []corev1.Pod) map[string]string {
 func (p *StreamReader) LogStream(writer io.Writer, logStream io.ReadCloser, timestamp bool) error {
 	// Use a longer indent when timestamps are enabled
 	if timestamp {
-		p.indent = "                                "
+		p.indent = strings.Repeat(" ", 32)
 	}
 
 	// Process logs line by line.

--- a/src/pkg/engine/pepr/stream_test.go
+++ b/src/pkg/engine/pepr/stream_test.go
@@ -17,14 +17,12 @@ import (
 )
 
 func TestNewStreamReader(t *testing.T) {
-	timestamp := true
 	filterNamespace := "test-namespace"
 	filterName := "test-name"
 
-	reader := NewStreamReader(timestamp, filterNamespace, filterName)
+	reader := NewStreamReader(filterNamespace, filterName)
 
-	require.True(t, reader.showTimestamp)
-	require.Equal(t, "                     ", reader.indent)
+	require.Equal(t, "", reader.indent)
 	require.Equal(t, "test-namespace", reader.filterNamespace)
 	require.Equal(t, "test-name", reader.filterName)
 }
@@ -160,11 +158,11 @@ func TestLogStream(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			reader := NewStreamReader(false, tc.filterNamespace, tc.filterName)
+			reader := NewStreamReader(tc.filterNamespace, tc.filterName)
 			reader.FilterStream = tc.filterStream
 
 			var buf bytes.Buffer
-			err := reader.LogStream(&buf, io.NopCloser(strings.NewReader(tc.logs)))
+			err := reader.LogStream(&buf, io.NopCloser(strings.NewReader(tc.logs)), false)
 			require.NoError(t, err)
 
 			expected := normalizeWhitespace(tc.expected)

--- a/src/pkg/engine/stream/common.go
+++ b/src/pkg/engine/stream/common.go
@@ -23,18 +23,19 @@ type Reader interface {
 	PodFilter(pods []corev1.Pod) map[string]string
 
 	// LogStream processes the log stream from Pepr and writes formatted output to the writer
-	LogStream(writer io.Writer, logStream io.ReadCloser) error
+	LogStream(writer io.Writer, logStream io.ReadCloser, timestamp bool) error
 
 	// LogFlush to flush the log at a given interval and at the end of the stream
 	LogFlush(writer io.Writer)
 }
 
 type Stream struct {
-	writer    io.Writer
-	reader    Reader
-	Follow    bool
-	Namespace string
-	Since     time.Duration
+	writer     io.Writer
+	reader     Reader
+	Follow     bool
+	Timestamps bool
+	Namespace  string
+	Since      time.Duration
 	// Adding for testability :-<
 	Client kubernetes.Interface
 }
@@ -47,8 +48,8 @@ func NewStream(writer io.Writer, reader Reader, namespace string) *Stream {
 	}
 }
 
-// Start starts the stream
-func (s *Stream) Start() error {
+// Start starts the stream with the provided context
+func (s *Stream) Start(ctx context.Context) error {
 	// Create a new client if one is not provided (usually for testing)
 	if s.Client == nil {
 		c, _, err := k8s.NewClient()
@@ -58,6 +59,7 @@ func (s *Stream) Start() error {
 		s.Client = c
 	}
 
+	// List the pods in the specified namespace
 	pods, err := s.Client.CoreV1().Pods(s.Namespace).List(context.TODO(), v1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to get pods: %v", err)
@@ -65,6 +67,7 @@ func (s *Stream) Start() error {
 
 	var wg sync.WaitGroup
 
+	// Filter the pods and containers to stream logs from
 	containers := s.reader.PodFilter(pods.Items)
 
 	// Stream logs for each pod
@@ -77,8 +80,9 @@ func (s *Stream) Start() error {
 
 			// Set up the pod log options
 			podOpts := &corev1.PodLogOptions{
-				Follow:    s.Follow,
-				Container: container,
+				Follow:     s.Follow,
+				Container:  container,
+				Timestamps: s.Timestamps,
 			}
 
 			// Set the sinceSeconds option if provided
@@ -89,14 +93,15 @@ func (s *Stream) Start() error {
 			}
 
 			// Get the log stream for the pod
-			logStream, err := s.Client.CoreV1().Pods(s.Namespace).GetLogs(podName, podOpts).Stream(context.TODO())
+			logStream, err := s.Client.CoreV1().Pods(s.Namespace).GetLogs(podName, podOpts).Stream(ctx)
 			if err != nil {
 				message.WarnErrf(err, "Error streaming logs for pod %s", podName)
 				return
 			}
 			defer logStream.Close()
 
-			if err := s.reader.LogStream(s.writer, logStream); err != nil {
+			// Process the log stream
+			if err := s.reader.LogStream(s.writer, logStream, s.Timestamps); err != nil {
 				message.WarnErrf(err, "Error streaming logs for pod %s", podName)
 			}
 		}(pod, container)
@@ -116,7 +121,10 @@ func (s *Stream) Start() error {
 				// Stop the goroutine when the stopChan is closed
 				case <-stopChan:
 					return
-					// Flush the logs every second
+				// Stop the goroutine when the context is done
+				case <-ctx.Done():
+					return
+				// Flush the logs every second
 				case <-time.After(time.Second):
 					s.reader.LogFlush(s.writer)
 				}

--- a/src/pkg/engine/stream/common_test.go
+++ b/src/pkg/engine/stream/common_test.go
@@ -6,6 +6,7 @@ package stream
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"testing"
@@ -30,7 +31,7 @@ func (m *MockReader) PodFilter(pods []corev1.Pod) map[string]string {
 	return args.Get(0).(map[string]string)
 }
 
-func (m *MockReader) LogStream(writer io.Writer, logStream io.ReadCloser) error {
+func (m *MockReader) LogStream(writer io.Writer, logStream io.ReadCloser, timestamp bool) error {
 	args := m.Called(writer, logStream)
 	return args.Error(0)
 }
@@ -111,7 +112,8 @@ func TestStream_Start(t *testing.T) {
 			stream.Follow = tt.follow
 			stream.Since = tt.since
 
-			err := stream.Start()
+			ctx := context.TODO()
+			err := stream.Start(ctx)
 			if tt.expectError {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
## Description

This PR uses the native K8s timestamp feature (which is the [CRI Log format](https://github.com/kubernetes/design-proposals-archive/blob/main/node/kubelet-cri-logging.md) instead of the timestamp from the pod. This ensure behavior consistent with normal K8s log output, reduces the need to parse each timestamp and eleminates an issue that exists for timestamp parsing currently.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)
