### PR TITLE
fix!: use provided public signing key to build bundles with local signed zarf packages

### DIFF
--- a/src/cmd/common.go
+++ b/src/cmd/common.go
@@ -73,7 +73,6 @@ func deploy(bndlClient *bundle.Bundle) error {
 
 // configureZarf copies configs from UDS-CLI to Zarf
 func configureZarf() {
-	zarfCLI.LogFormat = "legacy"
 	zarfConfig.CommonOptions = zarfTypes.ZarfCommonOptions{
 		Insecure:       config.CommonOptions.Insecure,
 		TempDirectory:  config.CommonOptions.TempDirectory,

--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -116,31 +116,9 @@ func (b *Bundle) ValidateBundleResources(spinner *message.Spinner) error {
 		}
 		var zarfYAML v1alpha1.ZarfPackage
 		var url string
-		ctx := context.TODO()
 		// if using a remote repository
-		// todo: refactor these hash checks using the fetcher
 		if pkg.Repository != "" {
 			url = fmt.Sprintf("%s:%s", pkg.Repository, pkg.Ref)
-			if strings.Contains(pkg.Ref, "@sha256:") {
-				url = fmt.Sprintf("%s:%s", pkg.Repository, pkg.Ref)
-			}
-
-			platform := ocispec.Platform{
-				Architecture: config.GetArch(),
-				OS:           oci.MultiOS,
-			}
-			remote, err := zoci.NewRemote(ctx, url, platform)
-			if err != nil {
-				return err
-			}
-			if err := remote.Repo().Reference.ValidateReferenceAsDigest(); err != nil {
-				manifestDesc, err := remote.ResolveRoot(ctx)
-				if err != nil {
-					return err
-				}
-				// todo: don't do this here, a "validate" fn shouldn't be modifying the bundle
-				bundle.Packages[idx].Ref = pkg.Ref + "@sha256:" + manifestDesc.Digest.Encoded()
-			}
 		} else {
 			// atm we don't support outputting a bundle with local pkgs outputting to OCI
 			if utils.IsRegistryURL(b.cfg.CreateOpts.Output) {

--- a/src/pkg/bundle/dev.go
+++ b/src/pkg/bundle/dev.go
@@ -69,7 +69,7 @@ func (b *Bundle) CreateZarfPkgs() error {
 				zarfCLI.Execute(context.TODO())
 
 				// NOTE: After executing the zarfCLI we need to reset the pterm stdout if we want logs..
-				pterm.SetDefaultOutput(os.Stdout)
+				pterm.SetDefaultOutput(os.Stderr)
 			}
 		}
 	}

--- a/src/pkg/bundle/dev.go
+++ b/src/pkg/bundle/dev.go
@@ -15,6 +15,8 @@ import (
 	"github.com/defenseunicorns/uds-cli/src/pkg/utils"
 	"github.com/defenseunicorns/uds-cli/src/types"
 
+	"github.com/pterm/pterm"
+
 	zarfCLI "github.com/zarf-dev/zarf/src/cmd"
 )
 
@@ -65,6 +67,9 @@ func (b *Bundle) CreateZarfPkgs() error {
 					os.Args = []string{"zarf", "package", "create", pkgDir, "--confirm", "-o", pkgDir, "--skip-sbom"}
 				}
 				zarfCLI.Execute(context.TODO())
+
+				// NOTE: After executing the zarfCLI we need to reset the pterm stdout if we want logs..
+				pterm.SetDefaultOutput(os.Stdout)
 			}
 		}
 	}

--- a/src/pkg/bundler/fetcher/common.go
+++ b/src/pkg/bundler/fetcher/common.go
@@ -99,3 +99,11 @@ func filterPkgPaths(pkgPaths *layout.PackagePaths, includeLayers []string, optio
 
 	return filteredPaths
 }
+
+func getAbsKeyPath(keyPath string, prefixDir string) (string, error) {
+	if keyPath == "" || filepath.IsAbs(keyPath) || helpers.IsURL(keyPath) {
+		return keyPath, nil
+	}
+
+	return filepath.Abs(filepath.Join(prefixDir, keyPath))
+}

--- a/src/pkg/bundler/fetcher/fetcher.go
+++ b/src/pkg/bundler/fetcher/fetcher.go
@@ -32,6 +32,7 @@ type Config struct {
 	NumPkgs            int
 	BundleRootManifest *ocispec.Manifest
 	Bundle             *types.UDSBundle
+	CreateSrcDir       string
 }
 
 // NewPkgFetcher creates a fetcher object to pull Zarf pkgs into a local bundle

