### PR TITLE
chore: various doc linting fixes

### DIFF
--- a/docs/bundle-anatomy.md
+++ b/docs/bundle-anatomy.md
@@ -5,6 +5,7 @@ weight: 6
 ---
 
 ## Bundle Anatomy
+
 A UDS Bundle is an OCI artifact with the following form:
 
-![](https://github.com/defenseunicorns/uds-cli/blob/main/docs/.images/uds-bundle.png?raw=true)
+![Bundle Anatomy](https://github.com/defenseunicorns/uds-cli/blob/main/docs/.images/uds-bundle.png?raw=true)

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -38,6 +38,7 @@ ui:
 ```
 
 The bundle overrides feature allows users to override the values specified in Zarf packages. For example:
+
 ```yaml
 kind: UDSBundle
 metadata:
@@ -111,6 +112,7 @@ packages:
 podAnnotations:
   customAnnotation: "customValue"
 ```
+
 In this example, the `helm-overrides-package` Zarf package has a component called `helm-overrides-component` which contains a Helm chart called `podinfo`; note how these names are keys in the `overrides` block. The `podinfo` chart has a `replicaCount` value that is overridden to `2`, a `podAnnotations` value that is overridden to include `customAnnotation: "customValue"` and a variable called `UI_COLOR` that is overridden to `purple`.
 
 ### Values Files
@@ -128,6 +130,7 @@ The `path` uses dot notation to specify the location of a value to override in t
 #### Value
 
 The `value` is the value to set at the `path`. Values can be simple values such as numbers and strings, as well as, complex lists and objects, for example:
+
 ```yaml
 ...
     overrides:
@@ -148,12 +151,14 @@ The `value` is the value to set at the `path`. Values can be simple values such 
 #### Bundle Variables as Values
 
 Bundle and Zarf variables can be used to set override values by using the syntax `${...}`. For example:
+
 ```yaml
 # uds-config.yaml
 variables:
   helm-overrides-package:
     replica_count: 2
 ```
+
 ```yaml
 kind: UDSBundle
 metadata:
@@ -185,12 +190,15 @@ packages:
 In the example above `${REPLICA_COUNT}` is set in the `uds-config.yaml` file and `${COLOR}` is set as an export from the `output-var` package. Note that you could also set these values with the `shared` key in a `uds-config.yaml`, environment variables prefixed with `UDS_` or with the `--set` flag during deployment.
 
 #### Value Precedence
+
 Value precedence is as follows:
+
 1. The `values` in an `overrides` block
 1. `values` set in the last `valuesFile` (if more than one specified)
 1. `values` set in the previous `valuesFile` (if more than one specified)
 
 ### Variables
+
 Variables are similar to [values](#values) in that they allow users to override values in a Zarf package component's underlying Helm chart; they also share a similar syntax. However, unlike `values`, `variables` can be overridden at deploy time. For example, consider the `variables` key in the following `uds-bundle.yaml`:
 
 ```yaml
@@ -242,13 +250,16 @@ A variable that is not overridden by any of the methods above and has no default
 {{% /alert-note %}}
 
 #### Variable Precedence
+
 Variable precedence is as follows:
+
 1. The `--set` flag
 1. Environment variables
 1. `uds-config.yaml` variables
 1. Variables `default` in the`uds-bundle.yaml`
 
 #### Variable Types
+
 Variables can be of either type `raw` or `file`. The type will default to raw if not set explicitly.
 
 {{% alert-caution %}}  
@@ -284,6 +295,7 @@ packages:
 If a file path is not absolute, it will be set as relative to the `uds-config.yaml` directory.
 
 e.g. the following `uds-config.yaml` is in [`src/test/bundles/07-helm-overrides/variable-files/`](https://github.com/defenseunicorns/uds-cli/blob/main/src/test/bundles/07-helm-overrides/uds-config.yaml)
+
 ```yaml
 variables:
   helm-overrides:
@@ -301,6 +313,7 @@ For example, if the file contains a key to be used in a Kubernetes secret, it mu
 {{% /alert-note %}}
 
 ### Namespace
+
 It's also possible to specify a namespace for a packaged Helm chart to be installed in. For example, to deploy the a chart in the `custom-podinfo` namespace, you can specify the `namespace` in the `overrides` block:
 
 ```yaml

--- a/docs/quickstart-and-usage.md
+++ b/docs/quickstart-and-usage.md
@@ -8,7 +8,7 @@ weight: 1
 
 Recommended installation method is with Brew:
 
-```
+```bash
 brew tap defenseunicorns/tap && brew install uds
 ```
 
@@ -44,11 +44,11 @@ The above `UDSBundle` deploys the Zarf init package and podinfo.
 
 The packages referenced in `packages` can exist either locally or in an OCI registry. See [here](https://github.com/defenseunicorns/uds-cli/tree/main/src/test/bundles/03-local-and-remote) for an example that deploys both local and remote Zarf packages. More `UDSBundle` examples can be found in the [src/test/bundles](https://github.com/defenseunicorns/uds-cli/tree/main/src/test/bundles) folder.
 
-#### Declarative Syntax
+### Declarative Syntax
 
 The syntax of a `uds-bundle.yaml` is entirely declarative. As a result, the UDS CLI will not prompt users to deploy optional components in a Zarf package. If you want to deploy an optional Zarf component, it must be specified in the `optionalComponents` key of a particular `package`.
 
-#### First-class UDS Support
+### First-class UDS Support
 
 When running `deploy`,`inspect`,`remove`, and `pull` commands, UDS CLI contains shorthand for interacting with the Defense Unicorns org on GHCR. Specifically, unless otherwise specified, paths will automatically be expanded to the Defense Unicorns org on GHCR. For example:
 
@@ -176,6 +176,7 @@ e.g.
 `uds deploy -a amd64 <remote-multi-arch-bundle.tar.zst> --confirm`
 
 ## Variables and Configuration
+
 The UDS CLI can be configured with a `uds-config.yaml` file. This file can be placed in the current working directory or specified with an environment variable called `UDS_CONFIG`. The basic structure of the `uds-config.yaml` is as follows:
 
 ```yaml
@@ -206,6 +207,7 @@ variables:
 The `options` key contains UDS CLI options that are not specific to a particular Zarf package. The `variables` key contains variables that are specific to a particular Zarf package. If you want to share insensitive variables across multiple Zarf packages, you can use the `shared` key, where the key is the variable name and the value is the variable value.
 
 ### Sharing Variables
+
 Zarf package variables can be passed between Zarf packages:
 
 ```yaml
@@ -342,43 +344,46 @@ To monitor the status of a UDS cluster's admission and operator controllers, run
 #### UDS Controllers
 
 UDS clusters contain two Kubernetes controllers, both created using [Pepr](https://pepr.dev/):
+
 1. **Admission Controller**: Corresponds to the `pepr-uds-core` pods in the cluster. This controller is responsible for validating and mutating resources in the cluster including the enforcement of [UDS Exemptions](https://uds.defenseunicorns.com/core/configuration/uds-configure-policy-exemptions/).
 
 1. **Operator Controller**: Corresponds to the `pepr-uds-core-watcher` pods. This controller is responsible for managing the lifecyle of [UDS Package](https://uds.defenseunicorns.com/core/configuration/uds-operator/) resources in the cluster.
 
 #### Monitor Args
+
 Aggregate all admission and operator logs into a single stream:  
-```
+
+```bash
 uds monitor pepr
 ```
 
 Stream UDS Operator actions (UDS Package processing, status updates, and errors):  
 
-```
+```bash
 uds monitor pepr operator
 ```
 
 Stream UDS Policy logs (Allow, Deny, Mutate):  
 
-```
+```bash
 uds monitor pepr policies
 ```
 
 Stream UDS Policy allow logs:  
 
-```
+```bash
 uds monitor pepr allowed
 ```
 
 Stream UDS Policy deny logs:  
 
-```
+```bash
 uds monitor pepr denied
 ```
 
 Stream UDS Policy mutation logs:  
 
-```
+```bash
 uds monitor pepr mutated
 ```
 

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -5,24 +5,26 @@ weight: 4
 ---
 UDS CLI contains vendors and configures the [maru-runner](https://github.com/defenseunicorns/maru-runner) build tool to make compiling and building UDS bundles simple.
 
-
 ## Quickstart
 
-#### Running a Task
+### Running a Task
+
 To run a task from a `tasks.yaml`:
-```
+
+```bash
 uds run <task-name>
 ```
 
 #### Running a Task from a specific tasks file
-```
+
+```bash
 uds run -f <path/to/tasks.yaml> <task-name>
 ```
-
 
 The Maru [docs](https://github.com/defenseunicorns/maru-runner) describe how to build `tasks.yaml` files to configure the runner. The functionality in UDS CLI is mostly identical with the following exceptions
 
 ### Variables Set with Environment Variables
+
 When running a `tasks.yaml` with `uds run my-task` you can set variables using environment prefixed with `UDS_`
 
 For example, running `UDS_FOO=bar uds run echo-foo` on the following task will echo `bar`.
@@ -38,7 +40,9 @@ tasks:
 ```
 
 ### Running UDS and Zarf Commands
+
 To run `uds` commands from within a task, you can invoke your system `uds` binary using the `./uds` syntax. Similarly, UDS CLI vendors Zarf, and tasks can run vendored Zarf commands using `./zarf`. For example:
+
 ```yaml
 tasks:
 - name: default
@@ -48,15 +52,19 @@ tasks:
 ```
 
 ### Architecture Environment Variable
+
 When running tasks with `uds run`, there is a special `UDS_ARCH` environment variable accessible within tasks that is automatically set to your system architecture, but is also configurable with a `UDS_ARCHITECTURE` environmental variable. For example:
-```
+
+```yaml
 tasks:
 - name: print-arch
   actions:
     - cmd: echo ${UDS_ARCH}
 ```
+
 - Running `uds run print-arch` will echo your local system architecture
 - Running `UDS_ARCHITECTURE=amd64 uds run print-arch` will echo "amd64"
 
 ### No Dependency on Zarf
+
 Since UDS CLI also vendors [Zarf](https://github.com/defenseunicorns/zarf), there is no need to also have Zarf installed on your system.


### PR DESCRIPTION
## Description
Small changes for meeting npm linting rules in the uds-docs repo. Mostly spacing and naming of code blocks.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed