### PR TITLE
chore: decrease ram usage

### DIFF
--- a/src/pkg/bundle/publish.go
+++ b/src/pkg/bundle/publish.go
@@ -5,7 +5,6 @@
 package bundle
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -41,13 +40,15 @@ func (b *Bundle) Publish() error {
 		return err
 	}
 
-	bundleBytes, err := os.ReadFile(b.cfg.PublishOpts.Source)
+	// Open the bundle file for streaming instead of loading it all into memory
+	bundleFile, err := os.Open(b.cfg.PublishOpts.Source)
 	if err != nil {
 		return err
 	}
+	defer bundleFile.Close()
 
-	// extract all files from the archive into a tmpdir
-	err = config.BundleArchiveFormat.Extract(context.TODO(), bytes.NewReader(bundleBytes), utils.ExtractAllFiles(b.tmp))
+	// Extract all files from the archive into a tmpdir using streaming
+	err = config.BundleArchiveFormat.Extract(context.TODO(), bundleFile, utils.ExtractAllFiles(b.tmp))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

use open and stream data vs reading all the data into memory

Seeing max resident set size of 131.25 MB when publishing core demo which is comparable to the RSS previously.

## Related Issue

Fixes #1128

Summary:Publishing bundles using uds-cli versions greater than v0.22.0 causes a significant increase in memory usage compared to earlier versions. For a basic k3d-core-demo bundle, the peak memory usage jumps from ~136 MB in v0.21.0 to over 4.6 GB in v0.25.0. For larger bundles, usage climbs as high as 25 GB, making publishing impossible on standard CI runners.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)
