### PR TITLE
chore: matrix testing pre-existing k3d clusters

### DIFF
--- a/.github/actions/golang/action.yaml
+++ b/.github/actions/golang/action.yaml
@@ -6,4 +6,4 @@ runs:
   steps:
     - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: 1.21.x
+        go-version-file: 'go.mod'

--- a/.github/actions/k3d/action.yaml
+++ b/.github/actions/k3d/action.yaml
@@ -4,7 +4,7 @@ description: "Install k3d and create a cluster"
 inputs:
   create-clutser:
     description: "Boolean specifying if k3d should create a cluster after installation"
-    required: true
+    required: false
     default: 'true'
 
 runs:

--- a/.github/actions/k3d/action.yaml
+++ b/.github/actions/k3d/action.yaml
@@ -10,9 +10,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+    - name: install k3d
+      run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
       shell: bash
 
-    - if: ${{ inputs.create-cluster == 'true' }}
+    - name: create cluster
+      if: ${{ inputs.create-cluster == 'true' }}
       run: k3d cluster delete && k3d cluster create
       shell: bash

--- a/.github/actions/k3d/action.yaml
+++ b/.github/actions/k3d/action.yaml
@@ -2,7 +2,7 @@ name: setup-k3d
 description: "Install k3d and create a cluster"
 
 inputs:
-  create-clutser:
+  create-cluster:
     description: "Boolean specifying if k3d should create a cluster after installation"
     required: false
     default: 'true'

--- a/.github/actions/k3d/action.yaml
+++ b/.github/actions/k3d/action.yaml
@@ -16,3 +16,4 @@ runs:
     - if: ${{ inputs.create-cluster }}
       run: k3d cluster delete && k3d cluster create
       shell: bash
+

--- a/.github/actions/k3d/action.yaml
+++ b/.github/actions/k3d/action.yaml
@@ -5,7 +5,7 @@ inputs:
   create-clutser:
     description: "Boolean specifying if k3d should create a cluster after installation"
     required: true
-    default: true
+    default: 'true'
 
 runs:
   using: composite
@@ -13,7 +13,6 @@ runs:
     - run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
       shell: bash
 
-    - if: ${{ inputs.create-cluster }}
+    - if: ${{ inputs.create-cluster == 'true' }}
       run: k3d cluster delete && k3d cluster create
       shell: bash
-

--- a/.github/actions/k3d/action.yaml
+++ b/.github/actions/k3d/action.yaml
@@ -1,11 +1,18 @@
 name: setup-k3d
 description: "Install k3d and create a cluster"
 
+inputs:
+  create-clutser:
+    description: "Boolean specifying if k3d should create a cluster after installation"
+    required: true
+    default: true
+
 runs:
   using: composite
   steps:
     - run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
       shell: bash
 
-    - run: k3d cluster delete && k3d cluster create
+    - if: ${{ inputs.create-cluster }}
+      run: k3d cluster delete && k3d cluster create
       shell: bash

--- a/.github/actions/setup-from-previous/action.yaml
+++ b/.github/actions/setup-from-previous/action.yaml
@@ -4,12 +4,6 @@ description: grabs artifact from a previous job and sets up the env for tests
 runs:
   using: composite
   steps:
-    # Checkout the repo and setup the tooling for this job
-    - name: Checkout
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      with:
-        fetch-depth: 0
-
     - name: Download build artifacts
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:

--- a/.github/workflows/nightly-uds-core.yaml
+++ b/.github/workflows/nightly-uds-core.yaml
@@ -42,14 +42,12 @@ jobs:
       - name: Make UDS-CLI executable
         run: |
           chmod +x build/uds
-      
+
       - name: Setup K3d
         uses: ./.github/actions/k3d
         with:
           create-cluster: ${{ matrix.create-cluster }}
-  
 
       - name: Run UDS Core smoke test
         run: build/uds run test:ci-uds-core-smoke-test
         shell: bash
-

--- a/.github/workflows/nightly-uds-core.yaml
+++ b/.github/workflows/nightly-uds-core.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup K3d
         uses: ./.github/actions/k3d
         with:
-          create-cluster: "${{ matrix.type == 'with-cluster' && 'false' || 'true'}}"
+          create-cluster: "${{ matrix.type == 'with-cluster' && 'true' || 'false'}}"
 
       - name: Run UDS Core smoke test
         run: build/uds run test:ci-uds-core-smoke-test

--- a/.github/workflows/nightly-uds-core.yaml
+++ b/.github/workflows/nightly-uds-core.yaml
@@ -18,12 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        existing-cluster: [with-cluster, without-cluster]
-        include:
-          - existing-cluster: without-cluster
-            create-cluster: 'false'
-          - existing-cluster: with-cluster
-            create-cluster: 'true'
+        type: [with-cluster, without-cluster]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/nightly-uds-core.yaml
+++ b/.github/workflows/nightly-uds-core.yaml
@@ -52,3 +52,4 @@ jobs:
       - name: Run UDS Core smoke test
         run: build/uds run test:ci-uds-core-smoke-test
         shell: bash
+

--- a/.github/workflows/nightly-uds-core.yaml
+++ b/.github/workflows/nightly-uds-core.yaml
@@ -21,7 +21,9 @@ jobs:
         existing-cluster: [with-cluster, without-cluster]
         include:
           - existing-cluster: without-cluster
