### PR TITLE
fix(deploy): santitize sensitive built-in init variables

### DIFF
--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -441,11 +441,26 @@ func formPkgMeta(pkg types.Package) map[string]string {
 }
 
 func addZarfVars(pkgVars map[string]overrideData, variables []interface{}) []interface{} {
+	// Built-in sensitive variables that should be sanitized
+	sensitiveBuiltInVars := map[string]bool{
+		config.RegistryPushUsername: true,
+		config.RegistryPushPassword: true,
+		config.RegistryPullUsername: true,
+		config.RegistryPullPassword: true,
+		config.RegistrySecretName:   true,
+		config.GitPushUsername:      true,
+		config.GitPushPassword:      true,
+		config.GitPullUsername:      true,
+		config.GitPullPassword:      true,
+		config.ArtifactPushUsername: true,
+		config.ArtifactPushToken:    true,
+	}
+
 	for key, fv := range pkgVars {
 		// "CONFIG" refers to "UDS_CONFIG" which is not a Zarf variable or override so we skip it
 		if key != "CONFIG" {
-			// Mask potentially secret ENV vars
-			if fv.source == valuesources.Env {
+			// Mask potentially secret ENV vars or built-in sensitive variables
+			if fv.source == valuesources.Env || sensitiveBuiltInVars[key] {
 				fv.value = hiddenVar
 			}
 			variables = append(variables, map[string]interface{}{key: fv.value})

--- a/src/pkg/bundle/deploy_test.go
+++ b/src/pkg/bundle/deploy_test.go
@@ -550,6 +550,102 @@ func TestFormPkgViews(t *testing.T) {
 			expectedVal: hiddenVar,
 			expectedKey: "FOO",
 		},
+		{
+			name: "hide built-in sensitive registry push password",
+			Bundle: newTestBundle(
+				ConfigVariables{
+					pkgName: {
+						"INIT_REGISTRY_PUSH_PASSWORD": "super-secret-password",
+					},
+				},
+				nil,
+				nil,
+				"uds-config.yaml",
+				"",
+			),
+			expectedKey: "INIT_REGISTRY_PUSH_PASSWORD",
+			expectedVal: hiddenVar,
+		},
+		{
+			name: "hide built-in sensitive git push password",
+			Bundle: newTestBundle(
+				ConfigVariables{
+					pkgName: {
+						"INIT_GIT_PUSH_PASSWORD": "git-secret-password",
+					},
+				},
+				nil,
+				nil,
+				"uds-config.yaml",
+				"",
+			),
+			expectedKey: "INIT_GIT_PUSH_PASSWORD",
+			expectedVal: hiddenVar,
+		},
+		{
+			name: "hide built-in sensitive artifact push token",
+			Bundle: newTestBundle(
+				ConfigVariables{
+					pkgName: {
+						"INIT_ARTIFACT_PUSH_TOKEN": "artifact-token-123",
+					},
+				},
+				nil,
+				nil,
+				"uds-config.yaml",
+				"",
+			),
+			expectedKey: "INIT_ARTIFACT_PUSH_TOKEN",
+			expectedVal: hiddenVar,
+		},
+		{
+			name: "hide built-in sensitive registry push username",
+			Bundle: newTestBundle(
+				ConfigVariables{
+					pkgName: {
+						"INIT_REGISTRY_PUSH_USERNAME": "registry-push-user",
+					},
+				},
+				nil,
+				nil,
+				"uds-config.yaml",
+				"",
+			),
+			expectedKey: "INIT_REGISTRY_PUSH_USERNAME",
+			expectedVal: hiddenVar,
+		},
+		{
+			name: "hide built-in sensitive git pull username",
+			Bundle: newTestBundle(
+				ConfigVariables{
+					pkgName: {
+						"INIT_GIT_PULL_USERNAME": "git-pull-user",
+					},
+				},
+				nil,
+				nil,
+				"uds-config.yaml",
+				"",
+			),
+			expectedKey: "INIT_GIT_PULL_USERNAME",
+			expectedVal: hiddenVar,
+		},
+		{
+			name: "hide built-in sensitive artifact push username",
+			Bundle: newTestBundle(
+				ConfigVariables{
+					pkgName: {
+						"INIT_ARTIFACT_PUSH_USERNAME": "artifact-push-user",
+					},
+				},
+				nil,
+				nil,
+				"uds-config.yaml",
+				"",
+			),
+			expectedKey: "INIT_ARTIFACT_PUSH_USERNAME",
+			expectedVal: hiddenVar,
+		},
 	}
 
 	for _, zarfVarTest := range zarfVarTests {


### PR DESCRIPTION
## Description

Init package variables - as outlined in [documentation](https://uds.defenseunicorns.com/reference/cli/quickstart-and-usage/#configuring-zarf-init-packages) - can be configured but are displayed during deploy confirmation (as well as when auto-confirmed) through package views. 

These internal variables for secret values should be sanitized during the deploy logging so as to not be available in the logs. 

Given a simple bundle with the init package and a uds-config.yaml with init variables


```yaml
# uds-config.yaml
variables:
  init:
    INIT_REGISTRY_URL: "https://my-registry.io"
    INIT_REGISTRY_PUSH_USERNAME: "registry-user"
    INIT_REGISTRY_PUSH_PASSWORD: "my-secret-password"
```

```yaml
# uds-bundle.yaml
kind: UDSBundle
metadata:
  name: example
  description: an example UDS bundle
  version: 0.0.1

packages:
  - name: init
    repository: ghcr.io/zarf-dev/packages/init
    ref: v0.63.0
    optionalComponents:
      - git-server
```

Before:
```bash
name: init
ref: v0.63.0@sha256:940a6e2dc9441d22e6163fa1cf5a79216bd186a2b457f5502b1a9174d40c28d3
repo: ghcr.io/zarf-dev/packages/init

overrides:
- INIT_REGISTRY_URL: https://my-registry.io/
- INIT_REGISTRY_PUSH_USERNAME: registry-user
- INIT_REGISTRY_PUSH_PASSWORD: my-secret-password
```

After:
```bash
name: init
ref: v0.63.0@sha256:940a6e2dc9441d22e6163fa1cf5a79216bd186a2b457f5502b1a9174d40c28d3
repo: ghcr.io/zarf-dev/packages/init

overrides:
- INIT_REGISTRY_URL: https://my-registry.io/
- INIT_REGISTRY_PUSH_USERNAME: "****"
- INIT_REGISTRY_PUSH_PASSWORD: "****"
```

## Related Issue

Relates to #901 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
