### PR TITLE
fix: adding renovate annotation to lint workflow

### DIFF
--- a/.github/workflows/callable-lint.yaml
+++ b/.github/workflows/callable-lint.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
         with:
           # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
-          version: v0.17.0
+          version: v0.27.13
 
       - name: Install lint deps
         run: |


### PR DESCRIPTION
## Description

I noticed we're referencing an older version of the CLI here.  Adding the tag for renovate to update.

## Related Issue

Fixes # n/a
<!-- or -->
Relates to # n/a

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
