### PR TITLE
feat: added timeout override for zarf package deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ packages:
   - name: init
     repository: ghcr.io/defenseunicorns/packages/init
     ref: v0.33.0
+    timeout: 20m
     optionalComponents:
       - git-server
   - name: podinfo

--- a/docs/reference/CLI/quickstart-and-usage.md
+++ b/docs/reference/CLI/quickstart-and-usage.md
@@ -31,6 +31,7 @@ packages:
   - name: init
     repository: ghcr.io/defenseunicorns/packages/init
     ref: v0.33.0
+    timeout: 20m
     optionalComponents:
       - git-server
   - name: podinfo
@@ -94,6 +95,20 @@ As an example: `uds deploy uds-bundle-<name>.tar.zst --packages init,nginx`
 By default all the packages in the bundle are deployed, regardless of if they have already been deployed, but you can also choose to only deploy packages that have not already been deployed by using the `--resume` flag
 
 As an example: `uds deploy uds-bundle-<name>.tar.zst --resume`
+
+#### Setting a package timeout
+
+By default, UDS uses a shared deploy timeout for all packages in a bundle. To override this for a specific package, set `timeout` on that package in `uds-bundle.yaml`.
+
+```yaml
+packages:
+  - name: init
+    repository: ghcr.io/defenseunicorns/packages/init
+    ref: v0.33.0
+    timeout: 20m
+```
+
+The value uses Go duration format (for example `30s`, `10m`, or `1h30m`).
 
 ### Pruning Unreferenced Packages
 

--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -103,6 +103,10 @@ func (b *Bundle) ValidateBundleResources(spinner *message.Spinner) error {
 			return fmt.Errorf("%v is missing required field: name", pkg)
 		}
 
+		if _, err := resolvePackageTimeout(pkg); err != nil {
+			return err
+		}
+
 		if pkg.Repository == "" && pkg.Path == "" {
 			return fmt.Errorf("zarf pkg %s must have either a repository or path field", pkg.Name)
 		}

--- a/src/pkg/bundle/timeout.go
+++ b/src/pkg/bundle/timeout.go
@@ -1,0 +1,42 @@
+// Copyright 2024 Defense Unicorns
+// SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+// Package bundle contains functions for interacting with, managing and deploying UDS packages
+package bundle
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/defenseunicorns/uds-cli/src/config"
+	"github.com/defenseunicorns/uds-cli/src/types"
+)
+
+func resolvePackageTimeout(pkg types.Package) (time.Duration, error) {
+	timeoutString := strings.TrimSpace(pkg.Timeout)
+	if timeoutString == "" {
+		return config.HelmTimeout, nil
+	}
+
+	timeout, err := time.ParseDuration(timeoutString)
+	if err != nil {
+		return 0, fmt.Errorf("invalid timeout for package %q: %q (use duration format like 30s, 10m, or 1h30m)", pkg.Name, pkg.Timeout)
+	}
+
+	if timeout <= 0 {
+		return 0, fmt.Errorf("invalid timeout for package %q: %q (timeout must be greater than zero)", pkg.Name, pkg.Timeout)
+	}
+
+	return timeout, nil
+}
+
+func validatePackageTimeouts(packages []types.Package) error {
+	for _, pkg := range packages {
+		if _, err := resolvePackageTimeout(pkg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/src/pkg/bundle/timeout_test.go
+++ b/src/pkg/bundle/timeout_test.go
@@ -1,0 +1,111 @@
+// Copyright 2024 Defense Unicorns
+// SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+// Package bundle contains functions for interacting with, managing and deploying UDS packages
+package bundle
+
+import (
+	"testing"
+	"time"
+
+	"github.com/defenseunicorns/uds-cli/src/config"
+	"github.com/defenseunicorns/uds-cli/src/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePackageTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		pkg           types.Package
+		expected      time.Duration
+		expectedError string
+	}{
+		{
+			name:     "empty timeout uses default",
+			pkg:      types.Package{Name: "podinfo"},
+			expected: config.HelmTimeout,
+		},
+		{
+			name:     "whitespace timeout uses default",
+			pkg:      types.Package{Name: "podinfo", Timeout: "   "},
+			expected: config.HelmTimeout,
+		},
+		{
+			name:     "valid timeout parses",
+			pkg:      types.Package{Name: "podinfo", Timeout: "2m30s"},
+			expected: 2*time.Minute + 30*time.Second,
+		},
+		{
+			name:     "valid timeout trims whitespace",
+			pkg:      types.Package{Name: "podinfo", Timeout: " 45s "},
+			expected: 45 * time.Second,
+		},
+		{
+			name:          "invalid timeout fails",
+			pkg:           types.Package{Name: "podinfo", Timeout: "ten-minutes"},
+			expectedError: "invalid timeout for package \"podinfo\": \"ten-minutes\"",
+		},
+		{
+			name:          "zero timeout fails",
+			pkg:           types.Package{Name: "podinfo", Timeout: "0s"},
+			expectedError: "timeout must be greater than zero",
+		},
+		{
+			name:          "negative timeout fails",
+			pkg:           types.Package{Name: "podinfo", Timeout: "-1s"},
+			expectedError: "timeout must be greater than zero",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			timeout, err := resolvePackageTimeout(tt.pkg)
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, timeout)
+		})
+	}
+}
+
+func TestValidatePackageTimeouts(t *testing.T) {
+	t.Parallel()
+
+	err := validatePackageTimeouts([]types.Package{
+		{Name: "nginx", Timeout: "5m"},
+		{Name: "podinfo", Timeout: "not-a-duration"},
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid timeout for package \"podinfo\": \"not-a-duration\"")
+}
+
+func TestFormPkgMetaTimeout(t *testing.T) {
+	t.Parallel()
+
+	metaWithTimeout := formPkgMeta(types.Package{
+		Name:       "podinfo",
+		Ref:        "0.0.1",
+		Repository: "ghcr.io/example/podinfo",
+		Timeout:    "5m",
+	})
+
+	require.Equal(t, "5m", metaWithTimeout["timeout"])
+
+	metaWithoutTimeout := formPkgMeta(types.Package{
+		Name: "podinfo",
+		Ref:  "0.0.1",
+		Path: "../../packages/podinfo",
+	})
+
+	_, exists := metaWithoutTimeout["timeout"]
+	require.False(t, exists)
+}

--- a/src/test/bundles/22-invalid-timeout/uds-bundle.yaml
+++ b/src/test/bundles/22-invalid-timeout/uds-bundle.yaml
@@ -1,0 +1,13 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+kind: UDSBundle
+metadata:
+  name: invalid-timeout
+  version: 0.0.1
+
+packages:
+  - name: real-simple
+    path: "../../packages/no-cluster/real-simple"
+    ref: 0.0.1
+    timeout: definitely-not-a-duration

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -95,6 +95,14 @@ func TestCreateRemotePackageWithoutPublicKey(t *testing.T) {
 	})
 }
 