--- a/src/pkg/bundler/fetcher/local.go
+++ b/src/pkg/bundler/fetcher/local.go
@@ -105,11 +105,17 @@ func (f *localFetcher) GetPkgMetadata() (v1alpha1.ZarfPackage, error) {
 // toBundle transfers a Zarf package to a given Bundle
 func (f *localFetcher) toBundle(pkgTmp string) ([]ocispec.Descriptor, error) {
 	ctx := context.TODO()
+	var err error
+	f.pkg.PublicKey, err = getAbsKeyPath(f.pkg.PublicKey, f.cfg.CreateSrcDir)
+	if err != nil {
+		return nil, err
+	}
 
 	// load pkg and layout of pkg paths
 	pkgSrc := zarfSources.TarballSource{
 		ZarfPackageOptions: &zarfTypes.ZarfPackageOptions{
 			PackageSource: f.pkg.Path,
+			PublicKeyPath: f.pkg.PublicKey,
 		},
 	}
 	pkg, pkgPaths, err := loadPkg(pkgTmp, &pkgSrc, f.pkg.OptionalComponents)

--- a/src/pkg/bundler/fetcher/local.go
+++ b/src/pkg/bundler/fetcher/local.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/defenseunicorns/pkg/oci"
 	"github.com/defenseunicorns/uds-cli/src/config"
@@ -220,7 +221,7 @@ func (f *localFetcher) toBundle(pkgTmp string) ([]ocispec.Descriptor, error) {
 	descs = append(descs, rootManifest, manifestConfigDesc)
 
 	// put digest in uds-bundle.yaml to reference during deploy
-	f.cfg.Bundle.Packages[f.cfg.PkgIter].Ref = f.cfg.Bundle.Packages[f.cfg.PkgIter].Ref + "@" + rootManifest.Digest.String()
+	f.cfg.Bundle.Packages[f.cfg.PkgIter].Ref = strings.Split(f.cfg.Bundle.Packages[f.cfg.PkgIter].Ref, "@")[0] + "@" + rootManifest.Digest.String()
 
 	// append zarf image manifest to bundle root manifest and grab path for archiving
 	f.cfg.BundleRootManifest.Layers = append(f.cfg.BundleRootManifest.Layers, rootManifest)

--- a/src/pkg/bundler/fetcher/remote.go
+++ b/src/pkg/bundler/fetcher/remote.go
@@ -61,7 +61,10 @@ func (f *remoteFetcher) Fetch() ([]ocispec.Descriptor, error) {
 	f.pkg.PublicKey, err = getAbsKeyPath(f.pkg.PublicKey, f.cfg.CreateSrcDir)
 	if err != nil {
 		return nil, err
-	} else if f.pkg.PublicKey != "" {
+	}
+
+	// If the publicKey was provided, add the key flag to the args list
+	if f.pkg.PublicKey != "" {
 		cmdArgs = append(cmdArgs, "--key="+f.pkg.PublicKey)
 	}
 
@@ -80,9 +83,11 @@ func (f *remoteFetcher) Fetch() ([]ocispec.Descriptor, error) {
 	matches, err := filepath.Glob(filepath.Join(outputDir, "zarf-*.tar.zst"))
 	if err != nil {
 		return nil, err
-	} else if len(matches) != 1 {
+	}
+	if len(matches) != 1 {
 		return nil, fmt.Errorf("unable to pull pacakge %s", f.pkg.Name)
 	}
+
 	localFetcher.pkg.Path = matches[0]
 	return localFetcher.Fetch()
 }

--- a/src/pkg/bundler/fetcher/remote.go
+++ b/src/pkg/bundler/fetcher/remote.go
@@ -7,16 +7,17 @@ package fetcher
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/defenseunicorns/pkg/oci"
 	"github.com/defenseunicorns/uds-cli/src/config"
-	"github.com/defenseunicorns/uds-cli/src/pkg/cache"
 	"github.com/defenseunicorns/uds-cli/src/pkg/utils"
-	"github.com/defenseunicorns/uds-cli/src/pkg/utils/boci"
 	"github.com/defenseunicorns/uds-cli/src/types"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	zarfCmd "github.com/zarf-dev/zarf/src/cmd"
+	zarfCfg "github.com/zarf-dev/zarf/src/config"
 	"github.com/zarf-dev/zarf/src/pkg/message"
 	zarfUtils "github.com/zarf-dev/zarf/src/pkg/utils"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
@@ -35,86 +36,49 @@ func (f *remoteFetcher) Fetch() ([]ocispec.Descriptor, error) {
 	fetchSpinner := message.NewProgressSpinner("Fetching package %s", f.pkg.Name)
 	defer fetchSpinner.Stop()
 
-	// find layers in remote
-	fetchSpinner.Updatef("Fetching %s package layer metadata (package %d of %d)", f.pkg.Name, f.cfg.PkgIter+1, f.cfg.NumPkgs)
-	layersToCopy, err := boci.FindPkgLayers(*f.remote, f.pkgRootManifest, f.pkg.OptionalComponents)
+	// Pull the remote package local tmpdir
+	zarfCmd := zarfCmd.NewZarfCommand()
+	zarfCfg.CLIArch = config.GetArch()
+	ociURL := "oci://" + f.pkg.Repository + ":" + f.pkg.Ref
+	outFlag := "--output-directory=" + f.cfg.TmpDstDir
+	cmdArgs := []string{
+		"package",
+		"pull",
+		ociURL,
+		outFlag,
+	}
+
+	// Add path to public key if provided
+	var err error
+	f.pkg.PublicKey, err = getAbsKeyPath(f.pkg.PublicKey, f.cfg.CreateSrcDir)
 	if err != nil {
 		return nil, err
+	} else if f.pkg.PublicKey != "" {
+		cmdArgs = append(cmdArgs, "--key="+f.pkg.PublicKey)
 	}
-	fetchSpinner.Stop()
 
-	// copy layers to local bundle
-	fetchSpinner.Updatef("Pushing package %s layers to bundle (package %d of %d)", f.pkg.Name, f.cfg.PkgIter+1, f.cfg.NumPkgs)
-	pkgDescs, err := f.copyRemotePkgLayers(layersToCopy)
+	zarfCmd.SetArgs(cmdArgs)
+	err = zarfCmd.Execute()
 	if err != nil {
-		return nil, err
+		return []ocispec.Descriptor{}, err
 	}
 
-	fetchSpinner.Successf("Fetched package: %s", f.pkg.Name)
-	return pkgDescs, nil
-}
-
-// copyRemotePkgLayers copies a remote Zarf pkg to a local OCI store
-func (f *remoteFetcher) copyRemotePkgLayers(layersToCopy []ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-	ctx := context.TODO()
-	// pull layers from remote and write to OCI artifact dir
-	var descsToBundle []ocispec.Descriptor
-	var layersToPull []ocispec.Descriptor
-	estimatedBytes := int64(0)
-
-	// grab descriptors of layers to copy
-	for _, layer := range layersToCopy {
-		if layer.Digest == "" {
-			continue
-		}
-
-		exists, err := cache.CheckLayerExists(ctx, layer, f.cfg.Store, f.cfg.TmpDstDir)
-		if err != nil {
-			return nil, err
-		}
-		// if layers don't already exist on disk, add to layersToPull
-		// but don't grab Zarf root manifest (id'd by image manifest) because we get it automatically during oras.Copy()
-		if !exists && layer.MediaType != ocispec.MediaTypeImageManifest {
-			layersToPull = append(layersToPull, layer)
-			estimatedBytes += layer.Size
-		}
-		descsToBundle = append(descsToBundle, layer)
+	// Fetch the descriptor layers from the, now local, zarf package
+	localFetcher := localFetcher{
+		pkg: f.pkg,
+		cfg: f.cfg,
 	}
-	// pull layers that didn't already exist on disk
-	if len(layersToPull) > 0 {
-		rootPkgDesc, err := boci.CopyLayers(layersToPull, estimatedBytes, f.cfg.TmpDstDir, f.remote.Repo(), f.cfg.Store, f.pkg.Name)
-		if err != nil {
-			return nil, err
+	zarfPkgName := fmt.Sprintf("zarf-package-%s-%s-%s.tar.zst", f.pkg.Name, config.GetArch(), f.pkg.Ref)
+	if _, err := os.Stat(filepath.Join(f.cfg.TmpDstDir, zarfPkgName)); err != nil {
+		// the downloaded packge might have been an 'init' package with a different file name
+		zarfPkgName = fmt.Sprintf("zarf-%s-%s-%s.tar.zst", f.pkg.Name, config.GetArch(), f.pkg.Ref)
+		if _, err := os.Stat(filepath.Join(f.cfg.TmpDstDir, zarfPkgName)); err != nil {
+			return nil, fmt.Errorf("Unable to fetch upstream package %s", ociURL)
 		}
-
-		// grab pkg root manifest for archiving and save it to bundle root manifest
-		descsToBundle = append(descsToBundle, rootPkgDesc)
-		rootPkgDesc.MediaType = zoci.ZarfLayerMediaTypeBlob // force media type to Zarf blob
-		f.cfg.BundleRootManifest.Layers = append(f.cfg.BundleRootManifest.Layers, rootPkgDesc)
-
-		// cache only the image layers that were just pulled
-		err = cache.AddPulledImgLayers(layersToPull, f.cfg.TmpDstDir)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		// no layers to pull but need to grab pkg root manifest and config manually bc we didn't use oras.Copy()
-		pkgManifestDesc, err := boci.ToOCIStore(f.pkgRootManifest, ocispec.MediaTypeImageManifest, f.cfg.Store)
-		if err != nil {
-			return nil, err
-		}
-
-		// save pkg manifest to bundle root manifest
-		pkgManifestDesc.MediaType = zoci.ZarfLayerMediaTypeBlob // force media type to Zarf blob
-		f.cfg.BundleRootManifest.Layers = append(f.cfg.BundleRootManifest.Layers, pkgManifestDesc)
-
-		manifestConfigDesc, err := boci.ToOCIStore(f.pkgRootManifest.Config, zoci.ZarfConfigMediaType, f.cfg.Store)
-		if err != nil {
-			return nil, err
-		}
-		descsToBundle = append(descsToBundle, pkgManifestDesc, manifestConfigDesc)
 	}
-	return descsToBundle, nil
+	localFetcher.pkg.Path = filepath.Join(f.cfg.TmpDstDir, zarfPkgName)
+
+	return localFetcher.Fetch()
 }
 
 func (f *remoteFetcher) GetPkgMetadata() (v1alpha1.ZarfPackage, error) {

--- a/src/pkg/bundler/localbundle.go
+++ b/src/pkg/bundler/localbundle.go
@@ -78,6 +78,7 @@ func (lo *LocalBundle) create(signature []byte) error {
 		TmpDstDir:          lo.tmpDstDir,
 		NumPkgs:            len(lo.bundle.Packages),
 		BundleRootManifest: &rootManifest,
+		CreateSrcDir:       lo.sourceDir,
 	}
 
 	message.Debug("Bundling", bundle.Metadata.Name, "to", lo.tmpDstDir)

--- a/src/pkg/bundler/remotebundle.go
+++ b/src/pkg/bundler/remotebundle.go
@@ -93,6 +93,14 @@ func (r *RemoteBundle) create(signature []byte) error {
 		pusherConfig.PkgRootManifest = pkgRootManifest
 		pusherConfig.PkgIter = i
 
+		if err := src.Repo().Reference.ValidateReferenceAsDigest(); err != nil {
+			manifestDesc, err := src.ResolveRoot(ctx)
+			if err != nil {
+				return err
+			}
+			pusherConfig.Bundle.Packages[i].Ref = pkg.Ref + "@sha256:" + manifestDesc.Digest.Encoded()
+		}
+
 		remotePusher := pusher.NewPkgPusher(pkg, pusherConfig)
 		zarfManifestDesc, err := remotePusher.Push()
 		if err != nil {

--- a/src/test/e2e/optional_bundle_test.go
+++ b/src/test/e2e/optional_bundle_test.go
@@ -99,12 +99,11 @@ func introspectOptionalComponentsBundle(t *testing.T) {
 
 	// for this remote pkg, ensure component tars exist in img manifest, but not in the bundle
 	componentName := "optional-kiwix"
-	verifyComponentNotIncluded := false
+	verifyComponentNotIncluded := true
 	for _, desc := range remotePkgManifest.Layers {
 		if strings.Contains(desc.Annotations[ocispec.AnnotationTitle], fmt.Sprintf("components/%s.tar", componentName)) {
-			_, err = os.ReadFile(filepath.Join(blobsDir, desc.Digest.Encoded()))
-			require.ErrorContains(t, err, "no such file or directory")
-			verifyComponentNotIncluded = true
+			// component shouldn't exist in pkg manifest for locally sourced pkgs
+			verifyComponentNotIncluded = false
 		}
 	}
 	require.True(t, verifyComponentNotIncluded)


### PR DESCRIPTION
fixes issue where bundles that referenced a Signed Zarf Package on the local filesystem were unable to be built


**NOTE:**
I think this should be considered (and advertised) as a breaking change. Bundles that were utilizing signed Zarf Packages without providing the publickey are now going to give an error when being created instead of silently failing/continuing before.