### PR TITLE
chore: Add @decleaver and @TristanHolady as code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @defenseunicorns/uds-cli
+* @defenseunicorns/uds-cli @decleaver @TristanHoladay
 
 # Additional privileged files
 /CODEOWNERS @jeff-mccoy @daveworth


### PR DESCRIPTION
## Description
Add Darcy and Tristan back as individual co-owners, who were removed when uds-experience was removed from CODEOWNERS file. Their approvals are still valuable as the most recent maintainers. There are no other devs in uds-cli team that can satisfy required codeowners PR approval rule (until JPerr is added and returns).
...

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
