### PR TITLE
chore: set ignore_tag properties in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -95,3 +95,19 @@ release:
   prerelease: auto
   mode: append
   draft: false
+
+git:
+  # What should be used to sort tags when gathering the current and previous
+  # tags if there are more than one tag in the same commit.
+  #
+  # Default: '-version:refname'.
+  tag_sort: -version:creatordate
+
+  # Tags to be ignored by GoReleaser.
+  # This means that GoReleaser will not pick up tags that match any of the
+  # provided values as either previous or current tags.
+  #
+  # Templates: allowed.
+  ignore_tags:
+    - nightly-unstable
+    - "{{.Env.IGNORE_TAG}}"


### PR DESCRIPTION
## Description

Setting `ignore_tags` in the `.goreleaser.yaml` file should allow us to ignore the `nightly` tag when creating the Changelog release notes. 

I copied these values from this documentation page: 

- https://goreleaser.com/customization/git/?h=ignore_tags

## Related Issue

Fixes #911

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
