### PR TITLE
feat: add an install.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Recommended installation method is with Brew:
 ```
 brew tap defenseunicorns/tap && brew install uds
 ```
+
+An `install.sh` file is also available for installation with curl (requires `sudo`):
+```
+curl -sSL https://raw.githubusercontent.com/defenseunicorns/uds-cli/main/install.sh | bash
+```
+
 UDS CLI binaries are also included with each [Github Release](https://github.com/defenseunicorns/uds-cli/releases)
 
 ## Official Documentation

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,7 @@ BINARY_NAME="uds"
 # Set full path to binary download
 FULL_PATH="releases/download/${VERSION}/uds-cli_${VERSION}_${OS}_${ARCH}"
 
-UDS_TMP_DIR="$(mktemp -dt uds-binary)"
+UDS_TMP_DIR="$(mktemp -d -t uds-binary-XXXXXX)"
 UDS_TMP_FILE="${UDS_TMP_DIR}/${BINARY_NAME}"
 
 # Download the binary

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,7 @@ BINARY_NAME="uds"
 # Set full path to binary download
 FULL_PATH="releases/download/${VERSION}/uds-cli_${VERSION}_${OS}_${ARCH}"
 
-UDS_TMP_DIR="$(mktemp -d -t uds-binary-XXXXXX)"
+UDS_TMP_DIR="$(mktemp -d -t uds-binary-XXXXXXXX)"
 UDS_TMP_FILE="${UDS_TMP_DIR}/${BINARY_NAME}"
 
 # Download the binary

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
 
 # Parse command-line arguments for debug flag
 DEBUG=false

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# Parse command-line arguments for debug flag
+DEBUG=false
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --debug) DEBUG=true ;;
+  esac
+  shift
+done
+
+# Function to print debug messages
+debug() {
+  if [ "${DEBUG}" = true ]; then
+    echo "$1"
+  fi
+}
+
+# Determine OS type (linux or macos)
+OS=$(uname | tr '[:upper:]' '[:lower:]')
+if [[ "${OS}" == "darwin" ]]; then
+  OS="Darwin"
+elif [[ "${OS}" == "linux" ]]; then
+  OS="Linux"
+else
+  debug "Unsupported OS: ${OS}"
+  exit 1
+fi
+
+# Determine architecture (amd64 or arm64)
+ARCH=$(uname -m)
+if [[ "${ARCH}" == "x86_64" ]]; then
+  ARCH="amd64"
+elif [[ "${ARCH}" == "arm64" || "${ARCH}" == "aarch64" ]]; then
+  ARCH="arm64"
+else
+  debug "Unsupported architecture: ${ARCH}"
+  exit 1
+fi
+
+# Construct the download URL
+URL="https://github.com/defenseunicorns/uds-cli"
+RELEASE_URL="${URL}/releases/latest"
+
+
+# Define the version to install
+VERSION=$(curl --tlsv1.2 --proto "=https" --fail --show-error -Ls -o /dev/null -w %{url_effective} ${RELEASE_URL} | grep -oE "[^/]+$" )
+debug "Version set to ${VERSION}"
+
+# Set binary name
+BINARY_NAME="uds"
+
+# Set full path to binary download
+FULL_PATH="releases/download/${VERSION}/uds-cli_${VERSION}_${OS}_${ARCH}"
+
+UDS_TMP_DIR="$(mktemp -dt uds-binary)"
+UDS_TMP_FILE="${UDS_TMP_DIR}/${BINARY_NAME}"
+
+# Download the binary
+debug "Downloading uds-cli for ${OS}-${ARCH}..."
+curl --tlsv1.2 --proto "=https" --fail --show-error -L -o "${UDS_TMP_FILE}" "${URL}/${FULL_PATH}"
+if [[ $? -ne 0 ]]; then
+  debug "Failed to download uds-cli from ${URL}/${FULL_PATH}"
+  exit 1
+fi
+
+# Make the binary executable
+chmod +x "${UDS_TMP_FILE}"
+
+# Define the installation directory and binary name
+INSTALL_DIR="/usr/local/bin"
+
+# Move the binary to the installation directory
+debug "Installing uds-cli to ${INSTALL_DIR}..."
+sudo mv "${UDS_TMP_FILE}" "${INSTALL_DIR}/"
+if [[ $? -ne 0 ]]; then
+  echo "Failed to move uds-cli to ${INSTALL_DIR}"
+  exit 1
+fi
+
+# Verify the installation
+debug "Verifying uds-cli installation..."
+"${INSTALL_DIR}/${BINARY_NAME}" version > /dev/null 2>&1
+if [[ $? -eq 0 ]]; then
+  debug "uds-cli ${VERSION} installed successfully!"
+else
+  debug "Installation failed."
+  exit 1
+fi


### PR DESCRIPTION
## Description

This pull request adds an install.sh script to automate the process of downloading the latest available binary for `uds-cli`. The script identifies the latest release, downloads the appropriate binary for the user’s operating system and architecture, and verifies it installs. This improves the user experience by simplifying the installation process.

## Related Issue

Relates to #1033 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
