### PR TITLE
feat: parse uds_bundle_metadata resource

### DIFF
--- a/src/pkg/tfparser/parser_test.go
+++ b/src/pkg/tfparser/parser_test.go
@@ -57,7 +57,7 @@ resource "uds_package" "prometheus" {
 				Providers: map[string]Provider{
 					"uds": {
 						Source:  "defenseunicorns/uds",
-						Version: "0.1.0",
+						Version: stringPtr("0.1.0"),
 					},
 				},
 				Packages: []Packages{
@@ -132,11 +132,11 @@ resource "aws_instance" "test" {
 				Providers: map[string]Provider{
 					"uds": {
 						Source:  "defenseunicorns/uds",
-						Version: "0.1.0",
+						Version: stringPtr("0.1.0"),
 					},
 					"aws": {
 						Source:  "hashicorp/aws",
-						Version: "4.0.0",
+						Version: stringPtr("4.0.0"),
 					},
 				},
 				Packages: []Packages{
@@ -171,18 +171,16 @@ terraform {
 				Providers: map[string]Provider{
 					"uds": {
 						Source:  "defenseunicorns/uds",
-						Version: "0.1.0",
+						Version: stringPtr("0.1.0"),
 					},
 					"aws": {
 						Source:  "hashicorp/aws",
-						Version: "4.0.0",
+						Version: stringPtr("4.0.0"),
 					},
 				},
-				Packages: []Packages{},
 			},
 			wantErr: false,
 		},
-
 		{
 			name: "invalid metadata",
 			content: `
@@ -194,6 +192,42 @@ resource "uds_bundle_metadata" "basic" {
 `,
 
 			wantErr: true,
+		},
+		{
+			name: "invalid required providers",
+			content: `
+terraform {
+  required_providers {
+    uds = {
+    	version = "0.1.0"
+    }
+  }
+}
+
+provider "uds" {}
+`,
+			wantErr: true,
+		},
+		{
+			name: "source with no version is valid configuration",
+			content: `
+terraform {
+  required_providers {
+    uds = {
+      source = "defenseunicorns/uds"
+      // version = "0.1.0"
+    }
+  }
+}
+`,
+			expected: &TerraformConfig{
+				Providers: map[string]Provider{
+					"uds": {
+						Source: "defenseunicorns/uds",
+					},
+				},
+			},
+			wantErr: false,
 		},
 	}
 
@@ -224,8 +258,4 @@ resource "uds_bundle_metadata" "basic" {
 			}
 		})
 	}
-}
-
-func stringPtr(s string) *string {
-	return &s
 }

--- a/src/pkg/tfparser/parser_test.go
+++ b/src/pkg/tfparser/parser_test.go
@@ -35,6 +35,12 @@ terraform {
 
 provider "uds" {}
 
+resource "uds_bundle_metadata" "basic" {
+  kind        = "UDSBundle"
+  version     = "0.1.0"
+  description = "This is a basic bundle"
+}
+
 resource "uds_package" "init" {
   oci_url = "ghcr.io/zarf-dev/packages/init@v0.45.0"
   ref = "v0.45.0"
@@ -66,6 +72,12 @@ resource "uds_package" "prometheus" {
 						OCIUrl: "localhost:888/prometheus@v0.1.0",
 						Type:   "uds_package",
 					},
+				},
+				Metadata: &BundleMetadata{
+					Kind:        "UDSBundle",
+					Name:        "basic",
+					Version:     "0.1.0",
+					Description: stringPtr("This is a basic bundle"),
 				},
 			},
 			wantErr: false,
@@ -170,6 +182,19 @@ terraform {
 			},
 			wantErr: false,
 		},
+
+		{
+			name: "invalid metadata",
+			content: `
+resource "uds_bundle_metadata" "basic" {
+  kind        = "UDSBundle"
+  // missing version
+  description = "This is a basic bundle"
+}
+`,
+
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -199,4 +224,8 @@ terraform {
 			}
 		})
 	}
+}
+
+func stringPtr(s string) *string {
+	return &s
 }


### PR DESCRIPTION
## Description

This PR adds to the `tfparser` to extract the bundle metadata from the `uds_bundle_metadata` resource, defined like so:

```hcl
resource "uds_bundle_metadata" "basic" {
  kind        = "UDSBundle"
  version     = "0.1.0"
  description = "This is a basic bundle"
}
```

NOTE: also fix an issue where the parser would panic if something it thought was required was missing (ex `version` in the `required_providers` block)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
