### PR TITLE
feat: exclude optional packages during dev deploy and create

### DIFF
--- a/hack/push-test-artifacts.sh
+++ b/hack/push-test-artifacts.sh
@@ -19,12 +19,13 @@ uds zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a ar
 cd ../../podinfo
 uds zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a amd64
 uds zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a arm64
+
 cd ./refs
 uds zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a amd64
 uds zarf package create -o oci://ghcr.io/defenseunicorns/uds-cli --confirm -a arm64
 
 # create ghcr-test bundle
-cd ../../bundles/06-ghcr
+cd ../../../bundles/06-ghcr
 uds create . -o ghcr.io/defenseunicorns/packages/uds-cli/test/create-remote --confirm -a amd64
 uds create . -o ghcr.io/defenseunicorns/packages/uds-cli/test/create-remote --confirm -a arm64
 

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -70,6 +70,9 @@ var devDeployCmd = &cobra.Command{
 			bundleCfg.DeployOpts.Config = config
 		}
 
+		// pass dev deploy exclude option to create option because components are excluded during create
+		bundleCfg.CreateOpts.ExcludeComponents = bundleCfg.DevDeployOpts.ExcludeComponents
+
 		bndlClient := bundle.NewOrDie(&bundleCfg)
 		defer bndlClient.ClearPaths()
 

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -40,8 +40,8 @@ var devDeployCmd = &cobra.Command{
 		// Check if source is a local bundle
 		isLocalBundle := isLocalBundle(src)
 
-		// Validate flags
-		err := validateDevDeployFlags(isLocalBundle)
+		// Validate flags related to creating Zarf pkgs during dev deploy
+		err := validatePkgCreateFlags(isLocalBundle)
 		if err != nil {
 			message.Fatalf(err, "Failed to validate flags: %s", err.Error())
 		}
@@ -96,12 +96,12 @@ func isLocalBundle(src string) bool {
 	return helpers.IsDir(src) || strings.Contains(src, ".tar.zst")
 }
 
-// validateDevDeployFlags validates the flags for dev deploy
-func validateDevDeployFlags(isLocalBundle bool) error {
+// validatePkgCreateFlags validates the flags for dev deploy
+func validatePkgCreateFlags(isLocalBundle bool) error {
 	if !isLocalBundle {
 		//Throw error if trying to run with --flavor or --force-create flag with remote bundle
 		if len(bundleCfg.DevDeployOpts.Flavor) > 0 || bundleCfg.DevDeployOpts.ForceCreate {
-			return fmt.Errorf("Cannot use --flavor or --force-create flags with remote bundle")
+			return fmt.Errorf("cannot use --flavor or --force-create flags with remote bundle")
 		}
 	}
 	return nil
@@ -119,7 +119,7 @@ func populateFlavorMap() error {
 				if len(entrySplit) == 1 && i == 0 {
 					bundleCfg.DevDeployOpts.Flavor = map[string]string{"": bundleCfg.DevDeployOpts.FlavorInput}
 				} else {
-					return fmt.Errorf("Invalid flavor entry: %s", entry)
+					return fmt.Errorf("invalid flavor entry: %s", entry)
 				}
 			} else {
 				bundleCfg.DevDeployOpts.Flavor[entrySplit[0]] = entrySplit[1]
@@ -137,5 +137,6 @@ func init() {
 	devDeployCmd.Flags().StringToStringVarP(&bundleCfg.DevDeployOpts.Ref, "ref", "r", map[string]string{}, lang.CmdBundleDeployFlagRef)
 	devDeployCmd.Flags().StringVarP(&bundleCfg.DevDeployOpts.FlavorInput, "flavor", "f", "", lang.CmdBundleCreateFlagFlavor)
 	devDeployCmd.Flags().BoolVar(&bundleCfg.DevDeployOpts.ForceCreate, "force-create", false, lang.CmdBundleCreateForceCreate)
-	devDeployCmd.Flags().StringToStringVar(&bundleCfg.DeployOpts.SetVariables, "set", nil, lang.CmdBundleDeployFlagSet)
+	devDeployCmd.Flags().StringToStringVar(&bundleCfg.DeployOpts.SetVariables, "set", map[string]string{}, lang.CmdBundleDeployFlagSet)
+	devDeployCmd.Flags().StringSliceVarP(&bundleCfg.DevDeployOpts.ExcludeComponents, "exclude-components", "e", []string{}, lang.CmdBundleFlagExcludeComponents)
 }

--- a/src/cmd/dev_test.go
+++ b/src/cmd/dev_test.go
@@ -56,7 +56,7 @@ func TestValidateDevDeployFlags(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			bundleCfg.DevDeployOpts = tc.DevDeployOpts
 
-			err := validateDevDeployFlags(tc.localBundle)
+			err := validatePkgCreateFlags(tc.localBundle)
 			if tc.expectError {
 				require.Error(t, err)
 			} else {

--- a/src/cmd/uds.go
+++ b/src/cmd/uds.go
@@ -189,6 +189,7 @@ func init() {
 	createCmd.Flags().StringVarP(&bundleCfg.CreateOpts.Output, "output", "o", v.GetString(V_BNDL_CREATE_OUTPUT), lang.CmdBundleCreateFlagOutput)
 	createCmd.Flags().StringVarP(&bundleCfg.CreateOpts.SigningKeyPath, "signing-key", "k", v.GetString(V_BNDL_CREATE_SIGNING_KEY), lang.CmdBundleCreateFlagSigningKey)
 	createCmd.Flags().StringVarP(&bundleCfg.CreateOpts.SigningKeyPassword, "signing-key-password", "p", v.GetString(V_BNDL_CREATE_SIGNING_KEY_PASSWORD), lang.CmdBundleCreateFlagSigningKeyPassword)
+	//createCmd.Flags().StringVarP(&bundleCfg.CreateOpts.ExcludeComponents, "exclude-components", "e", "", lang.CmdBundleFlagExcludeComponents)
 
 	// deploy cmd flags
 	rootCmd.AddCommand(deployCmd)

--- a/src/cmd/uds.go
+++ b/src/cmd/uds.go
@@ -189,7 +189,7 @@ func init() {
 	createCmd.Flags().StringVarP(&bundleCfg.CreateOpts.Output, "output", "o", v.GetString(V_BNDL_CREATE_OUTPUT), lang.CmdBundleCreateFlagOutput)
 	createCmd.Flags().StringVarP(&bundleCfg.CreateOpts.SigningKeyPath, "signing-key", "k", v.GetString(V_BNDL_CREATE_SIGNING_KEY), lang.CmdBundleCreateFlagSigningKey)
 	createCmd.Flags().StringVarP(&bundleCfg.CreateOpts.SigningKeyPassword, "signing-key-password", "p", v.GetString(V_BNDL_CREATE_SIGNING_KEY_PASSWORD), lang.CmdBundleCreateFlagSigningKeyPassword)
-	//createCmd.Flags().StringVarP(&bundleCfg.CreateOpts.ExcludeComponents, "exclude-components", "e", "", lang.CmdBundleFlagExcludeComponents)
+	createCmd.Flags().StringSliceVarP(&bundleCfg.CreateOpts.ExcludeComponents, "exclude-components", "e", []string{}, lang.CmdBundleFlagExcludeComponents)
 
 	// deploy cmd flags
 	rootCmd.AddCommand(deployCmd)

--- a/src/config/lang/lang.go
+++ b/src/config/lang/lang.go
@@ -20,7 +20,8 @@ const (
 	CmdBundleLogsShort = "View most recent UDS CLI logs"
 
 	// bundle
-	CmdBundleFlagConcurrency = "Number of concurrent layer operations to perform when interacting with a remote bundle."
+	CmdBundleFlagConcurrency       = "Number of concurrent layer operations to perform when interacting with a remote bundle."
+	CmdBundleFlagExcludeComponents = "Optional components to exclude <pkg.component>"
 
 	// bundle create
 	CmdBundleCreateShort                  = "Create a bundle from a given directory or the current directory"

--- a/src/pkg/bundle/create.go
+++ b/src/pkg/bundle/create.go
@@ -7,8 +7,11 @@ package bundle
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/defenseunicorns/uds-cli/src/config"
 	"github.com/defenseunicorns/uds-cli/src/pkg/bundler"
 	"github.com/defenseunicorns/uds-cli/src/pkg/utils"
@@ -28,6 +31,11 @@ func (b *Bundle) Create() error {
 		return err
 	}
 
+	// remove excluded optional components
+	if err := b.excludeComponents(b.cfg.CreateOpts.ExcludeComponents); err != nil {
+		return err
+	}
+
 	// Populate values from valuesFiles if provided
 	if err := b.processValuesFiles(); err != nil {
 		return err
@@ -38,8 +46,8 @@ func (b *Bundle) Create() error {
 		return fmt.Errorf("bundle creation cancelled")
 	}
 
-	// make the bundle's build information
-	if err := b.CalculateBuildInfo(); err != nil {
+	// create the bundle's build information
+	if err := b.CreateBuildInfo(); err != nil {
 		return err
 	}
 
@@ -182,4 +190,32 @@ func mergeBundleChartValues(bundleChartValueLists ...[]types.BundleChartValue) [
 	}
 
 	return merged
+}
+
+// excludeComponents removes excluded components from the bundle
+func (b *Bundle) excludeComponents(excludedComponents []string) error {
+	for _, exclude := range excludedComponents {
+		// process exclude strings in the format <pkg>.<component>
+		parts := strings.Split(exclude, ".")
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid exclude component: %s, must be of the format <pkg>.<component>", exclude)
+		}
+		excludedCompPkgName := parts[0]
+		excludedCompName := parts[1]
+		pkgExists := false // check if the excluded component's pkg actually exists in the bundle
+		for i, pkg := range b.bundle.Packages {
+			if excludedCompPkgName == pkg.Name {
+				pkgExists = true
+				if !slices.Contains(pkg.OptionalComponents, excludedCompName) {
+					return fmt.Errorf("component %s is not an optional component of package %s", excludedCompName, pkg)
+				}
+				// remove the excluded component from the package's OptionalComponents
+				b.bundle.Packages[i].OptionalComponents = helpers.RemoveMatches(b.bundle.Packages[i].OptionalComponents, func(s string) bool { return s == excludedCompName })
+			}
+		}
+		if !pkgExists {
+			return fmt.Errorf("package %s does not exist in bundle", excludedCompPkgName)
+		}
+	}
+	return nil
 }

--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -206,6 +206,7 @@ func (b *Bundle) PreDeployValidation() (string, string, string, error) {
 	}
 
 	bundleName := b.bundle.Metadata.Name
+
 	return bundleName, string(bundleYAML), source, err
 }
 
@@ -232,6 +233,7 @@ func (b *Bundle) ConfirmBundleDeploy() (confirm bool) {
 
 	for _, pkg := range pkgviews {
 		utils.ColorPrintYAML(pkg.meta, nil, false)
+		utils.ColorPrintYAML(map[string][]string{"optionalComponents": pkg.optionalComponents}, nil, false)
 		utils.ColorPrintYAML(pkg.overrides, nil, false)
 	}
 
@@ -253,8 +255,9 @@ func (b *Bundle) ConfirmBundleDeploy() (confirm bool) {
 }
 
 type PkgView struct {
-	meta      map[string]string
-	overrides map[string]interface{}
+	meta               map[string]string
+	overrides          map[string]interface{}
+	optionalComponents []string
 }
 
 // formPkgViews creates a unique pre deploy view of each package's set overrides and Zarf variables
@@ -287,7 +290,11 @@ func formPkgViews(b *Bundle) []PkgView {
 		}
 
 		variables = addZarfVars(variableData, variables)
-		pkgViews = append(pkgViews, PkgView{meta: formPkgMeta(pkg), overrides: map[string]interface{}{"overrides": variables}})
+		pkgViews = append(pkgViews, PkgView{
+			meta:               formPkgMeta(pkg),
+			overrides:          map[string]interface{}{"overrides": variables},
+			optionalComponents: pkg.OptionalComponents,
+		})
 	}
 	return pkgViews
 }

--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -44,7 +44,6 @@ func (b *Bundle) Deploy() error {
 
 	// Check if --packages flag is set and zarf packages have been specified
 	// todo: do we test if the packages specified by --packages are valid?
-	var packagesToDeploy []types.Package
 	if len(b.cfg.DeployOpts.Packages) != 0 {
 		userSpecifiedPackages := strings.Split(strings.ReplaceAll(b.cfg.DeployOpts.Packages[0], " ", ""), ",")
 		selectedPackages := []types.Package{}

--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -43,6 +43,8 @@ func (b *Bundle) Deploy() error {
 	packagesToDeploy := b.bundle.Packages
 
 	// Check if --packages flag is set and zarf packages have been specified
+	// todo: do we test if the packages specified by --packages are valid?
+	var packagesToDeploy []types.Package
 	if len(b.cfg.DeployOpts.Packages) != 0 {
 		userSpecifiedPackages := strings.Split(strings.ReplaceAll(b.cfg.DeployOpts.Packages[0], " ", ""), ",")
 		selectedPackages := []types.Package{}

--- a/src/pkg/bundle/deploy_test.go
+++ b/src/pkg/bundle/deploy_test.go
@@ -606,9 +606,10 @@ func TestFileVariableHandlers(t *testing.T) {
 
 func TestFormPkgViews(t *testing.T) {
 	const (
-		componentName = "test-component"
-		chartName     = "test-chart"
-		pkgName       = "test-package"
+		componentName     = "test-component"
+		chartName         = "test-chart"
+		pkgName           = "test-package"
+		optionalComponent = "test-optional-component"
 	)
 
 	type TestCase struct {
@@ -625,9 +626,15 @@ func TestFormPkgViews(t *testing.T) {
 
 	setUpPkg := func(overVar types.BundleChartVariable) types.Package {
 		return types.Package{Name: pkgName,
-			Overrides: map[string]map[string]types.BundleChartOverrides{componentName: {chartName: {Variables: []types.BundleChartVariable{
-				overVar,
-			}}}}}
+			OptionalComponents: []string{optionalComponent},
+			Overrides: map[string]map[string]types.BundleChartOverrides{
+				componentName: {
+					chartName: {
+						Variables: []types.BundleChartVariable{overVar},
+					},
+				},
+			},
+		}
 	}
 
 	testCases := []TestCase{
@@ -765,6 +772,7 @@ func TestFormPkgViews(t *testing.T) {
 			v := pkgViews[0].overrides["overrides"].([]interface{})[tc.expectedIndex].(map[string]map[string]interface{})[tc.expectedChart]["variables"]
 			fmt.Println(v)
 			require.Contains(t, v.(map[string]interface{})[tc.expectedKey], tc.expectedVal)
+			require.Contains(t, pkgViews[0].optionalComponents[0], optionalComponent)
 		})
 	}
 

--- a/src/pkg/bundle/deploy_test.go
+++ b/src/pkg/bundle/deploy_test.go
@@ -772,7 +772,11 @@ func TestFormPkgViews(t *testing.T) {
 			v := pkgViews[0].overrides["overrides"].([]interface{})[tc.expectedIndex].(map[string]map[string]interface{})[tc.expectedChart]["variables"]
 			fmt.Println(v)
 			require.Contains(t, v.(map[string]interface{})[tc.expectedKey], tc.expectedVal)
-			require.Contains(t, pkgViews[0].optionalComponents[0], optionalComponent)
+
+			// ensure that optionalComponents are part of the view when included in a bundle's pkg
+			if len(pkgViews[0].optionalComponents) > 0 {
+				require.Contains(t, pkgViews[0].optionalComponents[0], optionalComponent)
+			}
 		})
 	}
 

--- a/src/pkg/bundle/dev_test.go
+++ b/src/pkg/bundle/dev_test.go
@@ -1,0 +1,1 @@
+package bundle

--- a/src/pkg/bundle/dev_test.go
+++ b/src/pkg/bundle/dev_test.go
@@ -102,7 +102,7 @@ func Test_handleExcludedComponents(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.b.handleExcludedComponents(tt.excludeComponents)
+			err := tt.b.excludeComponents(tt.excludeComponents)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/src/pkg/bundle/dev_test.go
+++ b/src/pkg/bundle/dev_test.go
@@ -1,1 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The UDS Authors
+
+// Package bundle contains functions for interacting with, managing and deploying UDS packages
 package bundle
+
+import (
+	"testing"
+
+	"github.com/defenseunicorns/uds-cli/src/types"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_handleExcludedComponents(t *testing.T) {
+	tests := []struct {
+		name              string
+		b                 Bundle
+		excludeComponents []string
+		expected          []types.Package
+		wantErr           bool
+	}{
+		{
+			name:              "exclude components using duplicated pkg names",
+			excludeComponents: []string{"pkg1.foo", "pkg1.bar"},
+			b: Bundle{
+				bundle: types.UDSBundle{
+					Packages: []types.Package{
+						{Name: "pkg1", OptionalComponents: []string{"foo", "bar", "baz"}},
+					},
+				},
+			},
+			expected: []types.Package{
+				{Name: "pkg1", OptionalComponents: []string{"baz"}},
+			},
+		},
+		{
+			name:              "exclude all optional components from pkg",
+			excludeComponents: []string{"pkg1.foo", "pkg1.bar"},
+			b: Bundle{
+				bundle: types.UDSBundle{
+					Packages: []types.Package{
+						{Name: "pkg1", OptionalComponents: []string{"foo", "bar"}},
+					},
+				},
+			},
+			expected: []types.Package{
+				{Name: "pkg1", OptionalComponents: nil},
+			},
+		},
+		{
+			name:              "exclude components from multiple pkgs",
+			excludeComponents: []string{"pkg1.foo", "pkg1.bar", "pkg2.foo", "pkg2.baz"},
+			b: Bundle{
+				bundle: types.UDSBundle{
+					Packages: []types.Package{
+						{Name: "pkg1", OptionalComponents: []string{"foo", "bar", "baz"}},
+						{Name: "pkg2", OptionalComponents: []string{"foo", "bar", "baz"}},
+					},
+				},
+			},
+			expected: []types.Package{
+				{Name: "pkg1", OptionalComponents: []string{"baz"}},
+				{Name: "pkg2", OptionalComponents: []string{"bar"}},
+			},
+		},
+		{
+			name:              "err for invalid exclude syntax",
+			excludeComponents: []string{"pkg1=foo", "pkg1.bar"},
+			b: Bundle{
+				bundle: types.UDSBundle{
+					Packages: []types.Package{
+						{Name: "pkg1", OptionalComponents: []string{"foo", "bar", "baz"}},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:              "err when pkg doesn't exist in bundle",
+			excludeComponents: []string{"pkg1.foo", "pkg2.bar"},
+			b: Bundle{
+				bundle: types.UDSBundle{
+					Packages: []types.Package{
+						{Name: "pkg1", OptionalComponents: []string{"foo"}},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:              "err when component doesn't exist in pkg",
+			excludeComponents: []string{"pkg1.foo", "pkg1.bar"},
+			b: Bundle{
+				bundle: types.UDSBundle{
+					Packages: []types.Package{
+						{Name: "pkg1", OptionalComponents: []string{"foo"}},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.b.handleExcludedComponents(tt.excludeComponents)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, tt.b.bundle.Packages)
+		})
+	}
+}

--- a/src/test/bundles/14-optional-components/uds-bundle.yaml
+++ b/src/test/bundles/14-optional-components/uds-bundle.yaml
@@ -22,4 +22,4 @@ packages:
     path: ../../packages/podinfo-nginx
     ref: 0.0.1
     optionalComponents:
-      - nginx-remote
+      - nginx

--- a/src/test/bundles/15-dev-deploy/optional/uds-bundle.yaml
+++ b/src/test/bundles/15-dev-deploy/optional/uds-bundle.yaml
@@ -1,0 +1,15 @@
+# uds dev deploy . --exclude-component podinfo-nginx.metrics-server
+
+kind: UDSBundle
+metadata:
+  name: dev-deploy-components
+  description: bundle for testing including and excluding components
+  version: 0.0.1
+
+packages:
+  - name: podinfo-nginx
+    path: "../../../packages/podinfo-nginx"
+    ref: 0.0.1
+    optionalComponents:
+      - podinfo
+      - nginx

--- a/src/test/bundles/15-dev-deploy/optional/uds-bundle.yaml
+++ b/src/test/bundles/15-dev-deploy/optional/uds-bundle.yaml
@@ -1,9 +1,7 @@
-# uds dev deploy . --exclude-component podinfo-nginx.metrics-server
-
 kind: UDSBundle
 metadata:
-  name: dev-deploy-components
-  description: bundle for testing including and excluding components
+  name: dev-deploy-exclude
+  description: bundle to test excluding components
   version: 0.0.1
 
 packages:

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -738,3 +738,17 @@ func TestListVariables(t *testing.T) {
 		require.Contains(t, cleaned, "prometheus:\n  variables: []\n")
 	})
 }
+
+func TestExcludeComponentOnCreate(t *testing.T) {
+	bundleDir := "src/test/bundles/15-dev-deploy/optional"
+	bundleName := "dev-deploy-exclude"
+	bundleTarballPath := filepath.Join(bundleDir, fmt.Sprintf("uds-bundle-%s-%s-0.0.1.tar.zst", bundleName, e2e.Arch))
+	// exclude nginx from podinfo-nginx pkg
+	runUDSCmd(t, "create "+bundleDir+" --exclude-components=podinfo-nginx.nginx --confirm")
+
+	// inspect created bundle and ensure nginx isn't included
+	// todo: refactor when we move 'inspect' to stdout and add --no-color flag
+	_, stderr := runUDSCmd(t, "inspect "+bundleTarballPath)
+	require.Contains(t, stderr, "-\x1b[95m podinfo\x1b[0m")
+	require.NotContains(t, stderr, "-\x1b[95m nginx\x1b[0m")
+}

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -586,11 +586,11 @@ func TestBundleTmpDir(t *testing.T) {
 	}()
 
 	// run create command with tmpDir
-	runCmd(t, "create "+bundleDir+" --tmpdir "+tmpDir+" --confirm --insecure")
+	runUDSCmd(t, "create "+bundleDir+" --tmpdir "+tmpDir+" --confirm --insecure")
 	// run deploy command with tmpDir
-	runCmd(t, "deploy "+bundlePath+" --tmpdir "+tmpDir+" --confirm --insecure")
+	runUDSCmd(t, "deploy "+bundlePath+" --tmpdir "+tmpDir+" --confirm --insecure")
 	// run remove command with tmpDir
-	runCmd(t, "remove "+bundlePath+" --tmpdir "+tmpDir+" --confirm --insecure")
+	runUDSCmd(t, "remove "+bundlePath+" --tmpdir "+tmpDir+" --confirm --insecure")
 
 	// handle errors and failures
 	select {

--- a/src/test/e2e/commands_test.go
+++ b/src/test/e2e/commands_test.go
@@ -132,7 +132,7 @@ func devDeployPackages(t *testing.T, tarballPath string, packages string) (stdou
 	return stdout, stderr
 }
 
-func runCmd(t *testing.T, input string) (stdout string, stderr string) {
+func runUDSCmd(t *testing.T, input string) (stdout string, stderr string) {
 	cmd := strings.Split(input, " ")
 	stdout, stderr, err := e2e.UDS(cmd...)
 	require.NoError(t, err)

--- a/src/test/e2e/variable_test.go
+++ b/src/test/e2e/variable_test.go
@@ -56,19 +56,19 @@ func bundleVariablesTestChecks(t *testing.T, stderr string, bundleTarballPath st
 	require.Contains(t, stderr, "shared var in output-var pkg: burning.boats")
 	require.Contains(t, stderr, "shared var in receive-var pkg: burning.boats")
 
-	_, stderr = runCmd(t, "deploy "+bundleTarballPath+" --set ANIMAL=Longhorns --set COUNTRY=Texas --confirm -l=debug")
+	_, stderr = runUDSCmd(t, "deploy "+bundleTarballPath+" --set ANIMAL=Longhorns --set COUNTRY=Texas --confirm -l=debug")
 	require.Contains(t, stderr, "This fun-fact was imported: Longhorns are the national animal of Texas")
 	require.NotContains(t, stderr, "This fun-fact was imported: Unicorns are the national animal of Scotland")
 
-	_, stderr = runCmd(t, "deploy "+bundleTarballPath+" --set output-var.SPECIFIC_PKG_VAR=output-var-set --confirm -l=debug")
+	_, stderr = runUDSCmd(t, "deploy "+bundleTarballPath+" --set output-var.SPECIFIC_PKG_VAR=output-var-set --confirm -l=debug")
 	require.Contains(t, stderr, "output-var SPECIFIC_PKG_VAR = output-var-set")
 	require.Contains(t, stderr, "receive-var SPECIFIC_PKG_VAR = not-set")
 
-	_, stderr = runCmd(t, "deploy "+bundleTarballPath+" --set output-var.specific_pkg_var=output --set receive-var.SPECIFIC_PKG_VAR=receive --confirm -l=debug")
+	_, stderr = runUDSCmd(t, "deploy "+bundleTarballPath+" --set output-var.specific_pkg_var=output --set receive-var.SPECIFIC_PKG_VAR=receive --confirm -l=debug")
 	require.Contains(t, stderr, "output-var SPECIFIC_PKG_VAR = output")
 	require.Contains(t, stderr, "receive-var SPECIFIC_PKG_VAR = receive")
 
-	_, stderr = runCmd(t, "deploy "+bundleTarballPath+" --set SPECIFIC_PKG_VAR=errbody --confirm -l=debug")
+	_, stderr = runUDSCmd(t, "deploy "+bundleTarballPath+" --set SPECIFIC_PKG_VAR=errbody --confirm -l=debug")
 	require.Contains(t, stderr, "output-var SPECIFIC_PKG_VAR = errbody")
 	require.Contains(t, stderr, "receive-var SPECIFIC_PKG_VAR = errbody")
 }

--- a/src/test/packages/gitrepo/zarf.yaml
+++ b/src/test/packages/gitrepo/zarf.yaml
@@ -8,7 +8,7 @@ components:
     required: true
     repos:
       - https://github.com/defenseunicorns/uds-package-dubbd
-  - name: nginx-remote
+  - name: nginx
     required: true
     manifests:
       - name: simple-nginx-deployment

--- a/src/test/packages/nginx/refs/zarf.yaml
+++ b/src/test/packages/nginx/refs/zarf.yaml
@@ -5,7 +5,7 @@ metadata:
   description: nginx deployment using image docker.io/library/nginx:1.26.0 for testing dev deploy --refs flag
 
 components:
-  - name: nginx-remote
+  - name: nginx
     required: true
     manifests:
       - name: simple-nginx-deployment

--- a/src/test/packages/nginx/zarf.yaml
+++ b/src/test/packages/nginx/zarf.yaml
@@ -4,7 +4,7 @@ metadata:
   version: 0.0.1
 
 components:
-  - name: nginx-remote
+  - name: nginx
     required: true
     manifests:
       - name: simple-nginx-deployment

--- a/src/test/packages/podinfo-nginx/zarf.yaml
+++ b/src/test/packages/podinfo-nginx/zarf.yaml
@@ -9,7 +9,7 @@ components:
     import:
       path: ../podinfo
 
-  - name: nginx-remote
+  - name: nginx
     import:
       path: ../nginx
 

--- a/src/types/options.go
+++ b/src/types/options.go
@@ -22,6 +22,7 @@ type BundleCreateOptions struct {
 	SigningKeyPath     string
 	SigningKeyPassword string
 	BundleFile         string
+	ExcludeComponents  string
 }
 
 // BundleDeployOptions is the options for the bundler.Deploy() function
@@ -79,10 +80,11 @@ type BundleCommonOptions struct {
 
 // BundleDevDeployOptions are the options for when doing a dev deploy
 type BundleDevDeployOptions struct {
-	FlavorInput string
-	Flavor      map[string]string
-	ForceCreate bool
-	Ref         map[string]string
+	FlavorInput       string
+	Flavor            map[string]string
+	ForceCreate       bool
+	Ref               map[string]string
+	ExcludeComponents []string
 }
 
 // PathMap is a map of either absolute paths to relative paths or relative paths to absolute paths

--- a/src/types/options.go
+++ b/src/types/options.go
@@ -22,7 +22,7 @@ type BundleCreateOptions struct {
 	SigningKeyPath     string
 	SigningKeyPassword string
 	BundleFile         string
-	ExcludeComponents  string
+	ExcludeComponents  []string
 }
 
 // BundleDeployOptions is the options for the bundler.Deploy() function


### PR DESCRIPTION
## Description

- Adds `--exclude-components` or `-e` to `dev deploy` and `create`
- Adds `optionalComponents` to pre-deploy view

TODO:
- docs

## Related Issue

Fixes https://github.com/defenseunicorns/uds-cli/issues/757


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)


