### PR TITLE
chore: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+This document outlines the security policy for UDS CLI, including how to report vulnerabilities.
+
+## Reporting a vulnerability
+
+Email `security [at] defenseunicorns.com` to report a vulnerability. If you are unable to disclose details via email, please let us know and we can coordinate alternate communications.


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md` required for all public repositories per the Defense Unicorns GitHub Repository Structure standard (ALL-4)
- Contact address: `security@defenseunicorns.com`

## Test plan

- [ ] Confirm GitHub displays the Security Policy link on the repo's Security tab after merge