### PR TITLE
fix: update renovate to hopefully fix uds-runtime dep

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,7 +63,8 @@
     {
       "fileMatch": ["hack/update-uds-runtime-binaries.sh"],
       "matchStrings": ["CURRENT_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
-      "replaceString": "CURRENT_VERSION=\"${version}\""
+      "depNameTemplate": "defenseunicorns/uds-runtime",
+      "datasourceTemplate": "github-releases"
     }
   ]
 }


### PR DESCRIPTION
## Description

Renovate seems to be broken at the moment. In this PR we try to fix it. Pray I do not try to fix it further

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
