### PR TITLE
chore: add additional debug info on OCI source validation

### DIFF
--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -249,6 +249,9 @@ func (b *Bundle) CalculateBuildInfo() error {
 // ValidateBundleSignature validates the bundle signature
 func ValidateBundleSignature(bundleYAMLPath, signaturePath, publicKeyPath string) error {
 	if helpers.InvalidPath(bundleYAMLPath) {
+		if bundleYAMLPath == "" {
+			return fmt.Errorf("path for %s is empty", config.BundleYAML)
+		}
 		return fmt.Errorf("path for %s at %s does not exist", config.BundleYAML, bundleYAMLPath)
 	}
 	// The package is not signed, and no public key was provided

--- a/src/pkg/bundle/remote.go
+++ b/src/pkg/bundle/remote.go
@@ -252,6 +252,9 @@ func getOCIValidatedSource(source string) (string, error) {
 	if err == nil {
 		source = sourceWithOCI
 		_, err = remote.ResolveRoot(ctx)
+		if err != nil {
+			message.Debugf(err.Error())
+		}
 	}
 	// if root didn't resolve, expand the path
 	if err != nil {
@@ -262,7 +265,7 @@ func getOCIValidatedSource(source string) (string, error) {
 			_, err = remote.ResolveRoot(ctx)
 		}
 		if err != nil {
-			message.Debugf("%s: not found", source)
+			message.Debugf(err.Error())
 			// Check in delivery bundle path
 			source = GHCRDeliveryBundlePath + originalSource
 			remote, err = zoci.NewRemote(source, platform)
@@ -270,7 +273,7 @@ func getOCIValidatedSource(source string) (string, error) {
 				_, err = remote.ResolveRoot(ctx)
 			}
 			if err != nil {
-				message.Debugf("%s: not found", source)
+				message.Debugf(err.Error())
 				// Check in packages bundle path
 				source = GHCRPackagesPath + originalSource
 				remote, err = zoci.NewRemote(source, platform)
@@ -278,8 +281,8 @@ func getOCIValidatedSource(source string) (string, error) {
 					_, err = remote.ResolveRoot(ctx)
 				}
 				if err != nil {
-					errMsg := fmt.Sprintf("%s: not found", originalSource)
-					message.Debug(errMsg)
+					errMsg := fmt.Sprintf("%s: not found.", originalSource)
+					message.Debugf(err.Error())
 					return "", errors.New(errMsg)
 				}
 			}

--- a/src/pkg/bundle/remote.go
+++ b/src/pkg/bundle/remote.go
@@ -7,7 +7,6 @@ package bundle
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -249,10 +248,12 @@ func getOCIValidatedSource(source string) (string, error) {
 	// Check provided repository path
 	sourceWithOCI := boci.EnsureOCIPrefix(source)
 	remote, err := zoci.NewRemote(sourceWithOCI, platform)
+	var originalErr error
 	if err == nil {
 		source = sourceWithOCI
 		_, err = remote.ResolveRoot(ctx)
 		if err != nil {
+			originalErr = err
 			message.Debugf(err.Error())
 		}
 	}
@@ -281,9 +282,8 @@ func getOCIValidatedSource(source string) (string, error) {
 					_, err = remote.ResolveRoot(ctx)
 				}
 				if err != nil {
-					errMsg := fmt.Sprintf("%s: not found.", originalSource)
 					message.Debugf(err.Error())
-					return "", errors.New(errMsg)
+					return "", originalErr
 				}
 			}
 		}


### PR DESCRIPTION
## Description

Adds additional debug messaging when validating OCI sources and attempting to resolve the root descriptor from a remote repository. 

Debug messaging now provides the resolution sequence for the remote paths that are attempted:
- provided source
- ghcr.io/defenseunicorns/packages/uds/bundles/
- ghcr.io/defenseunicorns/packages/delivery/
- ghcr.io/defenseunicorns/packages/

## Related Issue

Fixes #705 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
