### PR TITLE
chore: set helm buildflags the way Zarf does

### DIFF
--- a/tasks.yaml
+++ b/tasks.yaml
@@ -37,6 +37,18 @@ tasks:
         mute: true
         setVariables:
           - name: CLI_VERSION
+      - cmd: go list -f '{{.Version}}' -m k8s.io/client-go | sed 's/^v//' | tr '.' ' '
+        mute: true
+        setVariables:
+          - name: K8S_MODULES_VER
+      - cmd: echo ${K8S_MODULES_VER} | awk '{print $$1 + 1}'
+        mute: true
+        setVariables:
+          - name: K8S_MODULES_MAJOR_VER
+      - cmd: echo ${K8S_MODULES_VER} | awk '{print substr($0, 3, 2)}'
+        mute: true
+        setVariables:
+          - name: K8S_MODULES_MINOR_VER
 
   - name: build-args
     description: generates the build args for building UDS CLI
@@ -44,6 +56,10 @@ tasks:
       - cmd: |
           cat <<EOF
           -s -w -X 'github.com/defenseunicorns/uds-cli/src/config.CLIVersion=${CLI_VERSION}' \
+            -X 'helm.sh/helm/v3/pkg/lint/rules.k8sVersionMajor=${K8S_MODULES_MAJOR_VER}' \
+            -X 'helm.sh/helm/v3/pkg/lint/rules.k8sVersionMinor=${K8S_MODULES_MINOR_VER}' \
+            -X 'helm.sh/helm/v3/pkg/chartutil.k8sVersionMajor=${K8S_MODULES_MAJOR_VER}' \
+            -X 'helm.sh/helm/v3/pkg/chartutil.k8sVersionMinor=${K8S_MODULES_MINOR_VER}' \
             -X 'github.com/zarf-dev/zarf/src/config.ActionsCommandZarfPrefix=zarf' \
             -X 'github.com/derailed/k9s/cmd.version=${K9S_VERSION}' \
             -X 'github.com/google/go-containerregistry/cmd/crane/cmd.Version=${CRANE_VERSION}' \


### PR DESCRIPTION
## Description

Without setting these buildflags, some `uds zarf` commands could produce different results than directly using `zarf` of the same version. See details for example.

<details>

```
❯ uds version               
v0.20.0

❯ uds zarf version                    
v0.45.0

❯ zarf version                    
v0.45.0

❯ uds zarf dev find-images -f upstream
[... omitted things ...]
 NOTE  Using build directory .
     [... omitted things ...]
     ERROR:  unable to find images: could not render the Helm template for [some chart]: error
             generating helm chart template: chart requires kubeVersion: >=1.24.0-0 which is incompatible with
             Kubernetes v1.20.0

❯ zarf dev find-images -f upstream    
[... omitted things ...]
 NOTE  Using build directory .
  [... omitted things ...]
components:

  - name: [some chart]
    images:
      - alpine
      - nats:2.10.19-alpine
      - [other images]
``` 

</details>


In this PR we add the necessary variables and buildflags to get the correct results in a similar manner to [how Zarf does](https://github.com/zarf-dev/zarf/blob/90b764bbe0fa4fdf2ace164ca10c2a899e1013a7/Makefile#L34-L36). 

<details>

```
❯ uds zarf dev find-images -f upstream    
[... omitted things ...]
 NOTE  Using build directory .
  [... omitted things ...]
components:

  - name: [some chart]
    images:
      - alpine
      - nats:2.10.19-alpine
      - [other images]
```

</details>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
