### PR TITLE
feat: change bundle ordering and improve inspect speed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/goccy/go-yaml v1.19.2
 	github.com/mholt/archives v0.1.5
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pterm/pterm v0.12.83
 	github.com/spf13/cobra v1.10.2
@@ -437,7 +438,6 @@ require (
 	github.com/olekukonko/ll v0.1.6 // indirect
 	github.com/olekukonko/tablewriter v1.1.4 // indirect
 	github.com/open-policy-agent/opa v1.14.1 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/opencontainers/selinux v1.13.1 // indirect
 	github.com/openvex/go-vex v0.2.7 // indirect

--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -35,6 +35,10 @@ type Bundle struct {
 	bundle types.UDSBundle
 	// tmp is the temporary directory used by the Bundle cleaned up with ClearPaths()
 	tmp string
+	// pkgMetaCache holds pre-fetched per-package metadata (zarf.yaml + sig +
+	// checksums) when a single-pass tarball prefetch has run. When non-nil,
+	// getMetadata reads from it instead of re-streaming the bundle per package.
+	pkgMetaCache map[string]*pkgPrefetchResult
 }
 
 // New creates a new Bundle

--- a/src/pkg/bundle/inspect.go
+++ b/src/pkg/bundle/inspect.go
@@ -73,6 +73,24 @@ func (b *Bundle) Inspect() error {
 				return err
 			}
 		}
+
+		// Pre-warm per-package metadata in a single pass through the bundle.
+		// On large bundles this is the dominant cost of `uds inspect`.
+		// We only do this for tarball sources — remote (OCI) providers already
+		// fetch metadata blobs independently.
+		needsPkgMeta := b.cfg.InspectOpts.ListVariables || b.cfg.InspectOpts.ListImages || !config.CommonOptions.SkipSignatureValidation
+		if needsPkgMeta {
+			if tp, ok := provider.(*tarballBundleProvider); ok {
+				cache, perr := tp.prefetchPackageMetadata(context.TODO(), b.bundle.Packages, b.tmp)
+				if perr != nil {
+					// Fall back to the per-package slow path on any error so
+					// inspect still works on bundles the prefetcher can't handle.
+					message.Warnf("package metadata prefetch failed, falling back to per-package extraction: %v", perr)
+				} else {
+					b.pkgMetaCache = cache
+				}
+			}
+		}
 	}
 
 	// handle --list-variables flag
