### PR TITLE
fix: ensure inspected image list is machine readable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ node_modules
 checksums.txt
 *.tape
 tmp/
+out.txt

--- a/src/pkg/bundle/inspect.go
+++ b/src/pkg/bundle/inspect.go
@@ -22,7 +22,6 @@ import (
 	zarfUtils "github.com/defenseunicorns/zarf/src/pkg/utils"
 	"github.com/defenseunicorns/zarf/src/pkg/zoci"
 	zarfTypes "github.com/defenseunicorns/zarf/src/types"
-	"github.com/fatih/color"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pterm/pterm"
 )
@@ -95,12 +94,12 @@ func (b *Bundle) listImages() error {
 		return err
 	}
 
-	formattedImgs := pterm.Color(color.FgHiMagenta).Sprintf(strings.Join(imgs, "\n"))
+	formattedImgs := strings.Join(imgs, "\n")
 
 	// print to stdout to enable users to easily grab the output
 	// (and stderr for backwards compatibility)
 	pterm.SetDefaultOutput(io.MultiWriter(os.Stderr, os.Stdout))
-	pterm.Printfln("\n%s\n", formattedImgs)
+	pterm.Printfln("%s\n", formattedImgs)
 	return nil
 }
 

--- a/src/pkg/bundle/inspect.go
+++ b/src/pkg/bundle/inspect.go
@@ -7,7 +7,6 @@ package bundle
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -97,8 +96,7 @@ func (b *Bundle) listImages() error {
 	formattedImgs := strings.Join(imgs, "\n")
 
 	// print to stdout to enable users to easily grab the output
-	// (and stderr for backwards compatibility)
-	pterm.SetDefaultOutput(io.MultiWriter(os.Stderr, os.Stdout))
+	pterm.SetDefaultOutput(os.Stdout)
 	pterm.Printfln("%s\n", formattedImgs)
 	return nil
 }

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -688,6 +688,8 @@ func TestListImages(t *testing.T) {
 		outfile, err := os.Create(filename)
 		require.NoError(t, err)
 		defer outfile.Close()
+		defer os.Remove(filename)
+
 		cmd.Stdout = outfile
 		cmd.Stderr = outfile
 

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -691,7 +691,6 @@ func TestListImages(t *testing.T) {
 		defer os.Remove(filename)
 
 		cmd.Stdout = outfile
-		cmd.Stderr = outfile
 
 		err = cmd.Run()
 		require.NoError(t, err)

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -661,22 +661,18 @@ func TestListImages(t *testing.T) {
 
 	t.Run("list images on bundle YAML only", func(t *testing.T) {
 		cmd := strings.Split(fmt.Sprintf("inspect %s --list-images --insecure", filepath.Join(bundleDir, config.BundleYAML)), " ")
-		stdout, stderr, err := e2e.UDS(cmd...)
+		stdout, _, err := e2e.UDS(cmd...)
 		require.NoError(t, err)
-		require.Contains(t, stderr, "library/registry")
-		require.Contains(t, stderr, "ghcr.io/defenseunicorns/zarf/agent")
-		require.Contains(t, stderr, "nginx")
-		require.Contains(t, stderr, "quay.io/prometheus/node-exporter")
 		require.Contains(t, stdout, "library/registry")
 		require.Contains(t, stdout, "ghcr.io/defenseunicorns/zarf/agent")
 		require.Contains(t, stdout, "nginx")
 		require.Contains(t, stdout, "quay.io/prometheus/node-exporter")
 
 		// ensure non-req'd components got filtered
-		require.NotContains(t, stderr, "grafana")
-		require.NotContains(t, stderr, "gitea")
-		require.NotContains(t, stderr, "kiwix")
-		require.NotContains(t, stderr, "podinfo")
+		require.NotContains(t, stdout, "grafana")
+		require.NotContains(t, stdout, "gitea")
+		require.NotContains(t, stdout, "kiwix")
+		require.NotContains(t, stdout, "podinfo")
 	})
 
 	t.Run("list images outputted to a file", func(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes https://github.com/defenseunicorns/uds-cli/issues/733

Noting that this is a breaking change as `--list-images` will now only go to stdout
