### PR TITLE
fix: cleanup zarf --no-progress deprecation

### DIFF
--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -65,10 +65,10 @@ func TestCreateWithNoPath(t *testing.T) {
 	defer e2e.TeardownRegistry(t, 888)
 
 	pkg := filepath.Join(zarfPkgPath1, fmt.Sprintf("zarf-package-output-var-%s-0.0.1.tar.zst", e2e.Arch))
-	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --insecure --oci-concurrency=10 -l debug", pkg))
+	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --plain-http --oci-concurrency=10 -l debug", pkg))
 
 	pkg = filepath.Join(zarfPkgPath2, fmt.Sprintf("zarf-package-receive-var-%s-0.0.1.tar.zst", e2e.Arch))
-	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --insecure --oci-concurrency=10 -l debug", pkg))
+	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --plain-http --oci-concurrency=10 -l debug", pkg))
 
 	// move the bundle to the current directory so we can test the create command with no path
 	err := os.Link(fmt.Sprintf("src/test/bundles/02-variables/remote/%s", config.BundleYAML), config.BundleYAML)
@@ -155,10 +155,10 @@ func TestLocalBundleWithRemotePkgs(t *testing.T) {
 	defer e2e.TeardownRegistry(t, 889)
 
 	pkg := fmt.Sprintf("src/test/packages/nginx/zarf-package-nginx-%s-0.0.1.tar.zst", e2e.Arch)
-	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --insecure --oci-concurrency=10 -l debug", pkg))
+	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --plain-http --oci-concurrency=10 -l debug", pkg))
 
 	pkg = fmt.Sprintf("src/test/packages/podinfo/zarf-package-podinfo-%s-0.0.1.tar.zst", e2e.Arch)
-	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:889 --insecure --oci-concurrency=10 -l debug", pkg))
+	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:889 --plain-http --oci-concurrency=10 -l debug", pkg))
 
 	bundleDir := "src/test/bundles/01-uds-bundle"
 	bundlePath := filepath.Join(bundleDir, fmt.Sprintf("uds-bundle-example-remote-%s-0.0.1.tar.zst", e2e.Arch))
@@ -181,10 +181,10 @@ func TestRemoteBundleWithRemotePkgs(t *testing.T) {
 	defer e2e.TeardownRegistry(t, 889)
 
 	pkg := fmt.Sprintf("src/test/packages/nginx/zarf-package-nginx-%s-0.0.1.tar.zst", e2e.Arch)
-	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --insecure --oci-concurrency=10 -l debug", pkg))
+	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --plain-http --oci-concurrency=10 -l debug", pkg))
 
 	pkg = fmt.Sprintf("src/test/packages/podinfo/zarf-package-podinfo-%s-0.0.1.tar.zst", e2e.Arch)
-	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:889 --insecure --oci-concurrency=10 -l debug", pkg))
+	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:889 --plain-http --oci-concurrency=10 -l debug", pkg))
 
 	bundleRef := registry.Reference{
 		Registry: "oci://localhost:888",
@@ -392,10 +392,10 @@ func TestPackageNaming(t *testing.T) {
 	defer e2e.TeardownRegistry(t, 889)
 
 	pkg := fmt.Sprintf("src/test/packages/nginx/zarf-package-nginx-%s-0.0.1.tar.zst", e2e.Arch)
-	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --insecure --oci-concurrency=10 -l debug", pkg))
+	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --plain-http --oci-concurrency=10 -l debug", pkg))
 
 	pkg = fmt.Sprintf("src/test/packages/podinfo/zarf-package-podinfo-%s-0.0.1.tar.zst", e2e.Arch)
-	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:889 --insecure --oci-concurrency=10 -l debug", pkg))
+	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:889 --plain-http --oci-concurrency=10 -l debug", pkg))
 
 	bundleDir := "src/test/bundles/10-package-naming"
 	bundleTarballName := fmt.Sprintf("uds-bundle-package-naming-%s-0.0.1.tar.zst", e2e.Arch)
@@ -426,7 +426,7 @@ func TestBundleWithComposedPkgComponent(t *testing.T) {
 	zarfPkgPath := "src/test/packages/prometheus"
 	pkg := filepath.Join(zarfPkgPath, fmt.Sprintf("zarf-package-prometheus-%s-0.0.1.tar.zst", e2e.Arch))
 	e2e.CreateZarfPkg(t, zarfPkgPath, false)
-	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --insecure --oci-concurrency=10 -l debug", pkg))
+	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --plain-http --oci-concurrency=10 -l debug", pkg))
 
 	bundleDir := "src/test/bundles/13-composable-component"
 	bundleName := "with-composed"
@@ -572,7 +572,7 @@ func TestListImages(t *testing.T) {
 	zarfPkgPath := "src/test/packages/prometheus"
 	pkg := filepath.Join(zarfPkgPath, fmt.Sprintf("zarf-package-prometheus-%s-0.0.1.tar.zst", e2e.Arch))
 	e2e.CreateZarfPkg(t, zarfPkgPath, false)
-	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --insecure --oci-concurrency=10 -l debug", pkg))
+	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --plain-http --oci-concurrency=10 -l debug", pkg))
 
 	zarfPkgPath = "src/test/packages/podinfo-nginx"
 	e2e.CreateZarfPkg(t, zarfPkgPath, false)
@@ -661,7 +661,7 @@ func TestListVariables(t *testing.T) {
 	zarfPkgPath := "src/test/packages/prometheus"
 	pkg := filepath.Join(zarfPkgPath, fmt.Sprintf("zarf-package-prometheus-%s-0.0.1.tar.zst", e2e.Arch))
 	e2e.CreateZarfPkg(t, zarfPkgPath, false)
-	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --insecure --oci-concurrency=10 -l debug", pkg))
+	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --plain-http --oci-concurrency=10 -l debug", pkg))
 
 	zarfPkgPath = "src/test/packages/podinfo-nginx"
 	e2e.CreateZarfPkg(t, zarfPkgPath, false)

--- a/src/test/e2e/optional_bundle_test.go
+++ b/src/test/e2e/optional_bundle_test.go
@@ -27,7 +27,7 @@ func TestBundleOptionalComponents(t *testing.T) {
 	zarfPkgPath = "src/test/packages/prometheus"
 	pkg := filepath.Join(zarfPkgPath, fmt.Sprintf("zarf-package-prometheus-%s-0.0.1.tar.zst", e2e.Arch))
 	e2e.CreateZarfPkg(t, zarfPkgPath, false)
-	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --insecure --oci-concurrency=10 -l debug", pkg))
+	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --plain-http --oci-concurrency=10 -l debug", pkg))
 
 	// create bundle and publish
 	bundleDir := "src/test/bundles/14-optional-components"

--- a/src/test/e2e/variable_test.go
+++ b/src/test/e2e/variable_test.go
@@ -193,7 +193,7 @@ func TestBundleWithDupPkgs(t *testing.T) {
 	e2e.CreateZarfPkg(t, zarfPkgPath, false)
 	name := "duplicates"
 	pkg := filepath.Join(zarfPkgPath, fmt.Sprintf("zarf-package-helm-overrides-%s-0.0.1.tar.zst", e2e.Arch))
-	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --insecure --oci-concurrency=10 -l debug", pkg))
+	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --plain-http --oci-concurrency=10 -l debug", pkg))
 	bundleDir := "src/test/bundles/07-helm-overrides/duplicate"
 	bundlePath := filepath.Join(bundleDir, fmt.Sprintf("uds-bundle-%s-%s-0.0.1.tar.zst", name, e2e.Arch))
 


### PR DESCRIPTION
## Description
Address these zarf deprecation warnings: `Flag --no-progress has been deprecated, Progress bars and spinners were removed with --log-format=legacy, this flag will be removed in a future version of Zarf.` 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
