### PR TITLE
Revert "fix!: use provided public signing key to build bundles with signed zarf packages

### DIFF
--- a/src/cmd/common.go
+++ b/src/cmd/common.go
@@ -73,6 +73,7 @@ func deploy(bndlClient *bundle.Bundle) error {
 
 // configureZarf copies configs from UDS-CLI to Zarf
 func configureZarf() {
+	zarfCLI.LogFormat = "legacy"
 	zarfConfig.CommonOptions = zarfTypes.ZarfCommonOptions{
 		Insecure:       config.CommonOptions.Insecure,
 		TempDirectory:  config.CommonOptions.TempDirectory,

--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -116,9 +116,31 @@ func (b *Bundle) ValidateBundleResources(spinner *message.Spinner) error {
 		}
 		var zarfYAML v1alpha1.ZarfPackage
 		var url string
+		ctx := context.TODO()
 		// if using a remote repository
+		// todo: refactor these hash checks using the fetcher
 		if pkg.Repository != "" {
 			url = fmt.Sprintf("%s:%s", pkg.Repository, pkg.Ref)
+			if strings.Contains(pkg.Ref, "@sha256:") {
+				url = fmt.Sprintf("%s:%s", pkg.Repository, pkg.Ref)
+			}
+
+			platform := ocispec.Platform{
+				Architecture: config.GetArch(),
+				OS:           oci.MultiOS,
+			}
+			remote, err := zoci.NewRemote(ctx, url, platform)
+			if err != nil {
+				return err
+			}
+			if err := remote.Repo().Reference.ValidateReferenceAsDigest(); err != nil {
+				manifestDesc, err := remote.ResolveRoot(ctx)
+				if err != nil {
+					return err
+				}
+				// todo: don't do this here, a "validate" fn shouldn't be modifying the bundle
+				bundle.Packages[idx].Ref = pkg.Ref + "@sha256:" + manifestDesc.Digest.Encoded()
+			}
 		} else {
 			// atm we don't support outputting a bundle with local pkgs outputting to OCI
 			if utils.IsRegistryURL(b.cfg.CreateOpts.Output) {

--- a/src/pkg/bundle/dev.go
+++ b/src/pkg/bundle/dev.go
@@ -15,8 +15,6 @@ import (
 	"github.com/defenseunicorns/uds-cli/src/pkg/utils"
 	"github.com/defenseunicorns/uds-cli/src/types"
 
-	"github.com/pterm/pterm"
-
 	zarfCLI "github.com/zarf-dev/zarf/src/cmd"
 )
 
@@ -67,9 +65,6 @@ func (b *Bundle) CreateZarfPkgs() error {
 					os.Args = []string{"zarf", "package", "create", pkgDir, "--confirm", "-o", pkgDir, "--skip-sbom"}
 				}
 				zarfCLI.Execute(context.TODO())
-
-				// NOTE: After executing the zarfCLI we need to reset the pterm stdout if we want logs..
-				pterm.SetDefaultOutput(os.Stderr)
 			}
 		}
 	}

--- a/src/pkg/bundler/fetcher/common.go
+++ b/src/pkg/bundler/fetcher/common.go
@@ -99,11 +99,3 @@ func filterPkgPaths(pkgPaths *layout.PackagePaths, includeLayers []string, optio
 
 	return filteredPaths
 }
-
-func getAbsKeyPath(keyPath string, prefixDir string) (string, error) {
-	if keyPath == "" || filepath.IsAbs(keyPath) || helpers.IsURL(keyPath) {
-		return keyPath, nil
-	}
-
-	return filepath.Abs(filepath.Join(prefixDir, keyPath))
-}

--- a/src/pkg/bundler/fetcher/fetcher.go
+++ b/src/pkg/bundler/fetcher/fetcher.go
@@ -32,7 +32,6 @@ type Config struct {
 	NumPkgs            int
 	BundleRootManifest *ocispec.Manifest
 	Bundle             *types.UDSBundle
-	CreateSrcDir       string
 }
 
 // NewPkgFetcher creates a fetcher object to pull Zarf pkgs into a local bundle

--- a/src/pkg/bundler/fetcher/local.go
+++ b/src/pkg/bundler/fetcher/local.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/defenseunicorns/pkg/oci"
 	"github.com/defenseunicorns/uds-cli/src/config"
@@ -105,17 +104,11 @@ func (f *localFetcher) GetPkgMetadata() (v1alpha1.ZarfPackage, error) {
 // toBundle transfers a Zarf package to a given Bundle
 func (f *localFetcher) toBundle(pkgTmp string) ([]ocispec.Descriptor, error) {
 	ctx := context.TODO()
-	var err error
-	f.pkg.PublicKey, err = getAbsKeyPath(f.pkg.PublicKey, f.cfg.CreateSrcDir)
-	if err != nil {
-		return nil, err
-	}
 
 	// load pkg and layout of pkg paths
 	pkgSrc := zarfSources.TarballSource{
 		ZarfPackageOptions: &zarfTypes.ZarfPackageOptions{
 			PackageSource: f.pkg.Path,
-			PublicKeyPath: f.pkg.PublicKey,
 		},
 	}
 	pkg, pkgPaths, err := loadPkg(pkgTmp, &pkgSrc, f.pkg.OptionalComponents)
@@ -220,7 +213,7 @@ func (f *localFetcher) toBundle(pkgTmp string) ([]ocispec.Descriptor, error) {
 	descs = append(descs, rootManifest, manifestConfigDesc)
 
 	// put digest in uds-bundle.yaml to reference during deploy
-	f.cfg.Bundle.Packages[f.cfg.PkgIter].Ref = strings.Split(f.cfg.Bundle.Packages[f.cfg.PkgIter].Ref, "@")[0] + "@" + rootManifest.Digest.String()
+	f.cfg.Bundle.Packages[f.cfg.PkgIter].Ref = f.cfg.Bundle.Packages[f.cfg.PkgIter].Ref + "@" + rootManifest.Digest.String()
 
 	// append zarf image manifest to bundle root manifest and grab path for archiving
 	f.cfg.BundleRootManifest.Layers = append(f.cfg.BundleRootManifest.Layers, rootManifest)

--- a/src/pkg/bundler/localbundle.go
+++ b/src/pkg/bundler/localbundle.go
@@ -78,7 +78,6 @@ func (lo *LocalBundle) create(signature []byte) error {
 		TmpDstDir:          lo.tmpDstDir,
 		NumPkgs:            len(lo.bundle.Packages),
 		BundleRootManifest: &rootManifest,
-		CreateSrcDir:       lo.sourceDir,
 	}
 
 	message.Debug("Bundling", bundle.Metadata.Name, "to", lo.tmpDstDir)

--- a/src/pkg/bundler/remotebundle.go
+++ b/src/pkg/bundler/remotebundle.go
@@ -93,14 +93,6 @@ func (r *RemoteBundle) create(signature []byte) error {
 		pusherConfig.PkgRootManifest = pkgRootManifest
 		pusherConfig.PkgIter = i
 
-		if err := src.Repo().Reference.ValidateReferenceAsDigest(); err != nil {
-			manifestDesc, err := src.ResolveRoot(ctx)
-			if err != nil {
-				return err
-			}
-			pusherConfig.Bundle.Packages[i].Ref = pkg.Ref + "@sha256:" + manifestDesc.Digest.Encoded()
-		}
-
 		remotePusher := pusher.NewPkgPusher(pkg, pusherConfig)
 		zarfManifestDesc, err := remotePusher.Push()
 		if err != nil {

--- a/src/test/e2e/optional_bundle_test.go
+++ b/src/test/e2e/optional_bundle_test.go
@@ -99,11 +99,12 @@ func introspectOptionalComponentsBundle(t *testing.T) {
 
 	// for this remote pkg, ensure component tars exist in img manifest, but not in the bundle
 	componentName := "optional-kiwix"
-	verifyComponentNotIncluded := true
+	verifyComponentNotIncluded := false
 	for _, desc := range remotePkgManifest.Layers {
 		if strings.Contains(desc.Annotations[ocispec.AnnotationTitle], fmt.Sprintf("components/%s.tar", componentName)) {
-			// component shouldn't exist in pkg manifest for locally sourced pkgs
-			verifyComponentNotIncluded = false
+			_, err = os.ReadFile(filepath.Join(blobsDir, desc.Digest.Encoded()))
+			require.ErrorContains(t, err, "no such file or directory")
+			verifyComponentNotIncluded = true
 		}
 	}
 	require.True(t, verifyComponentNotIncluded)


### PR DESCRIPTION
This reverts commit cbcf3daf300281a3451654c4fba5683213283c70.

## Description
Revert this commit because this ended up breaking the layer cache when building bundles. The layer cache broke because instead of UDS-CLI using custom internal logic to pull the zarf layers, UDS-CLI utilized the Zarf SDK to pull the entire package down. This change wasn't detected with our current testing suite.


I believe we can (and should) be using Zarf to pull packages (vs using custom logic within the UDS-CLI repo to perform pulls) but we should ensure that we are managing the cache of images layers correctly when we implement that approach. When that time comes, I believe we would be able to 'simply' utilize the Zarf Cache.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
