### PR TITLE
feat: add 'dev tofu-create' command to build bundles from a uds-bundle.tf config

### DIFF
--- a/docs/reference/CLI/commands/uds_dev_tofu-create.md
+++ b/docs/reference/CLI/commands/uds_dev_tofu-create.md
@@ -1,15 +1,19 @@
 ---
-title: uds dev
-description: UDS CLI command reference for <code>uds dev</code>.
+title: uds dev tofu-create
+description: UDS CLI command reference for <code>uds dev tofu-create</code>.
 ---
-## uds dev
+## uds dev tofu-create
 
-[beta] Commands useful for developing bundles
+create bundle from a uds-bundle.tf config
+
+```
+uds dev tofu-create [DIRECTORY] [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for dev
+  -h, --help   help for tofu-create
 ```
 
 ### Options inherited from parent commands
@@ -28,8 +32,5 @@ description: UDS CLI command reference for <code>uds dev</code>.
 
 ### SEE ALSO
 
-* [uds](/reference/cli/commands/uds/)	 - CLI for UDS Bundles
-* [uds dev deploy](/reference/cli/commands/uds_dev_deploy/)	 - [beta] Creates and deploys a UDS bundle in dev mode
-* [uds dev extract](/reference/cli/commands/uds_dev_extract/)	 - [alpha] Extract the Zarf Package tarballs from a Bundle
-* [uds dev tofu-create](/reference/cli/commands/uds_dev_tofu-create/)	 - create bundle from a uds-bundle.tf config
+* [uds dev](/reference/cli/commands/uds_dev/)	 - [beta] Commands useful for developing bundles
 

--- a/src/cmd/common.go
+++ b/src/cmd/common.go
@@ -92,6 +92,23 @@ func configureZarf() {
 	}
 }
 
