### PR TITLE
chore: give golangci-lint an extra minute to complete

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@
 
 run:
   concurrency: 6
-  timeout: 5m
+  timeout: 6m
   tests: false
 issues:
   # Maximum issues count per one linter.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     rev: v1.62.2
     hooks:
       - id: golangci-lint
-        args: [--timeout=5m]
+        args: [--timeout=6m]
   - repo: local
     hooks:
       - id: check-docs-and-schema


### PR DESCRIPTION
## Description

Sometimes, for _reasons_, the `pre-commit` linting check will fail because the `golangci-lint` step takes over [5 minutes in CI](https://github.com/defenseunicorns/uds-cli/actions/runs/12378236202/job/34549623374?pr=1043#step:6:106), where as other times [it finishes just shy of 5 minutes](https://github.com/defenseunicorns/uds-cli/actions/runs/12378278826/job/34549772864?pr=1029#step:6:106). 

In this PR we take an unscientific approach to fixing this by just giving it more time and bump the limit up 6 minutes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

