### PR TITLE
feat: add sensitive boolean for bundle override variables

### DIFF
--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -313,6 +313,30 @@ UDS CLI does not encrypt or base64 encode any file contents before passing said 
 For example, if the file contains a key to be used in a Kubernetes secret, it must be base64 encoded before being ingested by UDS CLI.
 {{% /alert-note %}}
 
+### Sensitive
+
+Variables can be specified as sensitive, which means their values, regardless of how they're set, will be masked in output.
+
+```yaml
+kind: UDSBundle
+metadata:
+   name: example-bundle
+   version: 0.0.1
+
+packages:
+   - name: helm-overrides-package
+     path: "../../packages/helm"
+     ref: 0.0.1
+     overrides:
+        podinfo-component:
+          unicorn-podinfo:
+           variables:
+            - name: SECRET_VAL
+                path: "testSecret"
+                description: "should be masked in output"
+                sensitive: true
+```
+
 ### Namespace
 
 It's also possible to specify a namespace for a packaged Helm chart to be installed in. For example, to deploy the a chart in the `custom-podinfo` namespace, you can specify the `namespace` in the `overrides` block:

--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -99,7 +99,7 @@ func (b *Bundle) ValidateBundleResources(spinner *message.Spinner) error {
 	for idx, pkg := range bundle.Packages {
 		spinner.Updatef("Validating Bundle Package: %s", pkg.Name)
 		if pkg.Name == "" {
-			return fmt.Errorf("%s is missing required field: name", pkg)
+			return fmt.Errorf("%v is missing required field: name", pkg)
 		}
 
 		if pkg.Repository == "" && pkg.Path == "" {

--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -435,7 +435,7 @@ func extractValues(helmChartVars map[string]interface{}, variables []types.Bundl
 	viewVars := make(map[string]interface{})
 	for _, v := range variables {
 		// Mask potentially sensitive variables
-		if v.Type == chartvariable.File || v.Source == valuesources.Env {
+		if v.Type == chartvariable.File || v.Source == valuesources.Env || v.Sensitive {
 			viewVars[v.Name] = hiddenVar
 			continue
 		}

--- a/src/pkg/bundle/deploy_test.go
+++ b/src/pkg/bundle/deploy_test.go
@@ -415,6 +415,27 @@ func TestFormPkgViews(t *testing.T) {
 			expectedVal: hiddenVar,
 		},
 		{
+			name: "mask sensitive config var",
+			Bundle: newTestBundle(
+				ConfigVariables{
+					pkgName: {
+						"VAR1": "iamsensitive",
+					},
+				},
+				nil,
+				nil,
+				"uds-config.yaml",
+				"",
+			),
+			bundleVars: types.BundleChartVariable{
+				Name:      "VAR1",
+				Path:      "path",
+				Sensitive: true,
+			},
+			expectedKey: "VAR1",
+			expectedVal: hiddenVar,
+		},
+		{
 			name: "mask file var",
 			Bundle: newTestBundle(
 				ConfigVariables{

--- a/src/test/bundles/07-helm-overrides/uds-bundle.yaml
+++ b/src/test/bundles/07-helm-overrides/uds-bundle.yaml
@@ -43,6 +43,7 @@ packages:
             - name: SECRET_VAL
               path: "testSecret"
               description: "testing a secret value"
+              sensitive: true
             - name: SECURITY_CTX
               path: "podinfo.securityContext"
               description: "testing an object"

--- a/src/test/bundles/07-helm-overrides/uds-config.yaml
+++ b/src/test/bundles/07-helm-overrides/uds-config.yaml
@@ -27,4 +27,3 @@ variables:
             pathType: "Prefix"
     secret_file_val: "./variable-files/test.cert"
     second_chart_secret: "./variable-files/test.cert"
-    secret_val: "test"

--- a/src/test/bundles/07-helm-overrides/uds-config.yaml
+++ b/src/test/bundles/07-helm-overrides/uds-config.yaml
@@ -27,3 +27,4 @@ variables:
             pathType: "Prefix"
     secret_file_val: "./variable-files/test.cert"
     second_chart_secret: "./variable-files/test.cert"
+    secret_val: "test"

--- a/src/types/bundle.go
+++ b/src/types/bundle.go
@@ -51,6 +51,7 @@ type BundleChartVariable struct {
 	Description string              `json:"description,omitempty" jsonschema:"name=Description of the variable"`
 	Default     interface{}         `json:"default,omitempty" jsonschema:"name=The default value to set"`
 	Type        chartvariable.Type  `json:"type,omitempty" jsonschema:"description=The type of value to be processed,enum=raw,enum=file"`
+	Sensitive   bool                `json:"sensitive,omitempty" jsonschema:"description=Whether the value is sensitive"`
 	Source      valuesources.Source `json:"source,omitempty" jsonschema:"description=Where the value is set from,enum=config,enum=env,enum=cli,enum=bundle"`
 }
 

--- a/uds.schema.json
+++ b/uds.schema.json
@@ -83,6 +83,10 @@
           "type": "string",
           "description": "The type of value to be processed"
         },
+        "sensitive": {
+          "type": "boolean",
+          "description": "Whether the value is sensitive"
+        },
         "source": {
           "enum": [
             "config",


### PR DESCRIPTION
## Description
Adds the `Sensitive` option to bundle override variables so that sensitive variables set in a `uds-config.yaml` can be masked in deployment output.

## Related Issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
