### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 * @defenseunicorns/uds-cli
 
 # Additional privileged files
-/CODEOWNERS @jeff-mccoy @catsby @UncleGedd @daveworth
+/CODEOWNERS @jeff-mccoy @daveworth
 # NOTE: No E to catch LICENSE and LICENSING
 /LICENS* @jeff-mccoy @austenbryan

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @defenseunicorns/uds-core
+* @defenseunicorns/uds-cli
 
 # Additional privileged files
 /CODEOWNERS @jeff-mccoy @catsby @UncleGedd @daveworth


### PR DESCRIPTION
Updates the CODEOWNERS file to be owned by the `uds-cli` GitHub team