### PR TITLE
fix: publish memory improvements 

### DIFF
--- a/src/pkg/bundle/remote.go
+++ b/src/pkg/bundle/remote.go
@@ -56,7 +56,7 @@ func (op *ociProvider) getBundleManifest() (*oci.Manifest, error) {
 // LoadBundleMetadata loads a remote bundle's metadata
 func (op *ociProvider) LoadBundleMetadata() (types.PathMap, error) {
 	ctx := context.TODO()
-	if err := helpers.CreateDirectory(filepath.Join(op.dst, config.BlobsDir), 0700); err != nil {
+	if err := helpers.CreateDirectory(filepath.Join(op.dst, config.BlobsDir), 0o700); err != nil {
 		return nil, err
 	}
 
@@ -94,7 +94,7 @@ func (op *ociProvider) CreateBundleSBOM(extractSBOM bool, bundleName string) ([]
 	}
 
 	// make tmp dir for pkg SBOM extraction
-	err = os.Mkdir(filepath.Join(op.dst, config.BundleSBOM), 0700)
+	err = os.Mkdir(filepath.Join(op.dst, config.BundleSBOM), 0o700)
 	if err != nil {
 		return warns, err
 	}

--- a/src/pkg/bundle/tarball.go
+++ b/src/pkg/bundle/tarball.go
@@ -59,13 +59,13 @@ func (tp *tarballBundleProvider) CreateBundleSBOM(extractSBOM bool, bundleName s
 			continue
 		}
 
-		tarBytes, err := os.ReadFile(tp.src)
+		tarBytes, err := os.Open(tp.src)
 		if err != nil {
 			return warns, err
 		}
 		var zarfImageManifest *oci.Manifest
 		fileHandler := utils.ExtractJSON(&zarfImageManifest, filepath.Join(config.BlobsDir, layer.Digest.Encoded()))
-		err = config.BundleArchiveFormat.Extract(context.TODO(), bytes.NewReader(tarBytes), fileHandler)
+		err = config.BundleArchiveFormat.Extract(context.TODO(), tarBytes, fileHandler)
 		if err != nil {
 			return warns, err
 		}
@@ -90,18 +90,18 @@ func (tp *tarballBundleProvider) CreateBundleSBOM(extractSBOM bool, bundleName s
 		}
 
 		fileHandler = utils.ExtractFile(sbomFilePath, tp.dst)
-		err = config.BundleArchiveFormat.Extract(context.TODO(), bytes.NewReader(tarBytes), fileHandler)
+		err = config.BundleArchiveFormat.Extract(context.TODO(), tarBytes, fileHandler)
 		if err != nil {
 			return warns, err
 		}
 
 		// extract SBOMs from tar
-		sbomTarBytes, err := os.ReadFile(filepath.Join(tp.dst, sbomFilePath))
+		sbomTarBytes, err := os.Open(filepath.Join(tp.dst, sbomFilePath))
 		if err != nil {
 			return warns, err
 		}
 		extractor := utils.SBOMExtractor(tp.dst, SBOMArtifactPathMap)
-		err = archives.Tar{}.Extract(context.TODO(), bytes.NewReader(sbomTarBytes), extractor)
+		err = archives.Tar{}.Extract(context.TODO(), sbomTarBytes, extractor)
 		if err != nil {
 			return warns, err
 		}
@@ -128,6 +128,7 @@ func (tp *tarballBundleProvider) loadBundleManifest() error {
 
 	var index ocispec.Index
 	tarBytes, err := os.ReadFile(tp.src)
+	// tarBytes, err := os.(tp.src)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/bundle/tarball.go
+++ b/src/pkg/bundle/tarball.go
@@ -199,12 +199,14 @@ func (tp *tarballBundleProvider) LoadBundleMetadata() (types.PathMap, error) {
 				continue
 			}
 
-			tarBytes, err := os.ReadFile(tp.src)
+			file, err := os.Open(tp.src)
 			if err != nil {
 				return nil, err
 			}
+			defer file.Close()
+
 			fileHandler := utils.ExtractFile(pathInTarball, tp.dst)
-			err = config.BundleArchiveFormat.Extract(context.TODO(), bytes.NewReader(tarBytes), fileHandler)
+			err = config.BundleArchiveFormat.Extract(context.TODO(), file, fileHandler)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Description

UDS CLI v0.23.0 introduced some significant memory bloat, specifically with `uds publish` but possibly other places as well. The PR works to reduce that bloat, in my testing cutting that down by 1/2, however it's still significantly larger than v0.22.0. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
