### PR TITLE
chore: add deprecation warning to publish --version

### DIFF
--- a/.github/workflows/scan-lint.yaml
+++ b/.github/workflows/scan-lint.yaml
@@ -21,7 +21,7 @@ jobs:
         run: go install golang.org/x/tools/cmd/goimports@latest
 
       - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.62.2
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.5
 
       - name: Run pre-commit
         uses: pre-commit/action@576ff52938d158a24ac7e009dfa94b1455e7df99 #

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: go-imports
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.62.2
+    rev: v1.64.5
     hooks:
       - id: golangci-lint
         args: [--timeout=6m]

--- a/docs/reference/CLI/commands/uds_publish.md
+++ b/docs/reference/CLI/commands/uds_publish.md
@@ -14,7 +14,7 @@ uds publish [BUNDLE_TARBALL] [OCI_REF] [flags]
 
 ```
   -h, --help             help for publish
-  -v, --version string   Specify the version of the bundle to be published
+  -v, --version string   [Deprecated] Specify the version of the bundle to be published. This flag will be removed in a future version. Users should use the --version flag during creation to override the version defined in uds-bundle.yaml
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/CLI/quickstart-and-usage.md
+++ b/docs/reference/CLI/quickstart-and-usage.md
@@ -143,6 +143,7 @@ init:
 *To extract only the image names and de-dupe*:
 
 `uds inspect k3d-core-slim-dev:0.26.0 --list-images | yq '.[] | .[]'` | sort | uniq
+
 ```yaml
 docker.io/istio/pilot:1.22.3-distroless
 docker.io/istio/proxyv2:1.22.3-distroless
@@ -152,7 +153,6 @@ ghcr.io/zarf-dev/zarf/agent:v0.38.2
 library/registry:2.8.3
 quay.io/keycloak/keycloak:24.0.5
 ```
-
 
 #### Viewing SBOMs
 
@@ -177,6 +177,10 @@ Local bundles can be published to an OCI registry like so:
 As an example: `uds publish uds-bundle-example-arm64-0.0.1.tar.zst oci://ghcr.io/github_user`
 
 #### Tagging
+
+:::note
+Using the `version` flag with `uds publish` is deprecated, and will be removed in a future version. Users should use the `--version` flag in `uds create` to override the version specified in `uds-bundle.yaml`.
+:::
 
 Bundles, by default, are tagged based on the bundle version found in the metadata of the `uds-bundle.yaml` file. To override the default tag, you can use the `--version` flag like so:
 
@@ -310,7 +314,9 @@ In a bundle, variables can come from 6 sources. Those sources and their preceden
 That is to say, variables set using the `--set` flag take precedence over all other variable sources.
 
 ### Configuring Zarf Init Packages
+
 Zarf init packages that are typically deployed using `zarf init` have a few special flags that are attached to that command. These options can be configured like any other variable: specified in a `uds-config.yaml`, as an environment variable prefixed with `UDS_` or via the `--set` flag.
+
 ```yaml
 # uds-config.yaml
 variables:

--- a/src/cmd/uds.go
+++ b/src/cmd/uds.go
@@ -16,6 +16,8 @@ import (
 	"github.com/defenseunicorns/uds-cli/src/config/lang"
 	"github.com/defenseunicorns/uds-cli/src/pkg/bundle"
 	"github.com/spf13/cobra"
+
+	"github.com/zarf-dev/zarf/src/pkg/message"
 )
 
 var createCmd = &cobra.Command{
@@ -151,6 +153,10 @@ var publishCmd = &cobra.Command{
 	PreRunE: func(_ *cobra.Command, args []string) error {
 		if _, err := os.Stat(args[0]); err != nil {
 			return fmt.Errorf("first argument (%q) must be a valid local Bundle path: %s", args[0], err.Error())
+		}
+
+		if bundleCfg.PublishOpts.Version != "" {
+			message.Warnf("the --version flag is deprecated and will be removed in a future version")
 		}
 		return nil
 	},

--- a/src/config/lang/lang.go
+++ b/src/config/lang/lang.go
@@ -66,7 +66,7 @@ const (
 
 	// bundle publish
 	CmdPublishShort       = "Publish a bundle from the local file system to a remote registry"
-	CmdPublishVersionFlag = "Specify the version of the bundle to be published"
+	CmdPublishVersionFlag = "[Deprecated] Specify the version of the bundle to be published. This flag will be removed in a future version. Users should use the --version flag during creation to override the version defined in uds-bundle.yaml"
 
 	// bundle pull
 	CmdBundlePullShort      = "Pull a bundle from a remote registry and save to the local file system"

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -124,6 +124,7 @@ func TestBundleWithLocalAndRemotePkgs(t *testing.T) {
 	})
 
 	t.Run("test custom tags", func(t *testing.T) {
+		// TODO: the --version flag for publish is going away so we can remove this test when that happens
 		runCmd(t, fmt.Sprintf("publish %s %s --insecure --version my-custom-tag", bundlePath, bundleRef.Registry))
 		pull(t, "oci://localhost:888/test-local-and-remote:my-custom-tag", bundleTarballName)
 		runCmd(t, fmt.Sprintf("deploy %s --insecure --confirm", pulledBundlePath))


### PR DESCRIPTION
## Description

Deprecate the `--version` flag on the `publish` command, since it doesn't work as it was thought to. 

Also updates the `golangci-lint` version used in pre-commit, since it was failing for error code `-9` _for reasons_ but passes fine with an updated version.

## Related Issue

- related to #1008 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
