### PR TITLE
chore: add uds-experience as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @defenseunicorns/uds-cli
+* @defenseunicorns/uds-experience @defenseunicorns/uds-cli
 
 # Additional privileged files
 /CODEOWNERS @jeff-mccoy @daveworth


### PR DESCRIPTION
## Description

Adds the `@defenseunicorns/uds-experience` as an owner of the repo, enabling that team to maintain the project. 


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