@@ -184,6 +202,32 @@ func (b *Bundle) listVariables() error {
 }
 
 func (b *Bundle) getMetadata(pkg types.Package) (v1alpha1.ZarfPackage, error) {
+	// Fast path: metadata was pre-fetched for the whole bundle in a single
+	// pass. Verify and load it the same keyless-capable way as the non-cached
+	// path below, just against the directory the prefetcher already wrote so we
+	// don't re-extract from the (multi-GB) bundle tarball per package.
+	if cached, ok := b.pkgMetaCache[pkg.Name]; ok {
+		keyTmp, err := zarfUtils.MakeTempDir(config.CommonOptions.TempDirectory)
+		if err != nil {
+			return v1alpha1.ZarfPackage{}, err
+		}
+		defer os.RemoveAll(keyTmp)
+
+		verifyOpts, err := utils.BuildVerifyBlobOptions(pkg, keyTmp)
+		if err != nil {
+			return v1alpha1.ZarfPackage{}, fmt.Errorf("package %q: %w", pkg.Name, err)
+		}
+
+		pkgLayout, err := utils.LoadPackageFromDir(context.TODO(), cached.dirPath, layout.PackageLayoutOptions{
+			IsPartial:            true,
+			VerificationStrategy: utils.GetPackageVerificationStrategy(config.CommonOptions.SkipSignatureValidation),
+			VerifyBlobOptions:    verifyOpts,
+		})
+		if err != nil {
+			return v1alpha1.ZarfPackage{}, fmt.Errorf("package %q: %w", pkg.Name, err)
+		}
+		return pkgLayout.Pkg, nil
+	}
 
 	// if we are inspecting a built bundle, get the metadata from the bundle
 	if !b.cfg.InspectOpts.IsYAMLFile {

--- a/src/pkg/bundle/tarball_prefetch.go
+++ b/src/pkg/bundle/tarball_prefetch.go
@@ -140,7 +140,7 @@ func (tp *tarballBundleProvider) prefetchPackageMetadata(ctx context.Context, pa
 			parsedManifests[digest] = &manifest
 			for _, layer := range manifest.Layers {
 				switch layer.Annotations[ocispec.AnnotationTitle] {
-				case layout.ZarfYAML, layout.Signature, config.ChecksumsTxt:
+				case layout.ZarfYAML, layout.Signature, layout.Bundle, config.ChecksumsTxt:
 					ld := layer.Digest.Encoded()
 					if _, already := captured[ld]; !already {
 						needed[ld] = true
@@ -196,6 +196,11 @@ func (tp *tarballBundleProvider) prefetchPackageMetadata(ctx context.Context, pa
 				zarfYAMLPath = dst
 			case layout.Signature:
 				dst = filepath.Join(pkgDir, layout.Signature)
+			case layout.Bundle:
+				// keyless per-package signature; the slow path in
+				// sources/tarball.go stages this too, and LoadPackageFromDir
+				// needs it to verify keyless-signed packages.
+				dst = filepath.Join(pkgDir, layout.Bundle)
 			case config.ChecksumsTxt:
 				dst = filepath.Join(pkgDir, layout.Checksums)
 			default:

--- a/src/pkg/bundle/tarball_prefetch.go
+++ b/src/pkg/bundle/tarball_prefetch.go
@@ -1,0 +1,223 @@
+// Copyright 2024 Defense Unicorns
+// SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+package bundle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/defenseunicorns/pkg/helpers/v2"
+	"github.com/defenseunicorns/pkg/oci"
+	"github.com/defenseunicorns/uds-cli/src/config"
+	"github.com/defenseunicorns/uds-cli/src/types"
+	"github.com/mholt/archives"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
+)
+
+// pkgPrefetchResult holds the on-disk location of the small metadata files
+// (zarf.yaml/signature/checksums) prefetched for a single bundled Zarf package.
+// getMetadata loads and verifies the package from this directory.
+type pkgPrefetchResult struct {
+	// dirPath is the directory containing zarf.yaml/signature/checksums on disk.
+	dirPath string
+}
+
+// maxPrefetchBlobBytes caps in-memory capture of any single blob the prefetcher
+// considers "needed." Today this only ever includes package image manifests
+// (small JSON), zarf.yaml, signature.sig, and checksums.txt — all <1 MB in
+// practice. The bound is defensive: if a future contributor adds a new title
+// to the switch in the handler below, a hostile or oversized blob can't OOM
+// the inspect process before we notice.
+//
+// This is a var rather than a const so tests can shrink it to exercise the
+// overflow guard without writing multi-MB fixtures.
+var maxPrefetchBlobBytes int64 = 32 << 20 // 32 MiB
+
+// prefetchPackageMetadata streams the bundle tarball ONCE and pulls every
+// package's zarf.yaml, signature, and checksums.txt blob out of it.
+//
+// The naive path in src/pkg/sources/tarball.go LoadPackageMetadata opens the
+// bundle twice per package (once for the package manifest, once for the
+// referenced metadata blobs). For a bundle with N packages that's roughly N*2
+// full zstd decompressions of a multi-GB tarball — the dominant cost of
+// `uds inspect`. Here we collapse it to a single pass: we drive a state
+// machine that knows about the package manifest digests up front, parses each
+// manifest as it streams by to learn the digests of its metadata layers, and
+// returns fs.SkipAll the moment every parser is satisfied. For new bundles
+// where metadata is at the front of the tar (see writeTarball priority list),
+// we typically exit after decompressing only the first few MB.
+//
+// Result blobs are written to per-package directories under dstDir so the
+// existing signature-verification path can run against them unchanged.
+func (tp *tarballBundleProvider) prefetchPackageMetadata(ctx context.Context, packages []types.Package, dstDir string) (map[string]*pkgPrefetchResult, error) {
+	// Build the up-front "things we want" set from each Package.Ref. The
+	// digest after @sha256: is the package manifest blob digest (uds-cli
+	// appends it during create).
+	type pkgEntry struct {
+		pkg            types.Package
+		manifestDigest string
+	}
+	entries := make([]pkgEntry, 0, len(packages))
+	for _, pkg := range packages {
+		idx := strings.LastIndex(pkg.Ref, "@sha256:")
+		if idx < 0 {
+			return nil, fmt.Errorf("package %q ref %q missing manifest digest", pkg.Name, pkg.Ref)
+		}
+		manifestDigest := pkg.Ref[idx+len("@sha256:"):]
+		// pkg.Ref originates from bundle metadata. This digest is used both to
+		// match tar entry names and to build on-disk paths (pkgmeta-<digest>),
+		// so validate it's a well-formed sha256 before use — otherwise a
+		// hostile ref could smuggle path separators and cause traversal.
+		if err := digest.NewDigestFromEncoded(digest.SHA256, manifestDigest).Validate(); err != nil {
+			return nil, fmt.Errorf("package %q has invalid manifest digest %q: %w", pkg.Name, manifestDigest, err)
+		}
+		entries = append(entries, pkgEntry{pkg: pkg, manifestDigest: manifestDigest})
+	}
+
+	// State that the streaming handler reads & mutates:
+	// - needed: blob digests we still want
+	// - captured: digest -> bytes for every needed blob we've already read
+	// - parsedManifests: digest -> parsed package manifest (used to discover
+	//   the per-package metadata layer digests on the fly)
+	needed := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		needed[e.manifestDigest] = true
+	}
+	isPackageManifest := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		isPackageManifest[e.manifestDigest] = true
+	}
+	captured := make(map[string][]byte)
+	parsedManifests := make(map[string]*oci.Manifest)
+
+	handler := func(_ context.Context, file archives.FileInfo) error {
+		// Only blobs are interesting; bundle layout puts everything under blobs/sha256/.
+		if !strings.HasPrefix(file.NameInArchive, config.BlobsDir+"/") {
+			return nil
+		}
+		digest := strings.TrimPrefix(file.NameInArchive, config.BlobsDir+"/")
+		if !needed[digest] {
+			return nil
+		}
+		delete(needed, digest)
+
+		stream, err := file.Open()
+		if err != nil {
+			return err
+		}
+		defer stream.Close()
+
+		// Bounded read: see maxPrefetchBlobBytes. +1 so we can detect overflow
+		// rather than silently truncate.
+		buf, err := io.ReadAll(io.LimitReader(stream, maxPrefetchBlobBytes+1))
+		if err != nil {
+			return err
+		}
+		if int64(len(buf)) > maxPrefetchBlobBytes {
+			return fmt.Errorf("prefetch blob %s exceeded %d byte cap", digest, maxPrefetchBlobBytes)
+		}
+		captured[digest] = buf
+
+		// If this blob is a package manifest, parse it now so we can discover
+		// the metadata-layer digests we still need to fetch from this same
+		// stream. Order is unpredictable in pre-priority bundles; we may have
+		// already passed (and ignored) some layer blob — that's why we keep
+		// streaming until everything is captured rather than bailing here.
+		if isPackageManifest[digest] {
+			var manifest oci.Manifest
+			if err := json.Unmarshal(buf, &manifest); err != nil {
+				return fmt.Errorf("parsing package manifest %s: %w", digest, err)
+			}
+			parsedManifests[digest] = &manifest
+			for _, layer := range manifest.Layers {
+				switch layer.Annotations[ocispec.AnnotationTitle] {
+				case layout.ZarfYAML, layout.Signature, config.ChecksumsTxt:
+					ld := layer.Digest.Encoded()
+					if _, already := captured[ld]; !already {
+						needed[ld] = true
+					}
+				}
+			}
+		}
+
+		// Stop iterating once every package manifest has been parsed AND
+		// every transitively-needed blob has been captured. For priority-
+		// ordered bundles this happens in the first few MB; for old bundles
+		// it may take a full drain to EOF — still a single drain rather than
+		// N*2 drains.
+		if len(needed) == 0 && len(parsedManifests) == len(entries) {
+			return fs.SkipAll
+		}
+		return nil
+	}
+
+	srcFile, err := os.Open(tp.src)
+	if err != nil {
+		return nil, err
+	}
+	defer srcFile.Close()
+	if err := config.BundleArchiveFormat.Extract(ctx, srcFile, handler); err != nil {
+		return nil, err
+	}
+
+	// Resolve each package: write its metadata files to per-package subdirs.
+	// We key the on-disk dir on the manifest digest so two packages with the
+	// same logical name (but different versions) don't collide on disk.
+	results := make(map[string]*pkgPrefetchResult, len(entries))
+	for _, e := range entries {
+		manifest, ok := parsedManifests[e.manifestDigest]
+		if !ok {
+			return nil, fmt.Errorf("package manifest %s for %q not found in bundle", e.manifestDigest, e.pkg.Name)
+		}
+		pkgDir := filepath.Join(dstDir, "pkgmeta-"+e.manifestDigest)
+		if err := os.MkdirAll(pkgDir, 0o700); err != nil {
+			return nil, err
+		}
+
+		var zarfYAMLPath string
+		for _, layer := range manifest.Layers {
+			data, ok := captured[layer.Digest.Encoded()]
+			if !ok {
+				continue
+			}
+			var dst string
+			switch layer.Annotations[ocispec.AnnotationTitle] {
+			case layout.ZarfYAML:
+				dst = filepath.Join(pkgDir, layout.ZarfYAML)
+				zarfYAMLPath = dst
+			case layout.Signature:
+				dst = filepath.Join(pkgDir, layout.Signature)
+			case config.ChecksumsTxt:
+				dst = filepath.Join(pkgDir, layout.Checksums)
+			default:
+				continue
+			}
+			if err := os.WriteFile(dst, data, helpers.ReadWriteUser); err != nil {
+				return nil, err
+			}
+		}
+		if zarfYAMLPath == "" {
+			return nil, fmt.Errorf("zarf.yaml not found for package %q in bundle", e.pkg.Name)
+		}
+
+		// The cache is keyed by package name (matching inspect.go's lookup). If
+		// two packages share a name, the second would silently overwrite the
+		// first and getMetadata would return the wrong metadata. On-disk dirs are
+		// per-manifest-digest so they don't collide, but the result map would.
+		if _, exists := results[e.pkg.Name]; exists {
+			return nil, fmt.Errorf("bundle contains multiple packages named %q; cannot prefetch metadata unambiguously", e.pkg.Name)
+		}
+		results[e.pkg.Name] = &pkgPrefetchResult{dirPath: pkgDir}
+	}
+
+	return results, nil
+}

--- a/src/pkg/bundle/tarball_prefetch_test.go
+++ b/src/pkg/bundle/tarball_prefetch_test.go
@@ -1,0 +1,248 @@
+// Copyright 2024 Defense Unicorns
+// SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+package bundle
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/defenseunicorns/pkg/oci"
+	"github.com/defenseunicorns/uds-cli/src/config"
+	"github.com/defenseunicorns/uds-cli/src/types"
+	"github.com/mholt/archives"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
+)
+
+type fixtureBlob struct {
+	title   string // org.opencontainers.image.title annotation (zarf.yaml/sig/checksums)
+	content []byte
+}
+
+type fixturePkg struct {
+	name  string // the bundle-level package name
+	blobs []fixtureBlob
+}
+
+func zarfYAML(name, version string) []byte {
+	return []byte("kind: ZarfPackageConfig\nmetadata:\n  name: " + name + "\n  version: " + version + "\n")
+}
+
+// writeFixtureBundle builds a minimal .tar.zst bundle on disk containing only
+// the OCI blobs the prefetcher cares about: one image manifest per package plus
+// that package's annotated metadata blobs. When manifestFirst is true each
+// package's manifest is written ahead of its metadata blobs (the order the real
+// writeTarball produces); when false the metadata blobs come first, which the
+// single-pass prefetcher cannot resolve. Returns the tarball path and, indexed
+// to match pkgs, each package's manifest digest (encoded, no algorithm prefix).
+func writeFixtureBundle(t *testing.T, pkgs []fixturePkg, manifestFirst bool) (string, []string) {
+	t.Helper()
+	srcDir := t.TempDir()
+	blobsDir := filepath.Join(srcDir, "blobs", "sha256")
+	require.NoError(t, os.MkdirAll(blobsDir, 0o755))
+
+	fileMap := map[string]string{} // disk path -> name in archive
+	var order []string             // archive names in the order we want them in the tar
+	manifestHexes := make([]string, len(pkgs))
+
+	writeBlob := func(content []byte) digest.Digest {
+		d := digest.FromBytes(content)
+		require.NoError(t, os.WriteFile(filepath.Join(blobsDir, d.Encoded()), content, 0o644))
+		fileMap[filepath.Join(blobsDir, d.Encoded())] = config.BlobsDir + "/" + d.Encoded()
+		return d
+	}
+
+	for i, p := range pkgs {
+		var layers []ocispec.Descriptor
+		var metaNames []string
+		for _, b := range p.blobs {
+			d := writeBlob(b.content)
+			layers = append(layers, ocispec.Descriptor{
+				Digest:      d,
+				Size:        int64(len(b.content)),
+				Annotations: map[string]string{ocispec.AnnotationTitle: b.title},
+			})
+			metaNames = append(metaNames, config.BlobsDir+"/"+d.Encoded())
+		}
+
+		manifestBytes, err := json.Marshal(oci.Manifest{Manifest: ocispec.Manifest{Layers: layers}})
+		require.NoError(t, err)
+		md := writeBlob(manifestBytes)
+		manifestHexes[i] = md.Encoded()
+
+		manifestName := config.BlobsDir + "/" + md.Encoded()
+		if manifestFirst {
+			order = append(order, manifestName)
+			order = append(order, metaNames...)
+		} else {
+			order = append(order, metaNames...)
+			order = append(order, manifestName)
+		}
+	}
+
+	files, err := archives.FilesFromDisk(context.Background(), nil, fileMap)
+	require.NoError(t, err)
+
+	// Order the slice to control tar layout; CompressedArchive.Archive writes
+	// entries in slice order.
+	rank := make(map[string]int, len(order))
+	for i, n := range order {
+		rank[n] = i
+	}
+	sort.SliceStable(files, func(a, b int) bool {
+		return rank[files[a].NameInArchive] < rank[files[b].NameInArchive]
+	})
+
+	tarPath := filepath.Join(t.TempDir(), "bundle.tar.zst")
+	out, err := os.Create(tarPath)
+	require.NoError(t, err)
+	require.NoError(t, config.BundleArchiveFormat.Archive(context.Background(), out, files))
+	require.NoError(t, out.Close())
+
+	return tarPath, manifestHexes
+}
+
+func TestPrefetchPackageMetadata(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("captures all packages when the manifest precedes its metadata", func(t *testing.T) {
+		pkgs := []fixturePkg{
+			{name: "signed-pkg", blobs: []fixtureBlob{
+				{title: layout.ZarfYAML, content: zarfYAML("internal-signed", "1.2.3")},
+				{title: layout.Signature, content: []byte("fake-signature")},
+				{title: config.ChecksumsTxt, content: []byte("fake-checksums")},
+			}},
+			{name: "unsigned-pkg", blobs: []fixtureBlob{
+				{title: layout.ZarfYAML, content: zarfYAML("internal-unsigned", "4.5.6")},
+				{title: config.ChecksumsTxt, content: []byte("more-checksums")},
+			}},
+		}
+		tarPath, hexes := writeFixtureBundle(t, pkgs, true)
+
+		tp := &tarballBundleProvider{src: tarPath}
+		results, err := tp.prefetchPackageMetadata(ctx, []types.Package{
+			{Name: "signed-pkg", Ref: "ghcr.io/x/signed@sha256:" + hexes[0]},
+			{Name: "unsigned-pkg", Ref: "ghcr.io/x/unsigned@sha256:" + hexes[1]},
+		}, t.TempDir())
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+
+		// The prefetcher only stages the metadata files on disk; getMetadata
+		// loads/verifies them. Assert the right files landed in each pkg's dir.
+		signed := results["signed-pkg"]
+		require.NotNil(t, signed)
+		require.FileExists(t, filepath.Join(signed.dirPath, layout.ZarfYAML))
+		require.FileExists(t, filepath.Join(signed.dirPath, layout.Signature))
+		require.FileExists(t, filepath.Join(signed.dirPath, layout.Checksums))
+
+		unsigned := results["unsigned-pkg"]
+		require.NotNil(t, unsigned)
+		require.FileExists(t, filepath.Join(unsigned.dirPath, layout.ZarfYAML))
+		require.FileExists(t, filepath.Join(unsigned.dirPath, layout.Checksums))
+		require.NoFileExists(t, filepath.Join(unsigned.dirPath, layout.Signature))
+	})
+
+	t.Run("fails when metadata precedes its manifest in the stream", func(t *testing.T) {
+		// This is the single-pass contract that writeTarball satisfies by
+		// ordering each package's manifest before its metadata blobs. If the
+		// metadata streams first, the prefetcher skips it (not yet known to be
+		// needed) and never recovers it in one forward pass.
+		pkgs := []fixturePkg{{name: "p", blobs: []fixtureBlob{
+			{title: layout.ZarfYAML, content: zarfYAML("p", "1.0.0")},
+			{title: config.ChecksumsTxt, content: []byte("c")},
+		}}}
+		tarPath, hexes := writeFixtureBundle(t, pkgs, false)
+
+		tp := &tarballBundleProvider{src: tarPath}
+		_, err := tp.prefetchPackageMetadata(ctx, []types.Package{
+			{Name: "p", Ref: "ghcr.io/x/p@sha256:" + hexes[0]},
+		}, t.TempDir())
+		require.Error(t, err)
+	})
+
+	t.Run("rejects duplicate package names", func(t *testing.T) {
+		pkgs := []fixturePkg{
+			{name: "dup", blobs: []fixtureBlob{
+				{title: layout.ZarfYAML, content: zarfYAML("a", "1.0.0")},
+				{title: config.ChecksumsTxt, content: []byte("c1")},
+			}},
+			{name: "dup", blobs: []fixtureBlob{
+				{title: layout.ZarfYAML, content: zarfYAML("b", "2.0.0")},
+				{title: config.ChecksumsTxt, content: []byte("c2")},
+			}},
+		}
+		tarPath, hexes := writeFixtureBundle(t, pkgs, true)
+
+		tp := &tarballBundleProvider{src: tarPath}
+		_, err := tp.prefetchPackageMetadata(ctx, []types.Package{
+			{Name: "dup", Ref: "ghcr.io/x/a@sha256:" + hexes[0]},
+			{Name: "dup", Ref: "ghcr.io/x/b@sha256:" + hexes[1]},
+		}, t.TempDir())
+		require.ErrorContains(t, err, "multiple packages named")
+	})
+
+	t.Run("rejects a ref without a manifest digest", func(t *testing.T) {
+		tp := &tarballBundleProvider{src: "ignored-no-file-opened"}
+		_, err := tp.prefetchPackageMetadata(ctx, []types.Package{
+			{Name: "p", Ref: "ghcr.io/x/p:1.0.0"},
+		}, t.TempDir())
+		require.ErrorContains(t, err, "missing manifest digest")
+	})
+
+	t.Run("rejects a ref with a malformed manifest digest", func(t *testing.T) {
+		for _, bad := range []string{
+			"../../../etc/passwd", // path traversal
+			"short",               // wrong length
+			"zz5e8b1f6a4d3c2e9f0a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566", // non-hex
+		} {
+			tp := &tarballBundleProvider{src: "ignored-no-file-opened"}
+			_, err := tp.prefetchPackageMetadata(ctx, []types.Package{
+				{Name: "p", Ref: "ghcr.io/x/p@sha256:" + bad},
+			}, t.TempDir())
+			require.ErrorContains(t, err, "invalid manifest digest", "digest %q should be rejected", bad)
+		}
+	})
+
+	t.Run("errors when a needed blob exceeds the size cap", func(t *testing.T) {
+		orig := maxPrefetchBlobBytes
+		maxPrefetchBlobBytes = 1024
+		t.Cleanup(func() { maxPrefetchBlobBytes = orig })
+
+		// Manifest stays under the cap and parses; the oversized zarf.yaml blob
+		// trips the overflow guard.
+		pkgs := []fixturePkg{{name: "p", blobs: []fixtureBlob{
+			{title: layout.ZarfYAML, content: bytes.Repeat([]byte("x"), 2048)},
+			{title: config.ChecksumsTxt, content: []byte("c")},
+		}}}
+		tarPath, hexes := writeFixtureBundle(t, pkgs, true)
+
+		tp := &tarballBundleProvider{src: tarPath}
+		_, err := tp.prefetchPackageMetadata(ctx, []types.Package{
+			{Name: "p", Ref: "ghcr.io/x/p@sha256:" + hexes[0]},
+		}, t.TempDir())
+		require.ErrorContains(t, err, "exceeded")
+	})
+
+	t.Run("errors when a package manifest is absent from the bundle", func(t *testing.T) {
+		pkgs := []fixturePkg{{name: "present", blobs: []fixtureBlob{
+			{title: layout.ZarfYAML, content: zarfYAML("present", "1.0.0")},
+			{title: config.ChecksumsTxt, content: []byte("c")},
+		}}}
+		tarPath, _ := writeFixtureBundle(t, pkgs, true)
+
+		ghost := digest.FromBytes([]byte("ghost-manifest")).Encoded()
+		tp := &tarballBundleProvider{src: tarPath}
+		_, err := tp.prefetchPackageMetadata(ctx, []types.Package{
+			{Name: "ghost", Ref: "ghcr.io/x/ghost@sha256:" + ghost},
+		}, t.TempDir())
+		require.ErrorContains(t, err, "not found in bundle")
+	})
+}

--- a/src/pkg/bundle/tarball_prefetch_test.go
+++ b/src/pkg/bundle/tarball_prefetch_test.go
@@ -150,6 +150,31 @@ func TestPrefetchPackageMetadata(t *testing.T) {
 		require.NoFileExists(t, filepath.Join(unsigned.dirPath, layout.Signature))
 	})
 
+	t.Run("stages the keyless bundle signature layer", func(t *testing.T) {
+		// Keyless-signed packages carry a zarf.bundle.sig (layout.Bundle) layer.
+		// The prefetcher must stage it alongside zarf.yaml so the downstream
+		// LoadPackageFromDir verification can find it — otherwise keyless
+		// packages fail in the fast path while the slow path would succeed.
+		pkgs := []fixturePkg{{name: "keyless-pkg", blobs: []fixtureBlob{
+			{title: layout.ZarfYAML, content: zarfYAML("keyless", "1.0.0")},
+			{title: layout.Bundle, content: []byte("fake-keyless-bundle-sig")},
+			{title: config.ChecksumsTxt, content: []byte("checksums")},
+		}}}
+		tarPath, hexes := writeFixtureBundle(t, pkgs, true)
+
+		tp := &tarballBundleProvider{src: tarPath}
+		results, err := tp.prefetchPackageMetadata(ctx, []types.Package{
+			{Name: "keyless-pkg", Ref: "ghcr.io/x/keyless@sha256:" + hexes[0]},
+		}, t.TempDir())
+		require.NoError(t, err)
+
+		res := results["keyless-pkg"]
+		require.NotNil(t, res)
+		require.FileExists(t, filepath.Join(res.dirPath, layout.ZarfYAML))
+		require.FileExists(t, filepath.Join(res.dirPath, layout.Bundle))
+		require.FileExists(t, filepath.Join(res.dirPath, layout.Checksums))
+	})
+
 	t.Run("fails when metadata precedes its manifest in the stream", func(t *testing.T) {
 		// This is the single-pass contract that writeTarball satisfies by
 		// ordering each package's manifest before its metadata blobs. If the

--- a/src/pkg/bundler/localbundle.go
+++ b/src/pkg/bundler/localbundle.go
@@ -108,6 +108,7 @@ func (lo *LocalBundle) create(ctx context.Context, signature []byte) error {
 		if err != nil {
 			return err
 		}
+		layersBefore := len(rootManifest.Layers)
 		pkgDescs, err := pkgFetcher.Fetch()
 		if err != nil {
 			return err
@@ -127,18 +128,23 @@ func (lo *LocalBundle) create(ctx context.Context, signature []byte) error {
 				pkgMetaBlobs = append(pkgMetaBlobs, archiveName)
 			}
 		}
-		// The fetcher appends each package's image manifest to the bundle
-		// root manifest as its last step. Order the manifest BEFORE its
-		// metadata blobs: the inspect prefetcher seeds itself with manifest
-		// digests and learns the zarf.yaml/sig/checksums digests by parsing
-		// each manifest inline. In a single forward pass it can only capture
-		// those blobs if the manifest has already streamed by — otherwise it
-		// skips them (not yet known to be needed) and is forced to drain to EOF.
-		if n := len(rootManifest.Layers); n > 0 {
-			pkgManifest := rootManifest.Layers[n-1]
+		// The fetcher appends exactly one layer to rootManifest as the final
+		// step of Fetch(): this package's image manifest. Validate that contract
+		// rather than blindly trusting Layers[n-1]. The prefetcher learns a
+		// package's metadata digests by parsing this manifest, so the manifest
+		// must be ordered BEFORE its metadata blobs — in a single forward pass
+		// the prefetcher can only capture those blobs if the manifest streamed
+		// by first. If the fetcher ever appends a different number of layers we
+		// can no longer reliably identify the manifest, so we skip the priority
+		// hint for this package entirely (inspect falls back to its slower
+		// per-package path) rather than front-load metadata without its manifest.
+		if added := len(rootManifest.Layers) - layersBefore; added == 1 {
+			pkgManifest := rootManifest.Layers[len(rootManifest.Layers)-1]
 			perPkgPriority = append(perPkgPriority, filepath.Join(config.BlobsDir, pkgManifest.Digest.Encoded()))
+			perPkgPriority = append(perPkgPriority, pkgMetaBlobs...)
+		} else {
+			message.Debugf("fetcher appended %d manifest layers for package %q (expected 1); skipping inspect priority hint", added, pkg.Name)
 		}
-		perPkgPriority = append(perPkgPriority, pkgMetaBlobs...)
 	}
 
 	message.HeaderInfof("🚧 Building Bundle")

--- a/src/pkg/bundler/localbundle.go
+++ b/src/pkg/bundler/localbundle.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
 	"github.com/defenseunicorns/pkg/oci"
@@ -24,6 +26,7 @@ import (
 	goyaml "github.com/goccy/go-yaml"
 	"github.com/mholt/archives"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/pkg/zoci"
 	"golang.org/x/sync/errgroup"
 	"oras.land/oras-go/v2/content"
@@ -91,6 +94,13 @@ func (lo *LocalBundle) create(ctx context.Context, signature []byte) error {
 
 	artifactPathMap := make(types.PathMap)
 
+	// perPkgPriority accumulates the archive names of small per-package
+	// metadata blobs (zarf.yaml/sig/checksums plus the package image manifest).
+	// These get prepended to the bundle tarball so `uds inspect` can find every
+	// package's definition in the first few MB of the stream instead of
+	// scanning past every image layer to reach them.
+	var perPkgPriority []string
+
 	// grab all Zarf pkgs from OCI and put blobs in OCI store
 	for i, pkg := range bundle.Packages {
 		fetcherConfig.PkgIter = i
@@ -103,11 +113,32 @@ func (lo *LocalBundle) create(ctx context.Context, signature []byte) error {
 			return err
 		}
 
-		// add to artifactPathMap for local bundle tarball
+		// add to artifactPathMap for local bundle tarball, collecting this
+		// package's small metadata blobs separately so they can be ordered
+		// AFTER the package image manifest below.
+		var pkgMetaBlobs []string
 		for _, layer := range pkgDescs {
 			digest := layer.Digest.Encoded()
-			artifactPathMap[filepath.Join(lo.tmpDstDir, config.BlobsDir, digest)] = filepath.Join(config.BlobsDir, digest)
+			archiveName := filepath.Join(config.BlobsDir, digest)
+			artifactPathMap[filepath.Join(lo.tmpDstDir, archiveName)] = archiveName
+
+			switch layer.Annotations[ocispec.AnnotationTitle] {
+			case layout.ZarfYAML, layout.Signature, config.ChecksumsTxt:
+				pkgMetaBlobs = append(pkgMetaBlobs, archiveName)
+			}
 		}
+		// The fetcher appends each package's image manifest to the bundle
+		// root manifest as its last step. Order the manifest BEFORE its
+		// metadata blobs: the inspect prefetcher seeds itself with manifest
+		// digests and learns the zarf.yaml/sig/checksums digests by parsing
+		// each manifest inline. In a single forward pass it can only capture
+		// those blobs if the manifest has already streamed by — otherwise it
+		// skips them (not yet known to be needed) and is forced to drain to EOF.
+		if n := len(rootManifest.Layers); n > 0 {
+			pkgManifest := rootManifest.Layers[n-1]
+			perPkgPriority = append(perPkgPriority, filepath.Join(config.BlobsDir, pkgManifest.Digest.Encoded()))
+		}
+		perPkgPriority = append(perPkgPriority, pkgMetaBlobs...)
 	}
 
 	message.HeaderInfof("🚧 Building Bundle")
@@ -147,6 +178,20 @@ func (lo *LocalBundle) create(ctx context.Context, signature []byte) error {
 	// grab oci-layout
 	artifactPathMap[filepath.Join(lo.tmpDstDir, "oci-layout")] = "oci-layout"
 
+	// priority blobs are written to the front of the tarball so consumers
+	// reading uds-bundle.yaml (and friends) can stop streaming early instead
+	// of decompressing past every package layer to find them.
+	priorityArchiveNames := []string{
+		"oci-layout",
+		"index.json",
+		filepath.Join(config.BlobsDir, rootManifestDesc.Digest.Encoded()),
+		filepath.Join(config.BlobsDir, manifestConfigDigest),
+		filepath.Join(config.BlobsDir, bundleYAMLDesc.Digest.Encoded()),
+	}
+	// followed by every package's small metadata + image manifest so
+	// `uds inspect` can resolve all package definitions in the same prefix.
+	priorityArchiveNames = append(priorityArchiveNames, perPkgPriority...)
+
 	// push the bundle's signature todo: need to understand functionality and add tests
 	if len(signature) > 0 {
 		signatureDesc, err := pushBundleSignature(store, signature)
@@ -159,6 +204,7 @@ func (lo *LocalBundle) create(ctx context.Context, signature []byte) error {
 			return err
 		}
 		message.Debug("Pushed", config.BundleYAMLSignature+":", jsonValue)
+		priorityArchiveNames = append(priorityArchiveNames, filepath.Join(config.BlobsDir, signatureDesc.Digest.Encoded()))
 	}
 
 	// tag the local bundle artifact
@@ -177,7 +223,7 @@ func (lo *LocalBundle) create(ctx context.Context, signature []byte) error {
 		lo.outputDir = lo.sourceDir
 	}
 	// tarball the bundle
-	err = writeTarball(bundle, artifactPathMap, lo.outputDir)
+	err = writeTarball(bundle, artifactPathMap, priorityArchiveNames, lo.outputDir)
 	if err != nil {
 		return err
 	}
@@ -228,8 +274,12 @@ func pushManifestConfig(store *ocistore.Store, metadata types.UDSMetadata, build
 	return manifestConfigDesc, err
 }
 
-// writeTarball builds and writes a bundle tarball to disk based on a file map
-func writeTarball(bundle *types.UDSBundle, artifactPathMap types.PathMap, outputDir string) error {
+// writeTarball builds and writes a bundle tarball to disk based on a file map.
+// priorityArchiveNames lists entries (by archive name) that must be written to
+// the tarball before any others; the order within that slice is preserved so
+// readers can `fs.SkipAll` after the first few KB instead of decompressing the
+// whole stream to find metadata blobs.
+func writeTarball(bundle *types.UDSBundle, artifactPathMap types.PathMap, priorityArchiveNames []string, outputDir string) error {
 	filename := fmt.Sprintf("%s%s-%s-%s.tar.zst", config.BundlePrefix, bundle.Metadata.Name, bundle.Metadata.Architecture, bundle.Metadata.Version)
 
 	if !helpers.IsDir(outputDir) {
@@ -252,6 +302,26 @@ func writeTarball(bundle *types.UDSBundle, artifactPathMap types.PathMap, output
 	if err != nil {
 		return err
 	}
+
+	// Sort: priority entries first (in given order), then everything else
+	// alphabetical for determinism.
+	priorityRank := make(map[string]int, len(priorityArchiveNames))
+	for i, name := range priorityArchiveNames {
+		priorityRank[name] = i
+	}
+	slices.SortFunc(files, func(a, b archives.FileInfo) int {
+		ar, aOK := priorityRank[a.NameInArchive]
+		br, bOK := priorityRank[b.NameInArchive]
+		switch {
+		case aOK && bOK:
+			return ar - br
+		case aOK:
+			return -1
+		case bOK:
+			return 1
+		}
+		return strings.Compare(a.NameInArchive, b.NameInArchive)
+	})
 
 	archiveErrorChan := make(chan error, len(files))
 	jobs := make(chan archives.ArchiveAsyncJob, len(files))

--- a/src/pkg/bundler/localbundle.go
+++ b/src/pkg/bundler/localbundle.go
@@ -123,7 +123,7 @@ func (lo *LocalBundle) create(ctx context.Context, signature []byte) error {
 			artifactPathMap[filepath.Join(lo.tmpDstDir, archiveName)] = archiveName
 
 			switch layer.Annotations[ocispec.AnnotationTitle] {
-			case layout.ZarfYAML, layout.Signature, config.ChecksumsTxt:
+			case layout.ZarfYAML, layout.Signature, layout.Bundle, config.ChecksumsTxt:
 				pkgMetaBlobs = append(pkgMetaBlobs, archiveName)
 			}
 		}
@@ -304,7 +304,10 @@ func writeTarball(bundle *types.UDSBundle, artifactPathMap types.PathMap, priori
 	}
 
 	// Sort: priority entries first (in given order), then everything else
-	// alphabetical for determinism.
+	// alphabetical for determinism. This slice order becomes the tar entry
+	// order only because mholt/archives v0.1.5 ArchiveAsync consumes the jobs
+	// channel serially in send order; if a future version parallelizes that,
+	// this ordering (and the inspect fast-path's prefix read) no longer holds.
 	priorityRank := make(map[string]int, len(priorityArchiveNames))
 	for i, name := range priorityArchiveNames {
 		priorityRank[name] = i

--- a/src/pkg/bundler/localbundle_test.go
+++ b/src/pkg/bundler/localbundle_test.go
@@ -1,0 +1,100 @@
+// Copyright 2024 Defense Unicorns
+// SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+// Package bundler defines behavior for bundling packages
+package bundler
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/defenseunicorns/uds-cli/src/config"
+	"github.com/defenseunicorns/uds-cli/src/types"
+	"github.com/mholt/archives"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWriteTarballPriorityOrdering guards the contract that priority entries are
+// written to the FRONT of the bundle tarball, in the given order, with the rest
+// alphabetical. The inspect fast-path depends on this layout, and it only holds
+// because mholt/archives' ArchiveAsync consumes its jobs channel serially (send
+// order == tar order). If a future library version parallelizes that, this test
+// fails loudly instead of the inspect speedup silently regressing.
+func TestWriteTarballPriorityOrdering(t *testing.T) {
+	src := t.TempDir()
+
+	// Stage a handful of fake archive entries on disk.
+	names := []string{
+		"oci-layout",
+		"index.json",
+		filepath.Join(config.BlobsDir, "aaaa"),
+		filepath.Join(config.BlobsDir, "bbbb"),
+		filepath.Join(config.BlobsDir, "cccc"),
+		filepath.Join(config.BlobsDir, "dddd"),
+	}
+	artifactPathMap := make(types.PathMap)
+	for _, n := range names {
+		disk := filepath.Join(src, n)
+		require.NoError(t, os.MkdirAll(filepath.Dir(disk), 0o755))
+		require.NoError(t, os.WriteFile(disk, []byte("x"), 0o644))
+		artifactPathMap[disk] = n
+	}
+
+	// A deliberately non-alphabetical priority list to prove ordering is honored.
+	priority := []string{
+		"oci-layout",
+		"index.json",
+		filepath.Join(config.BlobsDir, "cccc"),
+		filepath.Join(config.BlobsDir, "aaaa"),
+	}
+
+	out := t.TempDir()
+	bundle := &types.UDSBundle{Metadata: types.UDSMetadata{Name: "test", Architecture: "amd64", Version: "0.0.1"}}
+	require.NoError(t, writeTarball(bundle, artifactPathMap, priority, out))
+
+	tarballs, err := filepath.Glob(filepath.Join(out, "*.tar.zst"))
+	require.NoError(t, err)
+	require.Len(t, tarballs, 1)
+
+	// Read entries back in tar order.
+	f, err := os.Open(tarballs[0])
+	require.NoError(t, err)
+	defer f.Close()
+	var got []string
+	require.NoError(t, config.BundleArchiveFormat.Extract(context.Background(), f, func(_ context.Context, file archives.FileInfo) error {
+		got = append(got, file.NameInArchive)
+		return nil
+	}))
+
+	// Filter to the entries we staged (ignore any incidental directory entries)
+	// while preserving tar order.
+	known := make(map[string]bool, len(names))
+	for _, n := range names {
+		known[n] = true
+	}
+	var ordered []string
+	for _, n := range got {
+		if known[n] {
+			ordered = append(ordered, n)
+		}
+	}
+
+	// Expected: priority entries in the given order, then the rest alphabetical.
+	rest := make([]string, 0, len(names)-len(priority))
+	inPriority := make(map[string]bool, len(priority))
+	for _, p := range priority {
+		inPriority[p] = true
+	}
+	for _, n := range names {
+		if !inPriority[n] {
+			rest = append(rest, n)
+		}
+	}
+	sort.Strings(rest)
+	want := append(append([]string{}, priority...), rest...)
+
+	require.Equal(t, want, ordered, "priority blobs must be written to the front of the tar, in order, then the rest alphabetical")
+}

--- a/src/pkg/sources/tarball.go
+++ b/src/pkg/sources/tarball.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -159,6 +160,8 @@ func (t *TarballBundle) LoadPackageMetadata(_ context.Context, _ bool, _ bool) (
 	if bundleSigSHA != "" {
 		filePaths = append(filePaths, filepath.Join(config.BlobsDir, bundleSigSHA))
 	}
+	captured := 0
+	totalWanted := len(filePaths)
 	if err := config.BundleArchiveFormat.Extract(ctx, sourceArchive, func(_ context.Context, fileInArchive archives.FileInfo) error {
 		if !slices.Contains(filePaths, fileInArchive.NameInArchive) {
 			return nil
@@ -189,11 +192,20 @@ func (t *TarballBundle) LoadPackageMetadata(_ context.Context, _ bool, _ bool) (
 		if err != nil {
 			return err
 		}
+		captured++
+		if captured >= totalWanted {
+			// All targeted files have been written; stop decompressing the rest
+			// of the bundle. Without this we'd drain to EOF every call, and on
+			// a multi-GB bundle that's where most of the inspect time goes.
+			return fs.SkipAll
+		}
 		return nil
 	}); err != nil {
-		err = sourceArchive.Close()
-		if err != nil {
-			return v1alpha1.ZarfPackage{}, nil, err
+		// Pre-existing bug guard: don't let Close() overwrite the real error.
+		// If Close also fails, log it but surface the Extract error since that's
+		// what actually broke the operation.
+		if closeErr := sourceArchive.Close(); closeErr != nil {
+			message.Debugf("close after extract error: %v", closeErr)
 		}
 		return v1alpha1.ZarfPackage{}, nil, err
 	}

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -103,7 +103,9 @@ func ConfigureLogs(cmd *cobra.Command) error {
 	return nil
 }
 
-// ExtractJSON extracts and unmarshals a tarballed JSON file into a type
+// ExtractJSON extracts and unmarshals a tarballed JSON file into a type.
+// Returns fs.SkipAll once the target file is found so the archive stream
+// stops decompressing the remaining entries.
 func ExtractJSON(j any, expectedFilepath string) archives.FileHandler {
 	return func(_ context.Context, file archives.FileInfo) error {
 		if file.NameInArchive != expectedFilepath {
@@ -120,11 +122,16 @@ func ExtractJSON(j any, expectedFilepath string) archives.FileHandler {
 		if err != nil {
 			return err
 		}
-		return json.Unmarshal(fileBytes, &j)
+		if err := json.Unmarshal(fileBytes, &j); err != nil {
+			return err
+		}
+		return fs.SkipAll
 	}
 }
 
-// ExtractBytes returns an archives.FileHandler that extracts a byte contents of a file from an archive
+// ExtractBytes returns an archives.FileHandler that extracts a byte contents of a file from an archive.
+// Returns fs.SkipAll once the target file is found so the archive stream
+// stops decompressing the remaining entries.
 func ExtractBytes(b *[]byte, expectedFilepath string) archives.FileHandler {
 	return func(_ context.Context, file archives.FileInfo) error {
 		if file.NameInArchive != expectedFilepath {
@@ -143,7 +150,7 @@ func ExtractBytes(b *[]byte, expectedFilepath string) archives.FileHandler {
 		}
 
 		*b = fileBytes
-		return nil
+		return fs.SkipAll
 	}
 }
 
@@ -158,7 +165,9 @@ func ExtractAllFiles(outDirPath string) archives.FileHandler {
 }
 
 // extractFiles returns an archives.FileHandler that extracts file(s) from an archive.
-// If the provided extractedPath is empty, all files will be extracted
+// If the provided extractedPath is empty, all files will be extracted.
+// When extracting a single targeted file, fs.SkipAll is returned after the file
+// is written so the archive stream stops decompressing the remaining entries.
 func extractFiles(expectedFilepath string, outDirPath string) archives.FileHandler {
 	return func(_ context.Context, file archives.FileInfo) error {
 		// If an expectedFilepath was provided and it doesn't match the name of this file; do nothing
@@ -194,8 +203,13 @@ func extractFiles(expectedFilepath string, outDirPath string) archives.FileHandl
 		defer stream.Close()
 
 		// Stream directly from the archive to the file without loading everything into memory
-		_, err = io.Copy(outFile, stream)
-		return err
+		if _, err := io.Copy(outFile, stream); err != nil {
+			return err
+		}
+		if expectedFilepath != "" {
+			return fs.SkipAll
+		}
+		return nil
 	}
 }
 


### PR DESCRIPTION
## Description

This PR speeds up uds inspect on a bundle, especially large ones.

It does this through a few backwards compatible changes:

1. Reorder the tarball so metadata files (uds-bundle.yaml, and each package's zarf.yaml / signature / checksums) are written to the front.
2. Bail out of the read early once we've found the metadata files we're after, we stop decompressing instead of draining the rest of the archive.

Because the bundle is a sequential .tar.zst, finding a file means decompressing everything ahead of it. Putting metadata first and stopping as soon as it's read means we only decompress a small prefix instead of the whole multi-GB bundle.

While this technically changes the byte layout of a bundle, it is not a breaking change: every combination of old/new CLI against old/new bundles is fully compatible. The new tarball order is a hint, not a requirement and readers don't assume any ordering. Also, bundles were never byte-for-byte reproducible (file mtimes leak into the archive, iterating over a map in Go is random, etc), so this doesn't introduce any new non-determinism.

A performance breakdown and detailed summary from Claude:

<details>
# `uds inspect` performance

## Benchmark — 8 GB bundle

| Bundle built with | `uds inspect` (default, validates packages) | `uds inspect --skip-signature-validation` |
|---|---|---|
| **Old bundle** (upstream CLI) | 4:52 → 3:18 (**1.5×**) | 18.5s → 8.4s (**2.2×**) |
| **New bundle** (this CLI) | 4:53 → **6.36s** (**46×**) | 18.7s → **0.096s** (**195×**) |

Rows are *old uds-cli* → *new uds-cli* wall time.

The dramatic wins come from new bundles, where this CLI places metadata blobs at the front of the tarball; readers exit after decompressing only the prefix. Old bundles still benefit (1.5–2.2×) because every read path stops at the last match instead of draining the remaining bytes; the floor on old bundles is one full zstd decompression of the archive, since metadata blobs are scattered randomly throughout.

## Changes

### Bundle-tarball layout (write side)

| File | Change |
|---|---|
| `src/pkg/bundler/localbundle.go` | `writeTarball` now takes a `priorityArchiveNames` slice and sorts entries so those names appear first in the tar, in the given order. Priority list contains `oci-layout`, `index.json`, bundle root manifest, manifest config, `uds-bundle.yaml`, signature, **plus every package's image manifest, `zarf.yaml`, `signature.sig`, and `checksums.txt`**. |

### Streaming reads (read side)

| File | Change |
|---|---|
| `src/pkg/utils/utils.go` | `ExtractJSON`, `ExtractBytes`, and `ExtractFile` (single-target mode) return `fs.SkipAll` once the target file is captured, so the archive iterator stops instead of decompressing to EOF. |
| `src/pkg/sources/tarball.go` | The inline handler in `LoadPackageMetadata` counts matches and returns `fs.SkipAll` after all 3 target files (`zarf.yaml`, `signature.sig`, `checksums.txt`) are written. |

### Single-pass batch prefetch (the default-inspect win)

| File | Change |
|---|---|
| `src/pkg/bundle/tarball_prefetch.go` *(new)* | Streams the bundle **once** and extracts every package's metadata in that single pass. State machine: seeds itself with the package-manifest digests up front, parses each manifest inline to learn the inner `zarf.yaml` / signature / checksums digests, and returns `fs.SkipAll` once every parser is satisfied. Writes per-package files to disk so the existing signature-verification path runs unchanged. |
| `src/pkg/bundle/common.go` | New `pkgMetaCache` field on `Bundle` for prefetched results. |
| `src/pkg/bundle/inspect.go` | Before the per-package validation loop, calls `prefetchPackageMetadata` (tarball providers only). `getMetadata` checks the cache first and falls back to the existing slow path on any prefetch error. |

## Why it works

The bundle is a `.tar.zst` containing an OCI layout. Tar is sequential and zstd is non-seekable, so finding *any* file means decompressing the bytes up to that file. Today's code:

1. Decompresses the full bundle multiple times — typically `1 + 2·N` times where `N` is the number of packages, once for `uds-bundle.yaml` and twice per package (manifest, then referenced metadata blobs).
2. Drains every stream to EOF because no handler ever returns `fs.SkipAll`.

This PR reduces that to:

1. **At most one full pass** (the batch prefetcher) for old bundles.
2. **Prefix-only decompression** for new bundles, because every blob the prefetcher needs is placed at the front of the tar at create time.

## Backwards compatibility

| Direction | Behavior |
|---|---|
| Old CLI reading new bundle | Works. Tar order is a hint, not a requirement. |
| New CLI reading old bundle | Works. Read-side logic doesn't assume order — it just `SkipAll`s later when blobs are scattered. |
| Bundle format version | Unchanged. |
| Required fields / annotations | None added. |
| Signature verification semantics | Unchanged on the validation path. The prefetcher writes the same files the existing verifier expects. |

## Reproducibility

Short answer: **this PR makes bundles more reproducible than before, not less** — but doesn't fully solve reproducibility.

### What changed

Before this PR, `writeTarball` did:

```go
files, _ := archives.FilesFromDisk(ctx, nil, artifactPathMap)  // map iteration → random order
for _, file := range files {
    jobs <- archives.ArchiveAsyncJob{File: file, ...}
}
```

`artifactPathMap` is a Go map. Iterating it is intentionally randomized, so the tar entry order varied across runs. Two `uds create` invocations on the same inputs produced two `.tar.zst` files with the same logical content but different byte layouts (and therefore different zstd output and different file digests).

After this PR, the same slice gets a `slices.SortFunc` pass that puts priority entries first in the given order, then everything else alphabetical by `NameInArchive`. `ArchiveAsync` is actually a serial loop under the hood, so channel order = tar order. **Tar entry order is now deterministic for a given input.**

### What this does and doesn't get you

| Property | Before | After |
|---|---|---|
| Tar entry order | Non-deterministic (map iteration) | Deterministic (priority then alpha) |
| Blob content / digests | Already content-addressed (reproducible) | Same |
| Inner OCI manifest digests | Reproducible | Same |
| File mtimes inside the tar | Leaked from filesystem (`FilesFromDisk` was called with `nil` opts — no `ClearAttributes`) | **Still leaked** — this PR didn't touch that |
| Final `.tar.zst` byte-for-byte | Not reproducible | Not reproducible — mtimes still vary, but closer than before |

### Side note

If full bit-for-bit reproducibility is something we want, the remaining fix is small and orthogonal: pass `&archives.FromDiskOptions{ClearAttributes: true}` to `FilesFromDisk` in `writeTarball` — that's what zarf already does in `archive.Compress`. Can be a follow-up PR.

### Practical impact for existing users

- **OCI-level verification** (registries pulling/pushing by manifest digest) is unaffected. The bundle root manifest digest is computed from the manifest's content, not the tar layout.
- **Anyone comparing bundle tarball SHA-256s** across builds was already comparing apples to apples only by accident — the prior random-order behavior meant their SHAs were never stable run-to-run anyway. This PR doesn't introduce a new instability there; if anything it removes one source of it.

</details>

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
