### PR TITLE
chore: regroup and unlimit renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,12 +5,10 @@
   "extends": [
     "config:recommended"
   ],
+  "branchConcurrentLimit": 0,
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
   "ignorePaths": [],
-  "timezone": "America/New_York",
-  "schedule": [
-    "after 12pm every weekday",
-    "before 11am every weekday"
-  ],
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "Renovate Dashboard 🤖",
   "rebaseWhen": "conflicted",
@@ -23,25 +21,27 @@
   ],
   "packageRules": [
     {
+      "matchFileNames": [".github/**"],
+      "groupName": "github-actions",
+      "commitMessageTopic": "github actions"
+    },
+    {
+      "matchFileNames": ["src/test/**", "tasks/**"],
+      "groupName": "test-dependencies",
+      "commitMessageTopic": "test dependencies"
+    },
+    {
+      "matchFileNames": ["go.mod", "go.sum"],
+      "groupName": "go-dependencies",
+      "commitMessageTopic": "go dependencies"
+    },
+    {
       "matchPackageNames": [
         "zarf-dev/zarf",
         "github.com/zarf-dev/zarf"
       ],
-      "groupName": "zarf"
-    },
-    {
-      "matchPackageNames": [
-        "stefanprodan/podinfo",
-        "github.com/stefanprodan/podinfo",
-        "podinfo"
-      ],
-      "groupName": "podinfo"
-    },
-    {
-      "matchFileNames": [
-        "action.yaml"
-      ],
-      "groupName": "actions"
+      "groupName": "zarf",
+      "commitMessageTopic": "zarf"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Description

This PR focuses on improving the experience with Renovate PRs. There are a few particular changes of note:
- Removing limits and schedule on renovate PRs: This allows PRs to be created quickly and as many as needed. Happy to re-add the schedule if that is the desire of the team.
- Updating the package rules to group dependencies into a few discrete buckets:
  - Github actions/workflows: anything under `.github`
  - Test dependencies: anything under `src/test` and `tasks`
  - Go dependencies: anything in `go.sum` and `go.mod` except zarf
  - Zarf: any zarf updates (regardless of file)

Based on a skim of the repo I think this covers all renovate updates, but these categories can be updated or expanded as needed. I validated this [on my repo](https://github.com/mjnagel/uds-cli/pulls) for an example of what this results in. Note that I reverted the latest renovate update for zarf to validate that update. Also note that this config still separates out major updates (note the separate github actions update for uds-common v1).

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
