### PR TITLE
fix: add suffix to smoke test logs

### DIFF
--- a/.github/workflows/release-tests.yaml
+++ b/.github/workflows/release-tests.yaml
@@ -90,4 +90,4 @@ jobs:
         if: always()
         uses: defenseunicorns/uds-common/.github/actions/save-logs@ea9db8ab9bfc4a5d87acd7d1af385aa8e44206d3 # v0.13.0
         with:
-          suffix: smoke-test
+          suffix: smoke-test-${{ matrix.type }}


### PR DESCRIPTION
## Description

The nightly CI release workflow has been busted since we added matrix testing due to conflicts in the log names. This PR adds a suffix for the matrix type to distinguish.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
