### PR TITLE
chore: pin anchore/grype module version to v0.104.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/defenseunicorns/uds-cli
 go 1.25.5
 
 // TODO: awaiting release of derailed/k9s to include grype version bump: from https://github.com/zarf-dev/zarf/blob/6243c86df7c2de9abd28631108b6e84b5fecf29f/go.mod#L12
-replace github.com/anchore/grype => github.com/anchore/grype v0.104.1
+replace github.com/anchore/grype => github.com/anchore/grype v0.104.1 // renovate: ignore
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
## Description

Added an annotation in go.mod to prevent renovate from updating the version in the `replace` directive for `anchore/grype`. This needs to be temporarily pinned to versioned v0.104.1 to stay in sync with [Zarf](https://github.com/zarf-dev/zarf/blob/6243c86df7c2de9abd28631108b6e84b5fecf29f/go.mod#L12) as well as prevent an indirect upgrade to the `docker/cli` go package which is causing [pipeline error](https://github.com/defenseunicorns/uds-cli/actions/runs/21234358291/job/61099085828#step:4:168) when running govulncheck

## Related Issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
