### PR TITLE
fix(ci): remove apply of unneeded dev manifest during engine-e2e test

### DIFF
--- a/tasks/tests.yaml
+++ b/tasks/tests.yaml
@@ -67,7 +67,6 @@ tasks:
           build/uds zarf tools kubectl apply -f tmp/uds-core/hack/dev-manifests/uds-ca-certs.yaml
           build/uds zarf tools kubectl apply -f tmp/uds-core/hack/dev-manifests/cluster-config-init.yaml
           build/uds zarf tools kubectl apply -f tmp/uds-core/hack/dev-manifests/uds-operator-config-secret.yaml
-          build/uds zarf tools kubectl create namespace istio-system
         description: "Deploy the UDS Cluster Config CRD, CR, and config secret"
       - cmd: cd tmp/uds-core && npm i && npx pepr deploy --yes
         description: cd into the tmp/uds-core directory and deploy UDS Core's Pepr module


### PR DESCRIPTION
## Description

Removes unnecessary application of uds-core/hack/dev-manifests/sso-ca-cert-secret.yaml during engine-e2e tests. No longer necessary after [change](https://github.com/defenseunicorns/uds-core/pull/2281) in uds-core 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
