### PR TITLE
chore: minor io handling updates that avoid reading things in to memory

### DIFF
--- a/src/pkg/bundle/tarball.go
+++ b/src/pkg/bundle/tarball.go
@@ -199,12 +199,14 @@ func (tp *tarballBundleProvider) LoadBundleMetadata() (types.PathMap, error) {
 				continue
 			}
 
-			tarBytes, err := os.ReadFile(tp.src)
+			file, err := os.Open(tp.src)
 			if err != nil {
 				return nil, err
 			}
+			defer file.Close()
+
 			fileHandler := utils.ExtractFile(pathInTarball, tp.dst)
-			err = config.BundleArchiveFormat.Extract(context.TODO(), bytes.NewReader(tarBytes), fileHandler)
+			err = config.BundleArchiveFormat.Extract(context.TODO(), file, fileHandler)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Description

I noticed there are some points where we read potentially large files in to memory, to then write them somewhere else (in part or in whole). In this PR we effectively stream the bytes from A->B instead of loading into memory first.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
