### PR TITLE
fix: make dev deploy help msg better

### DIFF
--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -23,7 +23,7 @@ var devCmd = &cobra.Command{
 }
 
 var devDeployCmd = &cobra.Command{
-	Use:   "deploy",
+	Use:   "deploy [BUNDLE_DIR|OCI_REF]",
 	Args:  cobra.MaximumNArgs(1),
 	Short: lang.CmdDevDeployShort,
 	Long:  lang.CmdDevDeployLong,

--- a/src/config/lang/lang.go
+++ b/src/config/lang/lang.go
@@ -85,8 +85,8 @@ const (
 
 	// uds dev
 	CmdDevShort                = "[beta] Commands useful for developing bundles"
-	CmdDevDeployShort          = "[beta] Creates and deploys a UDS bundle from a given directory in dev mode"
-	CmdDevDeployLong           = "[beta] Creates and deploys a UDS bundle from a given directory in dev mode, setting package options like YOLO mode for faster iteration."
+	CmdDevDeployShort          = "[beta] Creates and deploys a UDS bundle in dev mode"
+	CmdDevDeployLong           = "[beta] Creates and deploys a UDS bundle from a given directory or OCI repository in dev mode, setting package options like YOLO mode for faster iteration."
 	CmdBundleCreateForceCreate = "For local bundles with local packages, specify whether to create a zarf package even if it already exists."
 
 	// uds monitor


### PR DESCRIPTION
## Description

Makes `dev deploy` help messages more accurate

## Related Issue

Fixes https://github.com/defenseunicorns/uds-cli/issues/755

