### PR TITLE
fix: error with deploying uds packages containing image archives via OCI

### DIFF
--- a/src/pkg/bundle/inspect.go
+++ b/src/pkg/bundle/inspect.go
@@ -157,9 +157,7 @@ func (b *Bundle) listImages() error {
 		}
 
 		// grab images from each filtered component
-		for _, component := range filteredComponents {
-			pkgImgMap[pkg.Name] = append(pkgImgMap[pkg.Name], component.GetImages()...)
-		}
+		pkgImgMap[pkg.Name] = append(pkgImgMap[pkg.Name], gatherComponentImages(filteredComponents)...)
 	}
 
 	pkgImgsOut, err := goyaml.Marshal(pkgImgMap)
@@ -168,6 +166,16 @@ func (b *Bundle) listImages() error {
 	}
 	fmt.Println(string(pkgImgsOut))
 	return nil
+}
+
+// gatherComponentImages returns all images across the given components, including
+// images bundled via imageArchives (component.GetImages accounts for both).
+func gatherComponentImages(components []v1alpha1.ZarfComponent) []string {
+	var images []string
+	for _, component := range components {
+		images = append(images, component.GetImages()...)
+	}
+	return images
 }
 
 // listVariables prints the variables and overrides for each package in the bundle

--- a/src/pkg/bundle/inspect.go
+++ b/src/pkg/bundle/inspect.go
@@ -158,7 +158,7 @@ func (b *Bundle) listImages() error {
 
 		// grab images from each filtered component
 		for _, component := range filteredComponents {
-			pkgImgMap[pkg.Name] = append(pkgImgMap[pkg.Name], component.Images...)
+			pkgImgMap[pkg.Name] = append(pkgImgMap[pkg.Name], component.GetImages()...)
 		}
 	}
 

--- a/src/pkg/bundle/inspect_test.go
+++ b/src/pkg/bundle/inspect_test.go
@@ -1,0 +1,64 @@
+// Copyright 2024 Defense Unicorns
+// SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+// Package bundle contains functions for interacting with, managing and deploying UDS packages
+package bundle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+)
+
+// TestGatherComponentImages ensures that `uds inspect --list-images` surfaces images referenced
+// via imageArchives, not just those in component.Images. Regression test for CLI-235.
+func TestGatherComponentImages(t *testing.T) {
+	const (
+		archiveImg = "ghcr.io/uds-packages/tinkerbell/hookos-artifacts:0.1.0"
+		regularImg = "ghcr.io/defenseunicorns/some-image:1.0.0"
+	)
+
+	tests := []struct {
+		name       string
+		components []v1alpha1.ZarfComponent
+		want       []string
+	}{
+		{
+			name:       "no components",
+			components: nil,
+			want:       nil,
+		},
+		{
+			name: "only imageArchives",
+			components: []v1alpha1.ZarfComponent{
+				{
+					Name: "hookos-artifacts",
+					ImageArchives: []v1alpha1.ImageArchive{
+						{Path: "image.tar", Images: []string{archiveImg}},
+					},
+				},
+			},
+			want: []string{archiveImg},
+		},
+		{
+			name: "images and imageArchives across components",
+			components: []v1alpha1.ZarfComponent{
+				{Name: "regular", Images: []string{regularImg}},
+				{
+					Name: "hookos-artifacts",
+					ImageArchives: []v1alpha1.ImageArchive{
+						{Path: "image.tar", Images: []string{archiveImg}},
+					},
+				},
+			},
+			want: []string{regularImg, archiveImg},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ElementsMatch(t, tt.want, gatherComponentImages(tt.components))
+		})
+	}
+}

--- a/src/pkg/sources/common.go
+++ b/src/pkg/sources/common.go
@@ -39,9 +39,10 @@ type PackageSource interface {
 // setAsYOLO sets the YOLO flag on a package and strips out all images and repos
 func setAsYOLO(pkg *v1alpha1.ZarfPackage) {
 	pkg.Metadata.YOLO = true
-	// strip out all images and repos
+	// strip out all images (including image archives) and repos
 	for idx := range pkg.Components {
 		pkg.Components[idx].Images = []string{}
+		pkg.Components[idx].ImageArchives = []v1alpha1.ImageArchive{}
 		pkg.Components[idx].Repos = []string{}
 	}
 }

--- a/src/pkg/sources/common_test.go
+++ b/src/pkg/sources/common_test.go
@@ -1,0 +1,42 @@
+// Copyright 2024 Defense Unicorns
+// SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+// Package sources contains Zarf packager sources
+package sources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+)
+
+// TestSetAsYOLO ensures YOLO mode strips images, image archives, and repos from every component.
+// imageArchives must be stripped too (CLI-235); otherwise a dev/YOLO deploy of a package with an
+// imageArchive would try to load images with no Zarf registry present.
+func TestSetAsYOLO(t *testing.T) {
+	pkg := &v1alpha1.ZarfPackage{
+		Components: []v1alpha1.ZarfComponent{
+			{
+				Name:   "with-images",
+				Images: []string{"ghcr.io/defenseunicorns/some-image:1.0.0"},
+				Repos:  []string{"https://github.com/defenseunicorns/uds-cli.git"},
+			},
+			{
+				Name: "with-archive",
+				ImageArchives: []v1alpha1.ImageArchive{
+					{Path: "image.tar", Images: []string{"ghcr.io/uds-packages/tinkerbell/hookos-artifacts:0.1.0"}},
+				},
+			},
+		},
+	}
+
+	setAsYOLO(pkg)
+
+	require.True(t, pkg.Metadata.YOLO)
+	for _, component := range pkg.Components {
+		require.Empty(t, component.Images, "images should be stripped for component %q", component.Name)
+		require.Empty(t, component.ImageArchives, "image archives should be stripped for component %q", component.Name)
+		require.Empty(t, component.Repos, "repos should be stripped for component %q", component.Name)
+	}
+}

