### PR TITLE
chore: embed tofu binary and expose 'plan' and 'apply'

### DIFF
--- a/.github/workflows/scan-lint.yaml
+++ b/.github/workflows/scan-lint.yaml
@@ -23,6 +23,11 @@ jobs:
       - name: Install golangci-lint
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.62.2
 
+      - name: Create temp tofu file to appease linter
+        run: |
+          mkdir -p src/cmd/bin
+          touch src/cmd/bin/tofu
+
       - name: Run pre-commit
         uses: pre-commit/action@576ff52938d158a24ac7e009dfa94b1455e7df99 #
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ out.txt
 src/cmd/bin
 src/cmd/certs
 *.pem
+bin/
+tofu

--- a/src/cmd/internal.go
+++ b/src/cmd/internal.go
@@ -61,6 +61,8 @@ var genCLIDocs = &cobra.Command{
 
 		rootCmd.RemoveCommand(zarfCli)
 		rootCmd.RemoveCommand(scanCmd)
+		rootCmd.RemoveCommand(planCmd)
+		rootCmd.RemoveCommand(applyCmd)
 
 		// Set the default value for the uds-cache flag (otherwise this defaults to the user's home directory)
 		rootCmd.Flag("uds-cache").DefValue = "~/.uds-cache"

--- a/src/config/lang/lang.go
+++ b/src/config/lang/lang.go
@@ -52,7 +52,6 @@ const (
 	CmdBundleDeployFlagRef      = "Specify which zarf package ref you want to deploy. By default the ref set in the bundle yaml is used."
 
 	// bundle plan
-	//TODO: @JPERRY come up with better strings for here..
 	CmdBundlePlanShort = "Generate a Tofu execution plan"
 
 	// bundle plan

--- a/src/config/lang/lang.go
+++ b/src/config/lang/lang.go
@@ -51,6 +51,13 @@ const (
 	CmdBundleDeployFlagRetries  = "Specify the number of retries for package deployments (applies to all pkgs in a bundle)"
 	CmdBundleDeployFlagRef      = "Specify which zarf package ref you want to deploy. By default the ref set in the bundle yaml is used."
 
+	// bundle plan
+	//TODO: @JPERRY come up with better strings for here..
+	CmdBundlePlanShort = "Generate a Tofu execution plan"
+
+	// bundle plan
+	CmdBundleApplyShort = "Create or update infrastructure with Tofu"
+
 	// bundle inspect
 	CmdBundleInspectShort             = "Display the metadata of a bundle"
 	CmdBundleInspectFlagKey           = "Path to a public key file that will be used to validate a signed bundle"

--- a/src/config/lang/lang.go
+++ b/src/config/lang/lang.go
@@ -54,7 +54,7 @@ const (
 	// bundle plan
 	CmdBundlePlanShort = "Generate a Tofu execution plan"
 
-	// bundle plan
+	// bundle apply
 	CmdBundleApplyShort = "Create or update infrastructure with Tofu"
 
 	// bundle inspect

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -59,7 +59,8 @@ tasks:
   - name: copy-tofu-bin
     description: download tofu for go:embed
     actions:
-      - cmd: cp -Lr $(which tofu) src/cmd/bin/
+      - cmd: mkdir -p src/cmd/bin
+      - cmd: cp -Lf $(which tofu) src/cmd/bin/
 
   - name: build-all
     description: build all the CLI binaries and gen checksums

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -54,6 +54,13 @@ tasks:
         setVariables:
           - name: BUILD_ARGS
 
+  # TODO: This is a naive (AND BROKEN!!!) solution. This will only work for a single architecture.
+  #       We need to create subcommands to install specific arch + OS versions of Tofu
+  - name: copy-tofu-bin
+    description: download tofu for go:embed
+    actions:
+      - cmd: cp -Lr $(which tofu) src/cmd/bin/
+
   - name: build-all
     description: build all the CLI binaries and gen checksums
     actions:
@@ -68,6 +75,7 @@ tasks:
     actions:
       - task: get-versions
       - task: build-args
+      - task: copy-tofu-bin
       - cmd: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="${BUILD_ARGS}" -o build/uds main.go
 
   - name: build-cli-linux-arm
@@ -75,6 +83,7 @@ tasks:
     actions:
       - task: get-versions
       - task: build-args
+      - task: copy-tofu-bin
       - cmd: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="${BUILD_ARGS}" -o build/uds-arm main.go
 
   - name: build-cli-mac-intel
@@ -82,6 +91,7 @@ tasks:
     actions:
       - task: get-versions
       - task: build-args
+      - task: copy-tofu-bin
       - cmd: GOOS=darwin GOARCH=amd64 go build -ldflags="${BUILD_ARGS}" -o build/uds-mac-intel main.go
 
   - name: build-cli-mac-apple
@@ -89,4 +99,5 @@ tasks:
     actions:
       - task: get-versions
       - task: build-args
+      - task: copy-tofu-bin
       - cmd: GOOS=darwin GOARCH=arm64 go build -ldflags="${BUILD_ARGS}" -o build/uds-mac-apple main.go

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -54,13 +54,41 @@ tasks:
         setVariables:
           - name: BUILD_ARGS
 
-  # TODO: This is a naive (AND BROKEN!!!) solution. This will only work for a single architecture.
-  #       We need to create subcommands to install specific arch + OS versions of Tofu
-  - name: copy-tofu-bin
+  - name: download-tofu-mac-intel
     description: download tofu for go:embed
     actions:
       - cmd: mkdir -p src/cmd/bin
-      - cmd: cp -Lf $(which tofu) src/cmd/bin/
+      - cmd: rm -f src/cmd/bin/tofu
+      - cmd: wget https://github.com/opentofu/opentofu/releases/download/v1.9.0/tofu_1.9.0_darwin_amd64.zip -O src/cmd/bin/tofu_1.9.0_darwin_amd64.zip
+      - cmd: unzip -p src/cmd/bin/tofu_1.9.0_darwin_amd64.zip tofu > src/cmd/bin/tofu
+      - cmd: rm src/cmd/bin/tofu_1.9.0_darwin_amd64.zip
+
+  - name: download-tofu-mac-apple
+    description: download tofu for go:embed
+    actions:
+      - cmd: mkdir -p src/cmd/bin
+      - cmd: rm -f src/cmd/bin/tofu
+      - cmd: wget https://github.com/opentofu/opentofu/releases/download/v1.9.0/tofu_1.9.0_darwin_arm64.zip -O src/cmd/bin/tofu_1.9.0_darwin_arm64.zip
+      - cmd: unzip -p src/cmd/bin/tofu_1.9.0_darwin_arm64.zip tofu > src/cmd/bin/tofu
+      - cmd: rm src/cmd/bin/tofu_1.9.0_darwin_arm64.zip
+
+  - name: download-tofu-linux-arm
+    description: download tofu for go:embed
+    actions:
+      - cmd: mkdir -p src/cmd/bin
+      - cmd: rm -f src/cmd/bin/tofu
+      - cmd: wget https://github.com/opentofu/opentofu/releases/download/v1.9.0/tofu_1.9.0_linux_arm64.zip -O src/cmd/bin/tofu_1.9.0_linux_arm64.zip
+      - cmd: unzip -p src/cmd/bin/tofu_1.9.0_linux_arm64.zip tofu > src/cmd/bin/tofu
+      - cmd: rm src/cmd/bin/tofu_1.9.0_linux_arm64.zip
+
+  - name: download-tofu-linux-amd
+    description: download tofu for go:embed
+    actions:
+      - cmd: mkdir -p src/cmd/bin
+      - cmd: rm -f src/cmd/bin/tofu
+      - cmd: wget https://github.com/opentofu/opentofu/releases/download/v1.9.0/tofu_1.9.0_linux_amd64.zip -O src/cmd/bin/tofu_1.9.0_linux_amd64.zip
+      - cmd: unzip -p src/cmd/bin/tofu_1.9.0_linux_amd64.zip tofu > src/cmd/bin/tofu
+      - cmd: rm src/cmd/bin/tofu_1.9.0_linux_amd64.zip
 
   - name: build-all
     description: build all the CLI binaries and gen checksums
@@ -76,7 +104,7 @@ tasks:
     actions:
       - task: get-versions
       - task: build-args
-      - task: copy-tofu-bin
+      - task: download-tofu-linux-amd
       - cmd: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="${BUILD_ARGS}" -o build/uds main.go
 
   - name: build-cli-linux-arm
@@ -84,7 +112,7 @@ tasks:
     actions:
       - task: get-versions
       - task: build-args
-      - task: copy-tofu-bin
+      - task: download-tofu-linux-arm
       - cmd: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="${BUILD_ARGS}" -o build/uds-arm main.go
 
   - name: build-cli-mac-intel
@@ -92,7 +120,7 @@ tasks:
     actions:
       - task: get-versions
       - task: build-args
-      - task: copy-tofu-bin
+      - task: download-tofu-mac-intel
       - cmd: GOOS=darwin GOARCH=amd64 go build -ldflags="${BUILD_ARGS}" -o build/uds-mac-intel main.go
 
   - name: build-cli-mac-apple
@@ -100,5 +128,5 @@ tasks:
     actions:
       - task: get-versions
       - task: build-args
-      - task: copy-tofu-bin
+      - task: download-tofu-mac-apple
       - cmd: GOOS=darwin GOARCH=arm64 go build -ldflags="${BUILD_ARGS}" -o build/uds-mac-apple main.go

--- a/tasks/docs.yaml
+++ b/tasks/docs.yaml
@@ -5,6 +5,8 @@ tasks:
   - name: update
     description: updates the CLI docs
     actions:
+      - cmd: mkdir -p src/cmd/bin/
+      - cmd: touch src/cmd/bin/tofu
       - cmd: ./hack/generate-docs.sh
 
   - name: test

--- a/tasks/schema.yaml
+++ b/tasks/schema.yaml
@@ -5,6 +5,8 @@ tasks:
   - name: update
     description: updates the JSON schema
     actions:
+      - cmd: mkdir -p src/cmd/bin/
+      - cmd: touch src/cmd/bin/tofu
       - cmd: ./hack/generate-schema.sh
 
   - name: test

--- a/tasks/tests.yaml
+++ b/tasks/tests.yaml
@@ -5,6 +5,8 @@ tasks:
   - name: unit
     description: run all the unit tests
     actions:
+      - cmd: mkdir -p src/cmd/bin
+      - cmd: touch src/cmd/bin/tofu
       - cmd: go test ./... -failfast -v -timeout 5m
         dir: src/pkg
       - cmd: go test ./... -failfast -v -timeout 5m


### PR DESCRIPTION
## Description

Working towards embedding the `tofu` binary within the UDS CLI. This embedded binary currently only exposes the `tofu plan (uds plan)` and `tofu apply (uds apply)` subcommands.


TODO: 
- [x] Implement a way to ensure the Tofu binary is in the correct location at build time so we can `go:embed` the binary into our code. Right now we only have a naive implementation that makes the following assumptions:
  1. `tofu` is somewhere on your path
  2. You are ONLY building the UDS CLI for your specific arch (since it is ONLY using the already existing tofu for your arch) 


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
