### PR TITLE
fix(ci): dev-manifests for core e2e test

### DIFF
--- a/tasks/tests.yaml
+++ b/tasks/tests.yaml
@@ -65,7 +65,7 @@ tasks:
           build/uds zarf tools kubectl apply -f tmp/uds-core/src/pepr/uds-cluster-crds/templates/clusterconfig.uds.dev.yaml
           build/uds zarf tools kubectl create namespace pepr-system
           build/uds zarf tools kubectl apply -f tmp/uds-core/hack/dev-manifests/uds-ca-certs.yaml
-          build/uds zarf tools kubectl apply -f tmp/uds-core/hack/dev-manifests/cluster-config-init.yaml          
+          build/uds zarf tools kubectl apply -f tmp/uds-core/hack/dev-manifests/cluster-config-init.yaml
           build/uds zarf tools kubectl apply -f tmp/uds-core/hack/dev-manifests/uds-operator-config-secret.yaml
           build/uds zarf tools kubectl create namespace istio-system
           build/uds zarf tools kubectl apply -f tmp/uds-core/hack/dev-manifests/sso-ca-cert-secret.yaml


### PR DESCRIPTION
## Description

Updates core e2e test to use the upstream (uds-core) hack manifests. This should fix CI issues and ensure that this stays in sync with upstream when these resources change.

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)