### PR TITLE
fix: update renovate script regex for uds-runtime

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -62,7 +62,7 @@
     },
     {
       "fileMatch": ["hack/update-uds-runtime-binaries.sh"],
-      "matchStrings": ["CURRENT_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
+      "matchStrings": ["CURRENT_VERSION=\"v(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
       "depNameTemplate": "defenseunicorns/uds-runtime",
       "datasourceTemplate": "github-releases"
     }


### PR DESCRIPTION
## Description

I am once again trying to fix renovate to properly update our `uds-runtime` dependency

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
