### PR TITLE
fix(inspect): update inspect logic to handle public key

### DIFF
--- a/src/pkg/bundle/inspect.go
+++ b/src/pkg/bundle/inspect.go
@@ -8,8 +8,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/defenseunicorns/uds-cli/src/config"
 	"github.com/defenseunicorns/uds-cli/src/pkg/message"
 	"github.com/defenseunicorns/uds-cli/src/pkg/sources"
@@ -172,6 +174,16 @@ func (b *Bundle) listVariables() error {
 }
 
 func (b *Bundle) getMetadata(pkg types.Package) (v1alpha1.ZarfPackage, error) {
+
+	publicKeyPath := filepath.Join(b.tmp, config.PublicKeyFile)
+	if pkg.PublicKey != "" {
+		if err := os.WriteFile(publicKeyPath, []byte(pkg.PublicKey), helpers.ReadWriteUser); err != nil {
+			return v1alpha1.ZarfPackage{}, err
+		}
+		defer os.Remove(publicKeyPath)
+	} else {
+		publicKeyPath = ""
+	}
 	// if we are inspecting a built bundle, get the metadata from the bundle
 	if !b.cfg.InspectOpts.IsYAMLFile {
 		pkgTmp, err := zarfUtils.MakeTempDir(config.CommonOptions.TempDirectory)
@@ -180,7 +192,6 @@ func (b *Bundle) getMetadata(pkg types.Package) (v1alpha1.ZarfPackage, error) {
 		}
 		defer os.RemoveAll(pkgTmp)
 
-		publicKeyPath := ""
 		sha := strings.Split(pkg.Ref, "@sha256:")[1] // using appended SHA from create!
 		source, err := sources.NewFromLocation(*b.cfg, pkg, pkgTmp, publicKeyPath, config.CommonOptions.VerifyPackages, sha, nil)
 		if err != nil {
@@ -211,7 +222,7 @@ func (b *Bundle) getMetadata(pkg types.Package) (v1alpha1.ZarfPackage, error) {
 		Filter:         filters.Empty(),
 		Verify:         config.CommonOptions.VerifyPackages,
 		Architecture:   config.GetArch(b.bundle.Metadata.Architecture),
-		PublicKeyPath:  b.cfg.DeployOpts.PublicKeyPath,
+		PublicKeyPath:  publicKeyPath,
 		CachePath:      config.CommonOptions.CachePath,
 		RemoteOptions:  remoteOpts,
 		OCIConcurrency: config.CommonOptions.OCIConcurrency,


### PR DESCRIPTION
## Description

This correctly writes the public key to a temporary directory in order to set  a temporary Public Key Path for package load operations. 

When inspecting a bundle yaml file - the public key was not being honored for a package as it was not being passed to `LoadPackage`.

Given a uds-bundle.yaml with a signed packaged and supporting public key
```yaml
kind: UDSBundle
metadata:
  name: example-dos
  description: an example UDS bundle with dos
  version: 0.0.1

packages:
  - name: dos-games
    repository: ghcr.io/zarf-dev/packages/dos-games
    ref: 1.2.0
    publicKey: |
      -----BEGIN PUBLIC KEY-----
      MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvzCVJ8lhKn7VrH8TyGRq
      Ie7BZhILJMsEJYUJTI/2meoEqHwsESM606QRIftD9KG3tk7eVA5h9Fnw8hPathwq
      9HGgfQAwdSUlEZK152u1QRD50elcT2EFs1FcFyFdoSYyORAFwAGY/nsEklfslpbc
      a7KXOgEMGKbOsdcIMjDzemBL6oyiwUEJWu+ZElCOkRgF7v+VpJhvqlGok2dPcNRt
      OLML3rU+sKrbsYRR89H32AOrrXnyQ6jHbPQ4DOhVQGGUCpKgHTrdp2Io+8ixEjRr
      kDm1ya9SzekXf9Yc7pHTjrTF7BkaxfeLKHHqT5DkmLlEjQqmYvvFmfVjrEEFJai4
      Gseul1aZMPHmLYLjoCeNFbJ9LaJVZ1KLTzPG3Js0lfTInfxMvcp9la2XJwViXvtO
      uSmVJEMe9bY7lrgwl/X022DArgz5R3EdQW64TLXvtKUQl232cC9wB4p4B5a0Dd+6
      yTUHHSj+0HpsInJWYk7+IJen8i28AVFdQxXIwI2sfWhwLg/udImhpKZdgRlsscjl
      +sHpe+RvqCRjKWhbDee/AcvIzvvsJfv+5OkqKlZBAu5NG6zOjDU+eHl1DhSdKsKZ
      XIhyiT1ZGF9PplLixSjg/9ZkXemg0ImybX/q3kMZiwL5Vii6ZLUUwQ1+SSTazfLg
      wJLcBrRj83HRenrsBoERXj0CAwEAAQ==
      -----END PUBLIC KEY-----
```

Then:
```bash
➜  uds-cli git:(1287_publickey_verify) ✗ ./build/uds-main inspect uds-bundle.yaml --list-variables

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Overrides and Variables:   configurable helm overrides and Zarf variables by package

dos-games:
  variables: []
➜  uds-cli git:(1287_publickey_verify) ✗ ./build/uds-main inspect uds-bundle.yaml --list-variables --verify-packages

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Overrides and Variables:   configurable helm overrides and Zarf variables by package
     ERROR:  failed to inspect bundle: signature verification failed: package is signed but no verification material was provided (Public Key, etc.)
➜  uds-cli git:(1287_publickey_verify) ✗ ./build/uds-branch inspect uds-bundle.yaml --list-variables                

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Overrides and Variables:   configurable helm overrides and Zarf variables by package
Verified OK

dos-games:
  variables: []
➜  uds-cli git:(1287_publickey_verify) ✗ ./build/uds-branch inspect uds-bundle.yaml --list-variables --verify-packages

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Overrides and Variables:   configurable helm overrides and Zarf variables by package
Verified OK

dos-games:
  variables: []
```

## Related Issue

Relates to #1287
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
