### PR TITLE
chore: copy over our own save-logs

### DIFF
--- a/.github/actions/save-logs/action.yaml
+++ b/.github/actions/save-logs/action.yaml
@@ -1,0 +1,47 @@
+name: save-logs
+description: Save debug logs
+
+inputs:
+  suffix:
+    description: Suffix to append to the debug log
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Pull logs from containerd
+      run: |
+        CONTAINER_NAME="k3d-uds-server-0"
+        if docker ps | grep -q "$CONTAINER_NAME"; then
+          echo "Container $CONTAINER_NAME is running. Proceeding with log copy..."
+          docker cp ${CONTAINER_NAME}:/var/log/ /tmp/uds-containerd-logs
+        else
+          echo "Container $CONTAINER_NAME is not running. Skipping log copy."
+        fi
+      shell: bash
+
+    - name: Dump Node Logs
+      run: |
+        docker ps --filter "name=k3d" --format "{{.Names}}" | while read line; do
+          docker logs "$line" 2> /tmp/$line.log
+        done
+      shell: bash
+
+    - name: Fix log permissions
+      run: |
+        sudo chown $USER /tmp/zarf-*.log || echo ""
+        sudo chown $USER /tmp/uds-*.log || echo ""
+      shell: bash
+
+    - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+      with:
+        name: debug-log${{ inputs.suffix }}
+        path: |
+          /tmp/zarf-*.log
+          /tmp/uds-*.log
+          /tmp/maru-*.log
+          /tmp/debug-*.log
+          /tmp/uds-containerd-logs
+          /tmp/k3d-uds-*.log
+          /tmp/oscal-assessment-results.yaml

--- a/.github/actions/save-logs/action.yaml
+++ b/.github/actions/save-logs/action.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
 name: save-logs
 description: Save debug logs
 

--- a/.github/workflows/nightly-ghcr.yaml
+++ b/.github/workflows/nightly-ghcr.yaml
@@ -52,6 +52,6 @@ jobs:
 
       - name: Save logs
         if: always()
-        uses: defenseunicorns/uds-common/.github/actions/save-logs@e3008473beab00b12a94f9fcc7340124338d5c08 # v0.13.1
+        uses: ./.github/actions/save-logs
         with:
           suffix: nightly-ghcr

--- a/.github/workflows/parallel-tests.yaml
+++ b/.github/workflows/parallel-tests.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Save logs
         if: always()
-        uses: defenseunicorns/uds-common/.github/actions/save-logs@e3008473beab00b12a94f9fcc7340124338d5c08 # v0.13.1
+        uses: ./.github/actions/save-logs
         with:
           suffix: ${{ matrix.test }}
 
@@ -76,7 +76,7 @@ jobs:
 
       - name: Save logs
         if: always()
-        uses: defenseunicorns/uds-common/.github/actions/save-logs@e3008473beab00b12a94f9fcc7340124338d5c08 # v0.13.1
+        uses: ./.github/actions/save-logs
         with:
           suffix: test-dev
 
@@ -98,7 +98,7 @@ jobs:
 
       - name: Save logs
         if: always()
-        uses: defenseunicorns/uds-common/.github/actions/save-logs@e3008473beab00b12a94f9fcc7340124338d5c08 # v0.13.1
+        uses: ./.github/actions/save-logs
         with:
           suffix: test-variables
 
@@ -120,7 +120,7 @@ jobs:
 
       - name: Save logs
         if: always()
-        uses: defenseunicorns/uds-common/.github/actions/save-logs@e3008473beab00b12a94f9fcc7340124338d5c08 # v0.13.1
+        uses: ./.github/actions/save-logs
         with:
           suffix: test-optional-bundle
 
@@ -151,7 +151,7 @@ jobs:
 
       - name: Save logs
         if: always()
-        uses: defenseunicorns/uds-common/.github/actions/save-logs@e3008473beab00b12a94f9fcc7340124338d5c08 # v0.13.1
+        uses: ./.github/actions/save-logs
         with:
           suffix: test-vendor
 
@@ -177,6 +177,6 @@ jobs:
 
       - name: Save logs
         if: always()
-        uses: defenseunicorns/uds-common/.github/actions/save-logs@e3008473beab00b12a94f9fcc7340124338d5c08 # v0.13.1
+        uses: ./.github/actions/save-logs
         with:
           suffix: test-engine

--- a/.github/workflows/release-tests.yaml
+++ b/.github/workflows/release-tests.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Save logs
         if: always()
-        uses: defenseunicorns/uds-common/.github/actions/save-logs@e3008473beab00b12a94f9fcc7340124338d5c08 # v0.13.1
+        uses: ./.github/actions/save-logs
         with:
           suffix: test-ghcr
 
@@ -91,6 +91,6 @@ jobs:
 
       - name: Save logs
         if: always()
-        uses: defenseunicorns/uds-common/.github/actions/save-logs@e3008473beab00b12a94f9fcc7340124338d5c08 # v0.13.1
+        uses: ./.github/actions/save-logs
         with:
           suffix: smoke-test-${{ matrix.type }}

--- a/.github/workflows/test-schema-and-docs.yaml
+++ b/.github/workflows/test-schema-and-docs.yaml
@@ -29,6 +29,6 @@ jobs:
 
       - name: Save logs
         if: always()
-        uses: defenseunicorns/uds-common/.github/actions/save-logs@e3008473beab00b12a94f9fcc7340124338d5c08 # v0.13.1
+        uses: ./.github/actions/save-logs
         with:
           suffix: validate-schema-and-docs

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -41,6 +41,6 @@ jobs:
 
       - name: Save logs
         if: always()
-        uses: defenseunicorns/uds-common/.github/actions/save-logs@e3008473beab00b12a94f9fcc7340124338d5c08 # v0.13.1
+        uses: ./.github/actions/save-logs
         with:
           suffix: unit


### PR DESCRIPTION
## Description

Replaces our dependency on uds-common save-logs GitHub action that was removed a long time ago. 

## Related Issue

Closes https://github.com/defenseunicorns/uds-cli/pull/1074

<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
