### PR TITLE
fix: remove extra Zarf logging output

### DIFF
--- a/src/cmd/common.go
+++ b/src/cmd/common.go
@@ -125,11 +125,16 @@ func cliSetup(cmd *cobra.Command) error {
 		}
 	}
 
-	// TODO(schristoff): Leverage SDK and refactor
-	// This sets up zarf CLI with the same configuration options as UDSCLI
-	err := zarfCommon.SetupCLI(logLevel, config.SkipLogFile, config.NoColor)
-	if err != nil {
-		return err
+	// don't configure Zarf CLI directly if we're calling vendored Zarf
+	if !strings.HasPrefix(cmd.Use, "zarf") {
+		pterm.DisableOutput() // don't print extra Zarf note about logs
+		// TODO(schristoff): Leverage SDK and refactor
+		// This sets up zarf CLI with the same configuration options as UDSCLI
+		err := zarfCommon.SetupCLI(logLevel, config.SkipLogFile, config.NoColor)
+		if err != nil {
+			return err
+		}
+		pterm.EnableOutput()
 	}
 
 	// configure logs for UDS after calling zarfCommon.SetupCLI


### PR DESCRIPTION
## Description

Remove extra Zarf logging output. Previously, we saw an extra note from Zarf saying where a log file was located, this PR removes that behavior by disabling `pterm` output briefly while setting up the Zarf CLI

Noting that the Zarf output pointed to a log file with no useful information because we capture all the useful output in the UDS log file
