### PR TITLE
fix: updates to .goreleaser.yaml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+version: 2
 
 before:
   hooks:
@@ -31,7 +32,7 @@ builds:
 
 # Save the built artifacts as binaries (instead of wrapping them in a tarball)
 archives:
-  - format: binary
+  - formats: binary
     name_template: "{{ .ProjectName }}_{{ .Tag }}_{{- title .Os }}_{{ .Arch }}"
 
 # generate a sha256 checksum of all release artifacts
@@ -46,7 +47,7 @@ sboms:
       - "sbom_{{ .ProjectName }}_{{ .Tag }}_{{- title .Os }}_{{ .Arch }}.sbom"
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-snapshot"
+  version_template: "{{ incpatch .Version }}-snapshot"
 
 # Use the auto-generated changelog github provides
 changelog:
@@ -110,4 +111,3 @@ git:
   # Templates: allowed.
   ignore_tags:
     - nightly-unstable
-    - "{{.Env.IGNORE_TAG}}"


### PR DESCRIPTION
## Description

https://github.com/defenseunicorns/uds-cli/pull/1124 introduced `ignore_tags` to our `.goreleaser.yaml` file, with the idea of ignoring certain tags when creating the changelog. Unfortunately using the `"{{.Env.IGNORE_TAG}}"` template option results in an error if the `IGNORE_TAG` environment variable doesn't exist. 

In this PR I remove that, as well as clean up other parts of the file after running `goreleaser check` on the file (ex. `format` and `version_template` options are deprecated).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