--- a/src/pkg/utils/boci/oci.go
+++ b/src/pkg/utils/boci/oci.go
@@ -301,7 +301,7 @@ func FilterImageIndex(components []v1alpha1.ZarfComponent, imgIndex ocispec.Inde
 	manifestIncludeMap := map[string]ocispec.Descriptor{}
 	for _, manifest := range imgIndex.Manifests {
 		for _, component := range components {
-			for _, imgName := range component.Images {
+			for _, imgName := range component.GetImages() {
 				refInfo, err := transform.ParseImageRef(imgName)
 				if err != nil {
 					return nil, fmt.Errorf("failed to parse image ref %q: %w", imgName, err)

--- a/src/pkg/utils/boci/oci_test.go
+++ b/src/pkg/utils/boci/oci_test.go
@@ -1,0 +1,109 @@
+// Copyright 2024 Defense Unicorns
+// SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+package boci
+
+import (
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+)
+
+// manifestFor builds an image manifest descriptor annotated with the given base image name.
+func manifestFor(imgName string) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    digest.FromString(imgName),
+		Annotations: map[string]string{
+			ocispec.AnnotationBaseImageName: imgName,
+		},
+	}
+}
+
+// TestFilterImageIndex ensures that images referenced only via imageArchives are retained when
+// filtering the image index. Regression test for CLI-235: deploying an OCI bundle whose Zarf
+// package declares an imageArchive previously failed with "checksum missing in layout" because
+// FilterImageIndex only inspected component.Images and dropped the archive's manifest/blobs.
+func TestFilterImageIndex(t *testing.T) {
+	const (
+		archiveImg = "ghcr.io/uds-packages/tinkerbell/hookos-artifacts:0.1.0"
+		regularImg = "ghcr.io/defenseunicorns/some-image:1.0.0"
+		unusedImg  = "ghcr.io/defenseunicorns/not-referenced:2.0.0"
+	)
+
+	index := ocispec.Index{
+		Manifests: []ocispec.Descriptor{
+			manifestFor(archiveImg),
+			manifestFor(regularImg),
+			manifestFor(unusedImg),
+		},
+	}
+
+	tests := []struct {
+		name       string
+		components []v1alpha1.ZarfComponent
+		wantImages []string
+	}{
+		{
+			name: "only imageArchives",
+			components: []v1alpha1.ZarfComponent{
+				{
+					Name: "hookos-artifacts",
+					ImageArchives: []v1alpha1.ImageArchive{
+						{Path: "image.tar", Images: []string{archiveImg}},
+					},
+				},
+			},
+			wantImages: []string{archiveImg},
+		},
+		{
+			name: "only images",
+			components: []v1alpha1.ZarfComponent{
+				{Name: "regular", Images: []string{regularImg}},
+			},
+			wantImages: []string{regularImg},
+		},
+		{
+			name: "both images and imageArchives",
+			components: []v1alpha1.ZarfComponent{
+				{
+					Name:   "mixed",
+					Images: []string{regularImg},
+					ImageArchives: []v1alpha1.ImageArchive{
+						{Path: "image.tar", Images: []string{archiveImg}},
+					},
+				},
+			},
+			wantImages: []string{regularImg, archiveImg},
+		},
+		{
+			name: "no matching images",
+			components: []v1alpha1.ZarfComponent{
+				{Name: "empty"},
+			},
+			wantImages: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifests, err := FilterImageIndex(tt.components, index)
+			require.NoError(t, err)
+
+			gotDigests := make([]string, 0, len(manifests))
+			for _, m := range manifests {
+				gotDigests = append(gotDigests, m.Digest.String())
+			}
+
+			wantDigests := make([]string, 0, len(tt.wantImages))
+			for _, img := range tt.wantImages {
+				wantDigests = append(wantDigests, digest.FromString(img).String())
+			}
+
+			require.ElementsMatch(t, wantDigests, gotDigests)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Previously, when deploying a bundle that contained a zarf package which used image archives via OCI, an error similar to failed to deploy bundle: `file images/blobs/sha256/060d0cbd1c16ff5ded94971e621bcf61330bc34dbca76e29bb9329319a52797a` from checksum missing in layout would occur.

This was due to UDS CLI only looking at the images contained in the packages, not the images and image archives. Used Zarf's GetImages() helper to handle this.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
