### PR TITLE
chore: add bundle name to bundle-sbom.tar

### DIFF
--- a/src/pkg/bundle/inspect.go
+++ b/src/pkg/bundle/inspect.go
@@ -65,16 +65,17 @@ func (b *Bundle) Inspect() error {
 		return err
 	}
 
-	// pull sbom
-	if b.cfg.InspectOpts.IncludeSBOM {
-		err := provider.CreateBundleSBOM(b.cfg.InspectOpts.ExtractSBOM)
-		if err != nil {
-			return err
-		}
-	}
 	// read the bundle's metadata into memory
 	if err := utils.ReadYAMLStrict(filepaths[config.BundleYAML], &b.bundle); err != nil {
 		return err
+	}
+
+	// pull sbom
+	if b.cfg.InspectOpts.IncludeSBOM {
+		err := provider.CreateBundleSBOM(b.cfg.InspectOpts.ExtractSBOM, b.bundle.Metadata.Name)
+		if err != nil {
+			return err
+		}
 	}
 
 	// handle --list-variables flag

--- a/src/pkg/bundle/provider.go
+++ b/src/pkg/bundle/provider.go
@@ -38,7 +38,7 @@ type Provider interface {
 	LoadBundle(options types.BundlePullOptions, concurrency int) (*types.UDSBundle, types.PathMap, error)
 
 	// CreateBundleSBOM creates a bundle-level SBOM from the underlying Zarf packages, if the Zarf package contains an SBOM
-	CreateBundleSBOM(extractSBOM bool) error
+	CreateBundleSBOM(extractSBOM bool, bundleName string) error
 
 	// PublishBundle publishes a bundle to a remote OCI repo
 	PublishBundle(bundle types.UDSBundle, remote *oci.OrasRemote) error

--- a/src/pkg/bundle/remote.go
+++ b/src/pkg/bundle/remote.go
@@ -85,13 +85,14 @@ func (op *ociProvider) LoadBundleMetadata() (types.PathMap, error) {
 }
 
 // CreateBundleSBOM creates a bundle-level SBOM from the underlying Zarf packages, if the Zarf package contains an SBOM
-func (op *ociProvider) CreateBundleSBOM(extractSBOM bool) error {
+func (op *ociProvider) CreateBundleSBOM(extractSBOM bool, bundleName string) error {
 	ctx := context.TODO()
 	SBOMArtifactPathMap := make(types.PathMap)
 	root, err := op.FetchRoot(ctx)
 	if err != nil {
 		return err
 	}
+
 	// make tmp dir for pkg SBOM extraction
 	err = os.Mkdir(filepath.Join(op.dst, config.BundleSBOM), 0700)
 	if err != nil {
@@ -140,7 +141,7 @@ func (op *ociProvider) CreateBundleSBOM(extractSBOM bool) error {
 			return err
 		}
 	} else {
-		err = utils.CreateSBOMArtifact(SBOMArtifactPathMap)
+		err = utils.CreateSBOMArtifact(SBOMArtifactPathMap, bundleName)
 		if err != nil {
 			return err
 		}

--- a/src/pkg/bundle/tarball.go
+++ b/src/pkg/bundle/tarball.go
@@ -38,7 +38,7 @@ type tarballBundleProvider struct {
 }
 
 // CreateBundleSBOM creates a bundle-level SBOM from the underlying Zarf packages, if the Zarf package contains an SBOM
-func (tp *tarballBundleProvider) CreateBundleSBOM(extractSBOM bool) error {
+func (tp *tarballBundleProvider) CreateBundleSBOM(extractSBOM bool, bundleName string) error {
 	rootManifest, err := tp.getBundleManifest()
 	if err != nil {
 		return err
@@ -109,7 +109,7 @@ func (tp *tarballBundleProvider) CreateBundleSBOM(extractSBOM bool) error {
 			return err
 		}
 	} else {
-		err = utils.CreateSBOMArtifact(SBOMArtifactPathMap)
+		err = utils.CreateSBOMArtifact(SBOMArtifactPathMap, bundleName)
 		if err != nil {
 			return err
 		}

--- a/src/pkg/utils/sbom.go
+++ b/src/pkg/utils/sbom.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -14,8 +15,8 @@ import (
 )
 
 // CreateSBOMArtifact creates sbom artifacts in the form of a tar archive
-func CreateSBOMArtifact(SBOMArtifactPathMap map[string]string) error {
-	out, err := os.Create(config.BundleSBOMTar)
+func CreateSBOMArtifact(SBOMArtifactPathMap map[string]string, bundleName string) error {
+	out, err := os.Create(fmt.Sprintf("%s-%s", bundleName, config.BundleSBOMTar))
 	if err != nil {
 		return err
 	}

--- a/src/test/e2e/bundle_deploy_flags_test.go
+++ b/src/test/e2e/bundle_deploy_flags_test.go
@@ -78,7 +78,7 @@ func TestResumeFlag(t *testing.T) {
 
 	runCmd(t, fmt.Sprintf("create %s --insecure --confirm -a %s", bundleDir, e2e.Arch))
 
-	inspectLocal(t, bundlePath)
+	inspectLocal(t, bundlePath, "test-local-and-remote")
 	inspectLocalAndSBOMExtract(t, bundlePath)
 
 	getDeploymentsCmd := "zarf tools kubectl get deployments -A -o=jsonpath='{.items[*].metadata.name}'"

--- a/src/test/e2e/bundle_index_test.go
+++ b/src/test/e2e/bundle_index_test.go
@@ -36,7 +36,7 @@ func TestBundleIndexInRemoteOnPublish(t *testing.T) {
 	require.NoError(t, err)
 	ValidateMultiArchIndex(t, index)
 
-	inspectRemoteInsecure(t, fmt.Sprintf("oci://localhost:888/%s:0.0.1", bundleName))
+	inspectRemoteInsecure(t, fmt.Sprintf("oci://localhost:888/%s:0.0.1", bundleName), bundleName)
 	pull(t, fmt.Sprintf("localhost:888/%s:0.0.1", bundleName), bundleTarballName) // test no oci prefix
 	deployAndRemoveLocalAndRemoteInsecure(t, fmt.Sprintf("oci://localhost:888/%s:0.0.1", bundleName), tarballPath)
 
@@ -46,7 +46,7 @@ func TestBundleIndexInRemoteOnPublish(t *testing.T) {
 	index, err = queryIndex(t, "http://localhost:888", bundleName)
 	require.NoError(t, err)
 	ValidateMultiArchIndex(t, index)
-	inspectRemoteInsecure(t, fmt.Sprintf("oci://localhost:888/%s:0.0.1", bundleName))
+	inspectRemoteInsecure(t, fmt.Sprintf("oci://localhost:888/%s:0.0.1", bundleName), bundleName)
 	pull(t, fmt.Sprintf("localhost:888/%s:0.0.1", bundleName), bundleTarballName) // test no oci prefix
 	deployAndRemoveLocalAndRemoteInsecure(t, fmt.Sprintf("oci://localhost:888/%s:0.0.1", bundleName), tarballPath)
 }
@@ -70,7 +70,7 @@ func TestBundleIndexInRemoteOnCreate(t *testing.T) {
 	require.NoError(t, err)
 	ValidateMultiArchIndex(t, index)
 
-	inspectRemoteInsecure(t, fmt.Sprintf("oci://localhost:888/%s:0.0.1", bundleName))
+	inspectRemoteInsecure(t, fmt.Sprintf("oci://localhost:888/%s:0.0.1", bundleName), bundleName)
 	pull(t, fmt.Sprintf("localhost:888/%s:0.0.1", bundleName), bundleTarballName) // test no oci prefix
 	deployAndRemoveLocalAndRemoteInsecure(t, fmt.Sprintf("oci://localhost:888/%s:0.0.1", bundleName), tarballPath)
 
@@ -81,7 +81,7 @@ func TestBundleIndexInRemoteOnCreate(t *testing.T) {
 	index, err = queryIndex(t, "http://localhost:888", bundleName)
 	require.NoError(t, err)
 	ValidateMultiArchIndex(t, index)
-	inspectRemoteInsecure(t, fmt.Sprintf("oci://localhost:888/%s:0.0.1", bundleName))
+	inspectRemoteInsecure(t, fmt.Sprintf("oci://localhost:888/%s:0.0.1", bundleName), bundleName)
 	pull(t, fmt.Sprintf("localhost:888/%s:0.0.1", bundleName), bundleTarballName) // test no oci prefix
 	deployAndRemoveLocalAndRemoteInsecure(t, fmt.Sprintf("oci://localhost:888/%s:0.0.1", bundleName), tarballPath)
 }

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -184,7 +184,7 @@ func TestRemoteBundleWithRemotePkgs(t *testing.T) {
 	runCmd(t, fmt.Sprintf("create %s -o %s --confirm --insecure -a %s", bundlePath, "localhost:888", e2e.Arch))
 
 	pull(t, bundleRef.String(), bundleTarballName)
-	inspectRemoteInsecure(t, bundleRef.String())
+	inspectRemoteInsecure(t, bundleRef.String(), "example-remote")
 	inspectRemoteAndSBOMExtract(t, bundleRef.String())
 	deployAndRemoveLocalAndRemoteInsecure(t, bundleRef.String(), tarballPath)
 

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -106,7 +106,7 @@ func TestBundleWithLocalAndRemotePkgs(t *testing.T) {
 	}
 
 	runCmd(t, fmt.Sprintf("create %s --insecure --confirm -a %s", bundleDir, e2e.Arch))
-	inspectLocal(t, bundlePath)
+	inspectLocal(t, bundlePath, "test-local-and-remote")
 	runCmd(t, fmt.Sprintf("deploy %s --retries 1 --confirm", bundlePath))
 	runCmd(t, fmt.Sprintf("remove %s --confirm --insecure", bundlePath))
 
@@ -146,7 +146,7 @@ func TestLocalBundleWithRemotePkgs(t *testing.T) {
 	bundlePath := filepath.Join(bundleDir, fmt.Sprintf("uds-bundle-example-remote-%s-0.0.1.tar.zst", e2e.Arch))
 
 	runCmd(t, fmt.Sprintf("create %s --insecure --confirm -a %s", bundleDir, e2e.Arch))
-	inspectLocal(t, bundlePath)
+	inspectLocal(t, bundlePath, "example-remote")
 	inspectLocalAndSBOMExtract(t, bundlePath)
 	runCmd(t, fmt.Sprintf("deploy %s --retries 1 --confirm", bundlePath))
 	runCmd(t, fmt.Sprintf("remove %s --confirm --insecure", bundlePath))
@@ -215,7 +215,7 @@ func TestBundleWithYmlFile(t *testing.T) {
 	bundlePath := filepath.Join(bundleDir, fmt.Sprintf("uds-bundle-yml-example-%s-0.0.1.tar.zst", e2e.Arch))
 
 	runCmd(t, fmt.Sprintf("create %s --insecure --confirm -a %s", bundleDir, e2e.Arch))
-	inspectLocal(t, bundlePath)
+	inspectLocal(t, bundlePath, "yml-example")
 	inspectLocalAndSBOMExtract(t, bundlePath)
 	os.Setenv("UDS_CONFIG", filepath.Join("src/test/bundles/09-uds-bundle-yml", "uds-config.yml"))
 	defer os.Unsetenv("UDS_CONFIG")

--- a/src/test/e2e/commands_test.go
+++ b/src/test/e2e/commands_test.go
@@ -25,19 +25,19 @@ import (
 
 // This file contains helpers for running UDS CLI commands (ie. uds create/deploy/etc with various flags and options)
 
-func inspectRemoteInsecure(t *testing.T, ref string) {
+func inspectRemoteInsecure(t *testing.T, ref string, bundleName string) {
 	runCmd(t, fmt.Sprintf("inspect %s --insecure --sbom", ref))
-	_, err := os.Stat(config.BundleSBOMTar)
+	_, err := os.Stat(fmt.Sprintf("%s-%s", bundleName, config.BundleSBOMTar))
 	require.NoError(t, err)
-	err = os.Remove(config.BundleSBOMTar)
+	err = os.Remove(fmt.Sprintf("%s-%s", bundleName, config.BundleSBOMTar))
 	require.NoError(t, err)
 }
 
-func inspectRemote(t *testing.T, ref string) {
+func inspectRemote(t *testing.T, ref string, bundleName string) {
 	runCmd(t, fmt.Sprintf("inspect %s --sbom", ref))
-	_, err := os.Stat(config.BundleSBOMTar)
+	_, err := os.Stat(fmt.Sprintf("%s-%s", bundleName, config.BundleSBOMTar))
 	require.NoError(t, err)
-	err = os.Remove(config.BundleSBOMTar)
+	err = os.Remove(fmt.Sprintf("%s-%s", bundleName, config.BundleSBOMTar))
 	require.NoError(t, err)
 }
 

--- a/src/test/e2e/commands_test.go
+++ b/src/test/e2e/commands_test.go
@@ -49,12 +49,12 @@ func inspectRemoteAndSBOMExtract(t *testing.T, ref string) {
 	require.NoError(t, err)
 }
 
-func inspectLocal(t *testing.T, tarballPath string) {
+func inspectLocal(t *testing.T, tarballPath string, bundleName string) {
 	stdout, _ := runCmd(t, fmt.Sprintf("inspect %s --sbom --no-color", tarballPath))
 	require.NotContains(t, stdout, "\x1b")
-	_, err := os.Stat(config.BundleSBOMTar)
+	_, err := os.Stat(fmt.Sprintf("%s-%s", bundleName, config.BundleSBOMTar))
 	require.NoError(t, err)
-	err = os.Remove(config.BundleSBOMTar)
+	err = os.Remove(fmt.Sprintf("%s-%s", bundleName, config.BundleSBOMTar))
 	require.NoError(t, err)
 }
 

--- a/src/test/e2e/ghcr_test.go
+++ b/src/test/e2e/ghcr_test.go
@@ -42,7 +42,7 @@ func TestBundleCreateAndPublishGHCR(t *testing.T) {
 	registryURL = "ghcr.io/defenseunicorns/packages/uds-cli/test/publish"
 	runCmd(t, fmt.Sprintf("publish %s %s --oci-concurrency=10", bundlePathAMD, registryURL))
 
-	inspectRemote(t, bundlePathARM)
+	inspectRemote(t, bundlePathARM, bundleName)
 	pull(t, bundleRef.String(), bundleTarballName)
 	runCmd(t, fmt.Sprintf("deploy %s --retries 1 --confirm", bundleRef.String()))
 	runCmd(t, fmt.Sprintf("remove %s --confirm --insecure", bundleRef.String()))
@@ -70,7 +70,7 @@ func TestBundleCreateRemoteAndDeployGHCR(t *testing.T) {
 	runCmd(t, fmt.Sprintf("create %s -o %s --confirm -a %s", bundleDir, registryURL, "arm64"))
 	runCmd(t, fmt.Sprintf("create %s -o %s --confirm -a %s", bundleDir, registryURL, "amd64"))
 
-	inspectRemote(t, bundleRef.String())
+	inspectRemote(t, bundleRef.String(), bundleName)
 	runCmd(t, fmt.Sprintf("deploy %s --retries 1 --confirm", bundleRef.String()))
 	runCmd(t, fmt.Sprintf("remove %s --confirm --insecure", bundleRef.String()))
 
@@ -90,14 +90,14 @@ func TestBundleCreateRemoteAndDeployGHCR(t *testing.T) {
 // The default bundle location if no source path provided is defenseunicorns/packages/uds/bundles/"
 func TestGHCRPathExpansion(t *testing.T) {
 	bundleName := "ghcr-test:0.0.1"
-	inspectRemote(t, bundleName)
+	inspectRemote(t, bundleName, "ghcr-test")
 
 	bundleName = fmt.Sprintf("ghcr-delivery-test:0.0.1-%s", e2e.Arch)
-	inspectRemote(t, bundleName)
+	inspectRemote(t, bundleName, "ghcr-test")
 
 	bundleName = fmt.Sprintf("delivery/ghcr-test:0.0.1-%s", e2e.Arch)
-	inspectRemote(t, bundleName)
+	inspectRemote(t, bundleName, "ghcr-test")
 
 	bundleName = "ghcr.io/defenseunicorns/packages/delivery/ghcr-delivery-test:0.0.1"
-	inspectRemote(t, bundleName)
+	inspectRemote(t, bundleName, "ghcr-test")
 }


### PR DESCRIPTION
## Description
Adding the bundle name to the bundle-sboms.tar file name for easier distinction when working with multiple bundles.

e.g. `<bundle-name>-bundle-sboms.tar`
## Related Issue

Resolves #880

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
