### PR TITLE
chore: use new zarf function for registry plain-http decision logic

### DIFF
--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -233,13 +233,10 @@ func (b *Bundle) newDeployOptions(ctx context.Context, pkg types.Package, pkgVar
 }
 
 func shouldUsePlainHTTPForDeployRegistry(ctx context.Context, registryInfo state.RegistryInfo, insecure bool) (bool, error) {
-	if registryInfo.ShouldUseMTLS() {
-		return false, nil
+	if plainHTTP, known := registryInfo.KnownPlainHTTP(); known {
+		return plainHTTP, nil
 	}
-	if registryInfo.IsInternal() {
-		return true, nil
-	}
-	if registryInfo.Address == "" {
+	if !registryInfo.IsConfigured() {
 		return false, nil
 	}
 	return utils.NegotiatePlainHTTPForRegistry(ctx, registryInfo.Address, insecure)

--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -27,7 +27,6 @@ import (
 	"github.com/zarf-dev/zarf/src/pkg/packager"
 	"github.com/zarf-dev/zarf/src/pkg/packager/filters"
 	"github.com/zarf-dev/zarf/src/pkg/state"
-	zarfState "github.com/zarf-dev/zarf/src/pkg/state"
 	zarfUtils "github.com/zarf-dev/zarf/src/pkg/utils"
 	zarfTypes "github.com/zarf-dev/zarf/src/types"
 	"golang.org/x/exp/slices"
@@ -185,7 +184,7 @@ func deployPackages(ctx context.Context, packagesToDeploy []types.Package, b *Bu
 		bundleExportedVars[pkg.Name] = pkgExportedVars
 
 		if !pkgLayout.Pkg.IsInitConfig() {
-			connectStrings := zarfState.ConnectStrings{}
+			connectStrings := state.ConnectStrings{}
 			for _, comp := range result.DeployedComponents {
 				for _, chart := range comp.InstalledCharts {
 					for k, v := range chart.ConnectStrings {

--- a/src/pkg/bundle/deploy_test.go
+++ b/src/pkg/bundle/deploy_test.go
@@ -842,6 +842,7 @@ func Test_shouldUsePlainHTTPForDeployRegistry(t *testing.T) {
 		{
 			name: "internal registry uses plain http",
 			registryInfo: state.RegistryInfo{
+				Address:      "127.0.0.1:1",
 				RegistryMode: state.RegistryModeNodePort,
 			},
 			expected: true,
@@ -850,10 +851,17 @@ func Test_shouldUsePlainHTTPForDeployRegistry(t *testing.T) {
 			name:     "internal mtls registry does not force plain http even when insecure",
 			insecure: true,
 			registryInfo: state.RegistryInfo{
+				Address:      "127.0.0.1:1",
 				RegistryMode: state.RegistryModeNodePort,
 				MTLSStrategy: state.MTLSStrategyZarfManaged,
 			},
 			expected: false,
+		},
+		{
+			name:         "package without image registry defaults to https",
+			insecure:     true,
+			registryInfo: state.RegistryInfo{},
+			expected:     false,
 		},
 		{
 			name: "external registry does not force plain http",

--- a/src/pkg/bundle/deploy_test.go
+++ b/src/pkg/bundle/deploy_test.go
@@ -858,7 +858,7 @@ func Test_shouldUsePlainHTTPForDeployRegistry(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:         "package without image registry defaults to https",
+			name:         "unconfigured registry skips transport negotiation",
 			insecure:     true,
 			registryInfo: state.RegistryInfo{},
 			expected:     false,


### PR DESCRIPTION
## Description

Small cleanup PR to replace some custom logic for determining zarf registry transport settings that was added in our upgrade to zarf `v0.81.0` with a new zarf function added in `v0.81.1` (see https://github.com/zarf-dev/zarf/pull/5054)

Small cleanup to remove duplicate import and address unrelated, but valid, Copilot feedback

## Related Issue

Relates to #1414

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
