### PR TITLE
fix: revert "fix: remove unused GitHub Action install-tools"

### DIFF
--- a/.github/actions/install-tools/action.yaml
+++ b/.github/actions/install-tools/action.yaml
@@ -1,0 +1,14 @@
+name: install-tools
+description: "Install pipeline tools"
+
+runs:
+  using: composite
+  steps:
+    - uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 # v3.6.0
+
+    - uses: anchore/sbom-action/download-syft@61119d458adab75f756bc0b9e4bde25725f86a7a # v0.17.2
+
+    - run: "curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin"
+      shell: bash
+
+    - uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1

--- a/.github/actions/install-tools/action.yaml
+++ b/.github/actions/install-tools/action.yaml
@@ -1,3 +1,6 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
 name: install-tools
 description: "Install pipeline tools"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,9 @@ jobs:
       - name: Setup golang
         uses: ./.github/actions/golang
 
+      - name: Install tools
+        uses: ./.github/actions/install-tools
+
       - name: Download build artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,6 @@
+ignore:
+  # This vulnerability does not affect UDS as we do not instantiate a rekor client
+  - vulnerability: GHSA-2h5h-59f5-c5x9
+
+  # This vulnerability does not affect UDS as we do not instantiate a rekor client
+  - vulnerability: GHSA-frqx-jfcm-6jjr

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,3 +1,6 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
 ignore:
   # This vulnerability does not affect UDS as we do not instantiate a rekor client
   - vulnerability: GHSA-2h5h-59f5-c5x9


### PR DESCRIPTION
Reverts defenseunicorns/uds-cli#961

It turns out these tools are used in the release process, albeit in a sort of hidden way (to me at least), by goreleaser. 