### PR TITLE
fix: ignore eslint config for license

### DIFF
--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -37,6 +37,9 @@ tasks:
             ignore_flags+=("-ignore" "\"$line\"")
           done < .gitignore
 
+          # Ignore eslint config
+          ignore_flags+=("-ignore" "eslint.config.mjs")
+
           # Construct the command as a string
           eval "$HOME/go/bin/addlicense -l \"AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial\" -check -s=only -v -c \"Defense Unicorns\" ${ignore_flags[*]} . 2>/dev/null"
 
@@ -62,6 +65,9 @@ tasks:
             # Add the line to ignore_flags array with quotes around it
             ignore_flags+=("-ignore" "\"$line\"")
           done < .gitignore
+          
+          # Ignore eslint config
+          ignore_flags+=("-ignore" "eslint.config.mjs")
 
           # Construct the command as a string
           eval "$HOME/go/bin/addlicense -l \"AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial\" -s=only -v -c \"Defense Unicorns\" ${ignore_flags[*]} . 2>/dev/null"


### PR DESCRIPTION
## Description

ESLint released a breaking change in v9.x which forced Pepr to also make a breaking change in order to update ESLint. Version 9.x of ESLint is configured differently and no longer use JSON files, instead now it is a `eslint.config.mjs`. 

We want to get ahead of any trouble in UDS Core and feel 💯 confident that this feature will not have impact on the product before the release so I am doing some testing on the nightly release of Pepr.

The problem is that the `addlicense` tool is [timing out after 0](https://github.com/defenseunicorns/uds-core/actions/runs/15022736270/job/42215747267?pr=1564#step:3:156) seconds on the new `eslint.config.mjs` in UDS Core CI.

Based on this error I would like to propose adding `eslint.config.mjs` to the ignore flags of the tool.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