-            create-cluster: false
+            create-cluster: 'false'
+          - existing-cluster: with-cluster
+            create-cluster: 'true'
     permissions:
       contents: read
     steps:

--- a/.github/workflows/nightly-uds-core.yaml
+++ b/.github/workflows/nightly-uds-core.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup K3d
         uses: ./.github/actions/k3d
         with:
-          create-cluster: ${{ matrix.create-cluster }}
+          create-cluster: "${{ matrix.type == 'with-cluster' && 'false' || 'true'}}"
 
       - name: Run UDS Core smoke test
         run: build/uds run test:ci-uds-core-smoke-test

--- a/.github/workflows/nightly-uds-core.yaml
+++ b/.github/workflows/nightly-uds-core.yaml
@@ -16,6 +16,12 @@ concurrency:
 jobs:
   uds-core-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        existing-cluster: [with-cluster, without-cluster]
+        include:
+          - existing-cluster: without-cluster
+            create-cluster: false
     permissions:
       contents: read
     steps:
@@ -36,10 +42,12 @@ jobs:
       - name: Make UDS-CLI executable
         run: |
           chmod +x build/uds
-
-      - name: Install-k3d
-        run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
-        shell: bash
+      
+      - name: Setup K3d
+        uses: ./.github/actions/k3d
+        with:
+          create-cluster: ${{ matrix.create-cluster }}
+  
 
       - name: Run UDS Core smoke test
         run: build/uds run test:ci-uds-core-smoke-test

--- a/.github/workflows/release-tests.yaml
+++ b/.github/workflows/release-tests.yaml
@@ -49,12 +49,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        existing-cluster: [with-cluster, without-cluster]
-        include:
-          - existing-cluster: without-cluster
-            create-cluster: 'false'
-          - existing-cluster: with-cluster
-            create-cluster: 'true'
+        type: [with-cluster, without-cluster]
     steps:
       # Checkout the repo and setup the tooling for this job
       - name: Checkout
@@ -78,7 +73,7 @@ jobs:
       - name: Setup K3d
         uses: ./.github/actions/k3d
         with:
-          create-cluster: ${{ matrix.create-cluster }}
+          create-cluster: "${{ matrix.type == 'with-cluster' && 'true' || 'false'}}"
 
       - name: Login to GHCR
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/.github/workflows/release-tests.yaml
+++ b/.github/workflows/release-tests.yaml
@@ -1,4 +1,4 @@
-name: E2E Tests
+name: E2E Release Tests
 on:
   workflow_call: # This is the event that triggers the workflow
 

--- a/.github/workflows/release-tests.yaml
+++ b/.github/workflows/release-tests.yaml
@@ -47,6 +47,12 @@ jobs:
   smoke-test:
     runs-on: ubuntu-latest
     needs: test
+    strategy:
+      matrix:
+        existing-cluster: [with-cluster, without-cluster]
+        include:
+          - existing-cluster: without-cluster
+            create-cluster: false
     steps:
       # Checkout the repo and setup the tooling for this job
       - name: Checkout
@@ -69,6 +75,8 @@ jobs:
 
       - name: Setup K3d
         uses: ./.github/actions/k3d
+        with:
+          create-cluster: ${{ matrix.create-cluster }}
 
       - name: Login to GHCR
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/.github/workflows/release-tests.yaml
+++ b/.github/workflows/release-tests.yaml
@@ -52,7 +52,9 @@ jobs:
         existing-cluster: [with-cluster, without-cluster]
         include:
           - existing-cluster: without-cluster
-            create-cluster: false
+            create-cluster: 'false'
+          - existing-cluster: with-cluster
+            create-cluster: 'true'
     steps:
       # Checkout the repo and setup the tooling for this job
       - name: Checkout

--- a/.github/workflows/test-e2e-pr.yaml
+++ b/.github/workflows/test-e2e-pr.yaml
@@ -1,4 +1,4 @@
-name: E2E Tests
+name: E2E PR Tests
 on:
   pull_request:
     paths-ignore:


### PR DESCRIPTION
## Description

Cleanup some of our GitHub Actions, and run (some of?) our e2e tests in a matrix where one scenario we have k3d installed and a cluster created, and another with k3d installed and no cluster created.

**Note about our `setup-golang` action:** I noticed that we were using `setup-go` to install go `1.21.x`, however the `setup-go` action does not list the `.x` syntax as supported. Furthermore our `go.mod` file says go 1.22.4, so the setup go action was setting 1.21.x, and then immediately switching to go 1.22.4 because that's what our go.mod says. The result was a long list of errors trying to use 1.22 because it was being pulled from cache but conflicted with the 1.21 we just setup. 

See here for example: https://github.com/defenseunicorns/uds-cli/actions/runs/11037302233/job/30657907519#step:3:102

**Note about our `setup-from-previous` action:** I noticed that every invocation was preceded by a `checkout` action, and the first step of `setup-from-previous` was also a checkout. 

See [here](https://github.com/defenseunicorns/uds-cli/actions/runs/11037302233/job/30657907519#step:2:165) and [here](https://github.com/defenseunicorns/uds-cli/actions/runs/11037302233/job/30657907519#step:3:67) for example of trying to checkout the repo 2x in the same job

## Related Issue

Fixes #940

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
