### PR TITLE
fix: nightly release workflow

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -10,7 +10,6 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    needs: checkout
     steps:
       - name: Run tests
         uses: ./.github/workflows/release-tests.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,6 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/release-tests.yaml
-    needs: checkout
 
   push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

remove `needs` from first block of release workflows
