### PR TITLE
fix: split override envs properly

### DIFF
--- a/src/pkg/bundle/overrides.go
+++ b/src/pkg/bundle/overrides.go
@@ -68,7 +68,7 @@ func (b *Bundle) loadVariables(pkg types.Package, bundleExportedVars map[string]
 	// env vars (vars that start with UDS_)
 	for _, envVar := range os.Environ() {
 		if strings.HasPrefix(envVar, config.EnvVarPrefix) {
-			parts := strings.Split(envVar, "=")
+			parts := strings.SplitN(envVar, "=", 2)
 			pkgVars[strings.ToUpper(strings.TrimPrefix(parts[0], config.EnvVarPrefix))] = parts[1]
 			overVarsData[strings.ToUpper(strings.TrimPrefix(parts[0], config.EnvVarPrefix))] = overrideData{parts[1], valuesources.Env}
 		}

--- a/src/test/e2e/variable_test.go
+++ b/src/test/e2e/variable_test.go
@@ -267,7 +267,7 @@ func TestBundleWithEnvVarHelmOverrides(t *testing.T) {
 	e2e.HelmDepUpdate(t, "src/test/packages/helm/unicorn-podinfo")
 	e2e.CreateZarfPkg(t, "src/test/packages/helm", false)
 	color := "purple"
-	b64Secret := "dGhhdCBhaW50IG15IHRydWNr"
+	b64Secret := "dGhhdCBhaW50IG15IHRydWNrCg=="
 	err := os.Setenv("UDS_CONFIG", filepath.Join("src/test/bundles/07-helm-overrides", "uds-config.yaml"))
 	require.NoError(t, err)
 	err = os.Setenv("UDS_UI_COLOR", color)


### PR DESCRIPTION
## Description

Splits envs into 2 sections explicitly, handling situations where envs have `=` in them.

Also updated the base64 secret test to include `=` since this is a common place where this could occur (base64 padding).

## Related Issue

No issue opened, can be if required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
