### PR TITLE
fix: cleanup color and typo

### DIFF
--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -358,8 +358,7 @@ func (b *Bundle) ConfirmBundleDeploy() (confirm bool) {
 
 	message.HeaderInfof("🎁 BUNDLE DEFINITION")
 
-	message.Title("Metatdata:", "information about this bundle")
-	zarfUtils.ColorPrintYAML(map[string]string{"kind": b.bundle.Kind}, nil, false)
+	message.Title("Metadata:", "information about this bundle")
 	zarfUtils.ColorPrintYAML(b.bundle.Metadata, nil, false)
 
 	message.HorizontalRule()

--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -21,7 +21,6 @@ import (
 	"github.com/defenseunicorns/uds-cli/src/types/chartvariable"
 	"github.com/defenseunicorns/uds-cli/src/types/valuesources"
 	goyaml "github.com/goccy/go-yaml"
-	"github.com/pterm/pterm"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	zarfConfig "github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
@@ -336,11 +335,10 @@ func (b *Bundle) ConfirmBundleDeploy() (confirm bool) {
 	pkgviews := formPkgViews(b)
 
 	message.HeaderInfof("🎁 BUNDLE DEFINITION")
-	pterm.Println("kind: UDS Bundle")
-
 	message.HorizontalRule()
 
 	message.Title("Metatdata:", "information about this bundle")
+	zarfUtils.ColorPrintYAML(map[string]string{"kind": b.bundle.Kind}, nil, false)
 	zarfUtils.ColorPrintYAML(b.bundle.Metadata, nil, false)
 
 	message.HorizontalRule()

--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -335,7 +335,6 @@ func (b *Bundle) ConfirmBundleDeploy() (confirm bool) {
 	pkgviews := formPkgViews(b)
 
 	message.HeaderInfof("🎁 BUNDLE DEFINITION")
-	message.HorizontalRule()
 
 	message.Title("Metatdata:", "information about this bundle")
 	zarfUtils.ColorPrintYAML(map[string]string{"kind": b.bundle.Kind}, nil, false)


### PR DESCRIPTION
## Description

~Cleans up the positioning of `"kind:"` to be under Metadata, fixes the color output, and fixes a typo~. UPDATE: removes `"kind:"` entirely and fixes typo.

Unfortunately I couldn't merge this in with the existing `b.bundle.Metadata` struct. I tried a new inline struct that embedded the `Metadata` one but the yaml printer ended up making a new section for it, which isn't what I wanted. 

New look:

![Screenshot 2024-09-06 at 10 37 51 AM](https://github.com/user-attachments/assets/f199c941-fe9b-4b49-ae60-86e3aaa29e19)

Also unfortunately, `ColorPrintYAML()` forces an empty line before printing, so that's why there's a gap there.

While I was here, I renamed the imported zarf utils package to `zarfUtils` because I noticed `uds-cli` also has a `utils` package. While we don't use the `uds-cli` one here, while experimenting here with `pterm` I found that we did and there was confusion as to which I was trying to use... naming the import `zarfUtils` is consistent with what we do in [pkg/bundle/create.go](https://github.com/defenseunicorns/uds-cli/blob/95747525dab27403a622b766fe4dd492cb013442/src/pkg/bundle/create.go#L20) so I went with that. 

## Related Issue

Fixes #897

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
