### PR TITLE
chore: update 'dev extract' command to work with bundles built from a uds-bundle.tf source

### DIFF
--- a/docs/reference/CLI/commands/uds_dev_extract.md
+++ b/docs/reference/CLI/commands/uds_dev_extract.md
@@ -13,7 +13,8 @@ uds dev extract {BUNDLE_TARBALL|OCI_REF} [EXTRACT_DIR] [flags]
 ### Options
 
 ```
-  -h, --help   help for extract
+  -h, --help      help for extract
+      --is-tofu   indicates if the package was built from a uds-bundle.tf
 ```
 
 ### Options inherited from parent commands

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -163,11 +163,16 @@ var extractCmd = &cobra.Command{
 			return err
 		}
 
-		// NOTE: I am obviously not chcking any of the outputs here, but this call is what sets
-		//       bndleClient.cfg.DeployOpts.Source which we need later...
-		_, _, _, err = bndlClient.PreDeployValidation()
-		if err != nil {
-			return err
+		if bundleCfg.IsTofu {
+			_, _, _, err = bndlClient.PreDeployValidationTF()
+			if err != nil {
+				return err
+			}
+		} else {
+			_, _, _, err = bndlClient.PreDeployValidation()
+			if err != nil {
+				return err
+			}
 		}
 
 		outputDir := "."
@@ -228,5 +233,6 @@ func init() {
 	devDeployCmd.Flags().StringToStringVar(&bundleCfg.DeployOpts.SetVariables, "set", nil, lang.CmdBundleDeployFlagSet)
 
 	devCmd.AddCommand(extractCmd)
+	extractCmd.Flags().BoolVar(&bundleCfg.IsTofu, "is-tofu", false, "indicates if the package was built from a uds-bundle.tf")
 	devCmd.AddCommand(tofuCreateCmd)
 }

--- a/src/cmd/dev.go
+++ b/src/cmd/dev.go
@@ -165,14 +165,11 @@ var extractCmd = &cobra.Command{
 
 		if bundleCfg.IsTofu {
 			_, _, _, err = bndlClient.PreDeployValidationTF()
-			if err != nil {
-				return err
-			}
 		} else {
 			_, _, _, err = bndlClient.PreDeployValidation()
-			if err != nil {
-				return err
-			}
+		}
+		if err != nil {
+			return err
 		}
 
 		outputDir := "."

--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -17,6 +17,7 @@ import (
 	"github.com/defenseunicorns/pkg/oci"
 	"github.com/defenseunicorns/uds-cli/src/config"
 	"github.com/defenseunicorns/uds-cli/src/pkg/bundler/fetcher"
+	"github.com/defenseunicorns/uds-cli/src/pkg/tfparser"
 	"github.com/defenseunicorns/uds-cli/src/pkg/utils"
 	"github.com/defenseunicorns/uds-cli/src/types"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -32,7 +33,8 @@ type Bundle struct {
 	// cfg is the Bundle's configuration options
 	cfg *types.BundleConfig
 	// bundle is the bundle's metadata read into memory
-	bundle types.UDSBundle
+	bundle   types.UDSBundle
+	tfConfig tfparser.TerraformConfig
 	// tmp is the temporary directory used by the Bundle cleaned up with ClearPaths()
 	tmp string
 }

--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -254,7 +254,7 @@ func (b *Bundle) PreDeployValidationTF() (string, string, string, error) {
 	config.BundleAlwaysPull = []string{config.BundleTF, config.BundleTFConfig}
 	filepaths, err := provider.LoadBundleMetadata()
 	if err != nil {
-		message.Warnf("@JPERRY error when loading the metadtaa of the .tf bundle: %s\n", err.Error())
+		message.Warnf("unable to load the metadata of the .tf bundle: %s\n", err.Error())
 		return "", "", "", err
 	}
 
@@ -272,7 +272,7 @@ func (b *Bundle) PreDeployValidationTF() (string, string, string, error) {
 	b.tfConfig = *tfConfig
 
 	//read the file at conifg.BundleTFConfig and unmarshal it
-	message.Infof("Reading uds-tf-config.yam at %s\n", filepaths[config.BundleTFConfig])
+	message.Infof("Reading uds-tf-config.yaml at %s\n", filepaths[config.BundleTFConfig])
 	bundleTFConfigYAML, err := os.ReadFile(filepaths[config.BundleTFConfig])
 	if err != nil {
 		return "", "", "", err


### PR DESCRIPTION
## Description

Bundles created from a `uds-bundle.tf` source file store the SHA256 checksum of the Zarf Package manifest in different place than bundles created from a `uds-bundle.yaml`


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging
😰😬🙈
- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
