### PR TITLE
fix(docs): typo in bundle overrides ref

### DIFF
--- a/docs/reference/bundles/overrides.md
+++ b/docs/reference/bundles/overrides.md
@@ -242,7 +242,9 @@ There are 3 ways to override the `UI_COLOR` variable:
    uds deploy example-bundle --set helm-overrides-package.ui_color=green
    ```
 
-   > **:warning: Warning**: Because Helm override variables and Zarf variables share the same --set syntax, be careful with variable names to avoid conflicts.
+:::caution
+Because Helm override variables and Zarf variables share the same --set syntax, be careful with variable names to avoid conflicts.
+:::
 
 :::note
 A variable that is not overridden by any of the methods above and has no default will be ignored.


### PR DESCRIPTION
## Description

Fixed a small typo in the bundle override reference doc

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