+func setTofuFile(args []string) error {
+	pathToTofuFile := ""
+	if len(args) > 0 {
+		if !helpers.IsDir(args[0]) {
+			return fmt.Errorf("(%q) is not a valid path to a directory", args[0])
+		}
+		pathToTofuFile = filepath.Join(args[0])
+	}
+
+	if _, err := os.Stat(filepath.Join(pathToTofuFile, config.BundleTF)); err != nil {
+		return fmt.Errorf("%s not found", config.BundleTF)
+	}
+	bundleCfg.CreateOpts.BundleFile = config.BundleTF
+
+	return nil
+}
+
 func setBundleFile(args []string) error {
 	pathToBundleFile := ""
 	if len(args) > 0 {

--- a/src/cmd/common.go
+++ b/src/cmd/common.go
@@ -93,19 +93,19 @@ func configureZarf() {
 }
 
 func setTofuFile(args []string) error {
-	pathToTofuFile := ""
+	pathToTofuDir := ""
 	if len(args) > 0 {
 		if !helpers.IsDir(args[0]) {
 			return fmt.Errorf("(%q) is not a valid path to a directory", args[0])
 		}
-		pathToTofuFile = filepath.Join(args[0])
+		pathToTofuDir = filepath.Join(args[0])
 	}
 
-	if _, err := os.Stat(filepath.Join(pathToTofuFile, config.BundleTF)); err != nil {
+	tofuFilePath := filepath.Join(pathToTofuDir, config.BundleTF)
+	if _, err := os.Stat(tofuFilePath); err != nil {
 		return fmt.Errorf("%s not found", config.BundleTF)
 	}
-	bundleCfg.CreateOpts.BundleFile = config.BundleTF
-
+	bundleCfg.CreateOpts.BundleFile = tofuFilePath
 	return nil
 }
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -22,7 +22,8 @@ const (
 	BundleYAML = "uds-bundle.yaml"
 
 	// BundleTF is the string for uds-bundle.tf
-	BundleTF = "uds-bundle.tf"
+	BundleTF       = "uds-bundle.tf"
+	BundleTFConfig = "uds-tf-config.yaml"
 
 	// BundlePrefix is the prefix for compiled uds bundles
 	BundlePrefix = "uds-bundle-"

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -21,6 +21,9 @@ const (
 	// BundleYAML is the string for uds-bundle.yaml
 	BundleYAML = "uds-bundle.yaml"
 
+	// BundleTF is the string for uds-bundle.tf
+	BundleTF = "uds-bundle.tf"
+
 	// BundlePrefix is the prefix for compiled uds bundles
 	BundlePrefix = "uds-bundle-"
 

--- a/src/pkg/bundle/create.go
+++ b/src/pkg/bundle/create.go
@@ -33,7 +33,6 @@ func (b *Bundle) Create() error {
 			return err
 		}
 
-		// Fake metadata for now
 		b.bundle.Kind = "UDSBundle"
 		b.bundle.Metadata = types.UDSMetadata{
 			Name:         tfConfig.Metadata.Name,
@@ -42,7 +41,7 @@ func (b *Bundle) Create() error {
 			Description:  *tfConfig.Metadata.Description,
 		}
 
-		// Parse each Package resoruce and convert it types.Package type
+		// Parse each tfparser.Packages resource and convert it to types.Package type
 		for _, pkg := range tfConfig.Packages {
 			newPackage := types.Package{
 				Name:       pkg.Name,
@@ -120,7 +119,7 @@ func (b *Bundle) Create() error {
 		}
 	}
 
-	// TODO: @JPERRY this dev eploy block has not been validated to work with tofu based bundles yet
+	// TODO: @JPERRY this dev deploy block has not been validated to work with tofu based bundles yet
 	// for dev mode update package ref for local bundles, refs for remote bundles updated on deploy
 	if config.Dev && len(b.cfg.DevDeployOpts.Ref) != 0 {
 		for i, pkg := range b.bundle.Packages {

--- a/src/pkg/bundle/create.go
+++ b/src/pkg/bundle/create.go
@@ -28,7 +28,7 @@ func (b *Bundle) Create() error {
 	if b.cfg.IsTofu {
 		// read the .tf data to determine which resources (packages) we are creating
 		// TODO: @JEPRRY consider making a helper function for this
-		tfConfig, err := tfparser.ParseFile(filepath.Join(b.cfg.CreateOpts.SourceDirectory, b.cfg.CreateOpts.BundleFile))
+		tfConfig, err := tfparser.ParseFile(b.cfg.CreateOpts.BundleFile)
 		if err != nil {
 			return err
 		}

--- a/src/pkg/bundle/create.go
+++ b/src/pkg/bundle/create.go
@@ -36,9 +36,10 @@ func (b *Bundle) Create() error {
 		// Fake metadata for now
 		b.bundle.Kind = "UDSBundle"
 		b.bundle.Metadata = types.UDSMetadata{
-			Name:         "test-tf-bundle",
-			Version:      "0.0.0",
-			Architecture: "arm64",
+			Name:         tfConfig.Metadata.Name,
+			Version:      tfConfig.Metadata.Version,
+			Architecture: *tfConfig.Metadata.Architecture,
+			Description:  *tfConfig.Metadata.Description,
 		}
 
 		// Parse each Package resoruce and convert it types.Package type

--- a/src/pkg/bundler/bundler.go
+++ b/src/pkg/bundler/bundler.go
@@ -15,6 +15,7 @@ type Bundler struct {
 	output    string
 	tmpDstDir string
 	sourceDir string
+	isTofu    bool
 }
 
 // Pusher is the interface for pushing bundles
@@ -27,6 +28,7 @@ type Options struct {
 	Output    string
 	TmpDstDir string
 	SourceDir string
+	IsTofu    bool
 }
 
 // NewBundler creates a new bundler
@@ -36,6 +38,7 @@ func NewBundler(opts *Options) *Bundler {
 		output:    opts.Output,
 		tmpDstDir: opts.TmpDstDir,
 		sourceDir: opts.SourceDir,
+		isTofu:    opts.IsTofu,
 	}
 	return &b
 }
@@ -43,13 +46,14 @@ func NewBundler(opts *Options) *Bundler {
 // Create creates a bundle
 func (b *Bundler) Create() error {
 	if utils.IsRegistryURL(b.output) {
+		// TODO: @JPERRY Remote bundles have not been implemented to work with tofu based bundles yet
 		remoteBundle := NewRemoteBundle(&RemoteBundleOpts{Bundle: b.bundle, Output: b.output})
 		err := remoteBundle.create(nil)
 		if err != nil {
 			return err
 		}
 	} else {
-		localBundle := NewLocalBundle(&LocalBundleOpts{Bundle: b.bundle, TmpDstDir: b.tmpDstDir, SourceDir: b.sourceDir, OutputDir: b.output})
+		localBundle := NewLocalBundle(&LocalBundleOpts{Bundle: b.bundle, TmpDstDir: b.tmpDstDir, SourceDir: b.sourceDir, OutputDir: b.output, IsTofu: b.isTofu})
 		err := localBundle.create(nil)
 		if err != nil {
 			return err

--- a/src/pkg/bundler/localbundle.go
+++ b/src/pkg/bundler/localbundle.go
@@ -110,18 +110,15 @@ func (lo *LocalBundle) create(signature []byte) error {
 
 	message.HeaderInfof("🚧 Building Bundle")
 
+	// push bundle manifest to OCI stoer
 	var bundleManifestDesc ocispec.Descriptor
 	if lo.isTofu {
 		bundleManifestDesc, err = pushBundleTFToStore(store, filepath.Join(lo.sourceDir, config.BundleTF))
-		if err != nil {
-			return err
-		}
 	} else {
-		// push uds-bundle.yaml to OCI store
 		bundleManifestDesc, err = pushBundleYAMLToStore(store, bundle)
-		if err != nil {
-			return err
-		}
+	}
+	if err != nil {
+		return err
 	}
 
 	// append uds-bundle.yaml layer to rootManifest and grab path for archiving

--- a/src/pkg/bundler/localbundle.go
+++ b/src/pkg/bundler/localbundle.go
@@ -112,7 +112,7 @@ func (lo *LocalBundle) create(signature []byte) error {
 
 	var bundleManifestDesc ocispec.Descriptor
 	if lo.isTofu {
-		bundleManifestDesc, err = pushBundleTFToStore(store, bundle)
+		bundleManifestDesc, err = pushBundleTFToStore(store, filepath.Join(lo.sourceDir, config.BundleTF))
 		if err != nil {
 			return err
 		}
@@ -217,8 +217,8 @@ func pushBundleTFConfigToStore(store *ocistore.Store, bundle *types.UDSBundle) (
 	return configYAMLDesc, err
 }
 
-func pushBundleTFToStore(store *ocistore.Store, _ *types.UDSBundle) (ocispec.Descriptor, error) {
-	bundleTFBytes, err := os.ReadFile(config.BundleTF)
+func pushBundleTFToStore(store *ocistore.Store, bundleSourcePath string) (ocispec.Descriptor, error) {
+	bundleTFBytes, err := os.ReadFile(bundleSourcePath)
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}

--- a/src/types/options.go
+++ b/src/types/options.go
@@ -13,6 +13,7 @@ type BundleConfig struct {
 	InspectOpts   BundleInspectOptions
 	RemoveOpts    BundleRemoveOptions
 	DevDeployOpts BundleDevDeployOptions
+	IsTofu        bool
 }
 
 // BundleCreateOptions is the options for the bundler.Create() function

--- a/src/types/options.go
+++ b/src/types/options.go
@@ -93,3 +93,9 @@ type BundleDevDeployOptions struct {
 // PathMap is a map of either absolute paths to relative paths or relative paths to absolute paths
 // used to map filenames during local bundle tarball creation
 type PathMap map[string]string
+
+// TFConfigHelper is a subset of the Bundle struct, this is where configs will go that the TF bundle will need when deploying (such as shasum of the package manifest within the OCI tarball)
+// I appologize for such a long comment - I didn't have the ~time~ understanding to write a short one
+type TFConfigHelper struct {
+	Packages []Package `json:"packages" jsonschema:"description=List of Zarf packages"`
+}


### PR DESCRIPTION
## Description

Parses `uds-bundle.tf` files and generates a `uds-bundle-fake-metadata-0.0.0.tar.zst` tarball bundle.

There is (a lot) more work that will need to be implemented to ensure full feature parity with the standard `uds create` from a `uds-bundle.yaml` file, but I believe this PR offers a good starting point.

The changes in this PR add additional config booleans to check against so we do not change the behavior of a standard `uds create` command.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
😰😬🙈
- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