+func TestCreateBundleWithInvalidPackageTimeout(t *testing.T) {
+	bundleDir := "src/test/bundles/22-invalid-timeout"
+
+	_, stderr, err := runCmdWithErr(fmt.Sprintf("create %s --confirm --insecure -a %s", bundleDir, e2e.Arch))
+	require.Error(t, err)
+	require.Contains(t, stderr, `invalid timeout for package "real-simple": "definitely-not-a-duration"`)
+}
+
 func TestBundleWithLocalAndRemotePkgs(t *testing.T) {
 	deployZarfInit(t)
 	e2e.SetupDockerRegistry(t, 888)

--- a/src/types/bundle.go
+++ b/src/types/bundle.go
@@ -24,6 +24,7 @@ type Package struct {
 	Repository         string                                     `json:"repository,omitempty" jsonschema:"description=The repository to import the package from"`
 	Path               string                                     `json:"path,omitempty" jsonschema:"description=The local path to import the package from"`
 	Ref                string                                     `json:"ref" jsonschema:"description=Ref (tag) of the Zarf package"`
+	Timeout            string                                     `json:"timeout,omitempty" jsonschema:"description=Timeout for deploying the package. Use duration format such as 30s 10m or 1h30m"`
 	Flavor             string                                     `json:"flavor,omitempty" jsonschema:"description=Flavor of the Zarf package"`
 	OptionalComponents []string                                   `json:"optionalComponents,omitempty" jsonschema:"description=List of optional components to include from the package (required components are always included)"`
 	PublicKey          string                                     `json:"publicKey,omitempty" jsonschema:"description=The public key to use to verify the package"`

--- a/uds.schema.json
+++ b/uds.schema.json
@@ -169,6 +169,10 @@
           "type": "string",
           "description": "Ref (tag) of the Zarf package"
         },
+        "timeout": {
+          "type": "string",
+          "description": "Timeout for deploying the package. Use duration format such as 30s 10m or 1h30m"
+        },
         "flavor": {
           "type": "string",
           "description": "Flavor of the Zarf package"


### PR DESCRIPTION
## Description
UDS doesn't currently expose the ability to override the deployment timeout of zarf packages in a UDS-bundle. This feature adds support to setting a timeout value override per zarf package in your uds-bundle.yaml file. 

## Related Issue

Fixes #588 
<!-- or -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed

## Misc
Following the contribution guidelines, I was unable to run the e2e test defined here: https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md#running-tests as the `test:e2e-no-ghcr-write` task no longer exists but I ran all other automated tests and manual tests. 