### PR TITLE
chore: update renovate to exclude pterm v0.12.80

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,12 @@
       ],
       "groupName": "zarf",
       "commitMessageTopic": "zarf"
+    },
+    {
+      "matchPackageNames": [
+        "github.com/pterm/pterm"
+      ],
+      "allowedVersions": "!/v0.12.80/"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
pterm v0.12.80 breaks our things. Let's remove it from renovate so our other deps can be updated. This should exclude just the single broken version

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
