### PR TITLE
fix(zarf tools): update build args for uds zarf tools kubectl version

### DIFF
--- a/tasks.yaml
+++ b/tasks.yaml
@@ -49,6 +49,10 @@ tasks:
         mute: true
         setVariables:
           - name: K8S_MODULES_MINOR_VER
+      - cmd: echo ${K8S_MODULES_VER} | awk '{print $3}'
+        mute: true
+        setVariables:
+          - name: K8S_MODULES_PATCH_VER
 
   - name: build-args
     description: generates the build args for building UDS CLI
@@ -66,6 +70,7 @@ tasks:
             -X 'github.com/zarf-dev/zarf/src/cmd/tools.syftVersion=${SYFT_VERSION}' \
             -X 'github.com/zarf-dev/zarf/src/cmd/tools.archiverVersion=${ARCHIVER_VERSION}' \
             -X 'github.com/zarf-dev/zarf/src/cmd/tools.helmVersion=${HELM_VERSION}'
+            -X 'k8s.io/component-base/version.gitVersion=v${K8S_MODULES_MAJOR_VER}.${K8S_MODULES_MINOR_VER}.${K8S_MODULES_PATCH_VER}'
           EOF
         setVariables:
           - name: BUILD_ARGS


### PR DESCRIPTION
## Description

Adds a build `BUILD_ARG` for the kubectl version such that the version returns as expected. 

Before:
```bash
uds zarf tools kubectl version --client
Client Version: v0.0.0-master+$Format:%H$
Kustomize Version: v5.7.1
```

After:
```bash
./build/uds-arm zarf tools kubectl version --client
Client Version: v1.34.2
Kustomize Version: v5.7.1
```

## Related Issue

No associated issue
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
