### PR TITLE
fix: disable bundle format signature explicitly

### DIFF
--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -262,6 +262,7 @@ func ValidateBundleSignature(bundleYAMLPath, signaturePath, publicKeyPath string
 	verifyBlobOptions := signing.DefaultVerifyBlobOptions()
 	verifyBlobOptions.Signature = signaturePath
 	verifyBlobOptions.Key = publicKeyPath
+	verifyBlobOptions.CommonVerifyOptions.NewBundleFormat = false
 	return signing.CosignVerifyBlobWithOptions(context.TODO(), bundleYAMLPath, verifyBlobOptions)
 }
 

--- a/src/pkg/bundle/create.go
+++ b/src/pkg/bundle/create.go
@@ -84,6 +84,7 @@ func (b *Bundle) Create(ctx context.Context) error {
 		signBlobOptions.OutputSignature = filepath.Join(b.tmp, config.BundleYAMLSignature)
 		signBlobOptions.PassFunc = getSigCreatePassword
 		signBlobOptions.Key = b.cfg.CreateOpts.SigningKeyPath
+		signBlobOptions.NewBundleFormat = false
 		_, err := signing.CosignSignBlobWithOptions(ctx, bundlePath, signBlobOptions)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description

This sets `NewBundleFormat` to false explicitly as changes in Cosign (consumed through the next Zarf update) would not produce a standard signature. 

This is to keep parity with current processes - it does not introduce any new support. 

Note that `verifyOptions` update is not strictly required but also sets explicit intent so as to not succumb to the same process in any future changes to cosign.

## Related Issue

Fixes #1409
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
