### PR TITLE
chore: update gateway resource to check in latest slim-dev bundle

### DIFF
--- a/tasks/tests.yaml
+++ b/tasks/tests.yaml
@@ -82,6 +82,6 @@ tasks:
       - cmd: build/uds deploy k3d-core-slim-dev:latest --confirm
       - cmd: |
           # basic status checks
-          build/uds zarf tools wait-for gateway admin-gateway -n istio-admin-gateway --timeout 10s
-          build/uds zarf tools wait-for gateway tenant-gateway -n istio-tenant-gateway --timeout 10s
+          build/uds zarf tools wait-for gateways.networking.istio.io admin-gateway -n istio-admin-gateway --timeout 10s
+          build/uds zarf tools wait-for gateways.networking.istio.io tenant-gateway -n istio-tenant-gateway --timeout 10s
           build/uds zarf tools wait-for package keycloak -n keycloak --timeout 10s


### PR DESCRIPTION
## Description

Latest k3d-core-slim-dev adds another gateway resource, so the smoke test status checks need to be updated with the fully qualified resource name. ```gateways.networking.istio.io```
