### PR TITLE
feat: mask sensitive zarf vars

### DIFF
--- a/src/cmd/common.go
+++ b/src/cmd/common.go
@@ -59,7 +59,11 @@ func deploy(ctx context.Context, bndlClient *bundle.Bundle) error {
 	}
 
 	// confirm deployment
-	if ok := bndlClient.ConfirmBundleDeploy(); !ok {
+	ok, err := bndlClient.ConfirmBundleDeploy()
+	if err != nil {
+		return fmt.Errorf("failed to confirm bundle deployment: %w", err)
+	}
+	if !ok {
 		return errors.New("bundle deployment cancelled")
 	}
 

--- a/src/pkg/bundle/common.go
+++ b/src/pkg/bundle/common.go
@@ -19,6 +19,7 @@ import (
 	"github.com/defenseunicorns/uds-cli/src/pkg/message"
 	"github.com/defenseunicorns/uds-cli/src/pkg/utils"
 	"github.com/defenseunicorns/uds-cli/src/types"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/cluster"
@@ -365,6 +366,20 @@ func bundlePackageLifecycleID(pkg types.Package) string {
 	}
 
 	return fmt.Sprintf("%s/%s", pkg.Name, pkg.Namespace)
+}
+
+func packageManifestDigest(pkg types.Package) (string, error) {
+	_, encoded, ok := strings.Cut(pkg.Ref, "@sha256:")
+	if !ok || encoded == "" {
+		return "", fmt.Errorf("package %q reference is missing a manifest digest", pkg.Name)
+	}
+
+	manifestDigest := digest.NewDigestFromEncoded(digest.SHA256, encoded)
+	if err := manifestDigest.Validate(); err != nil {
+		return "", fmt.Errorf("package %q has invalid manifest digest: %w", pkg.Name, err)
+	}
+
+	return encoded, nil
 }
 
 func deployedPackageLifecycleID(pkg state.DeployedPackage) string {

--- a/src/pkg/bundle/common_test.go
+++ b/src/pkg/bundle/common_test.go
@@ -70,6 +70,49 @@ func Test_validateBundleVars(t *testing.T) {
 	}
 }
 
+func TestPackageManifestDigest(t *testing.T) {
+	tests := []struct {
+		name           string
+		ref            string
+		expectedDigest string
+		expectedError  string
+	}{
+		{
+			name:           "returns manifest digest",
+			ref:            "ghcr.io/example/package:0.0.1@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			expectedDigest: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		},
+		{
+			name:          "rejects ref without digest",
+			ref:           "ghcr.io/example/package:0.0.1",
+			expectedError: "reference is missing a manifest digest",
+		},
+		{
+			name:          "rejects empty digest",
+			ref:           "ghcr.io/example/package:0.0.1@sha256:",
+			expectedError: "reference is missing a manifest digest",
+		},
+		{
+			name:          "rejects malformed digest",
+			ref:           "ghcr.io/example/package:0.0.1@sha256:abc123",
+			expectedError: "invalid manifest digest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			digest, err := packageManifestDigest(types.Package{Name: "test-package", Ref: tt.ref})
+
+			if tt.expectedError != "" {
+				require.ErrorContains(t, err, tt.expectedError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedDigest, digest)
+		})
+	}
+}
+
 func Test_validateOverrides(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -492,7 +492,17 @@ func formPkgViews(b *Bundle) []PkgView {
 			}
 		}
 
-		variables = addZarfVars(variableData, variables)
+		// Load the package metadata to get the list of sensitive variables for masking their values in the view
+		zarfPkg, err := b.getMetadata(pkg)
+		sensitiveVars := sensitiveZarfVariableNames(zarfPkg.Variables)
+		if err != nil {
+			message.WarnErr(err, fmt.Sprintf("unable to load metadata for package %q; masking all Zarf variable values", pkg.Name))
+			for name := range variableData {
+				sensitiveVars[name] = true
+			}
+		}
+
+		variables = addZarfVars(variableData, variables, sensitiveVars)
 		pkgViews = append(pkgViews, PkgView{meta: formPkgMeta(pkg), overrides: map[string]interface{}{"overrides": variables}})
 	}
 	return pkgViews
@@ -514,7 +524,17 @@ func formPkgMeta(pkg types.Package) map[string]string {
 	return pkgMeta
 }
 
-func addZarfVars(pkgVars map[string]overrideData, variables []interface{}) []interface{} {
+func sensitiveZarfVariableNames(variables []v1alpha1.InteractiveVariable) map[string]bool {
+	sensitiveVars := make(map[string]bool)
+	for _, variable := range variables {
+		if variable.Sensitive {
+			sensitiveVars[strings.ToUpper(variable.Name)] = true
+		}
+	}
+	return sensitiveVars
+}
+
+func addZarfVars(pkgVars map[string]overrideData, variables []interface{}, sensitiveVars map[string]bool) []interface{} {
 	// Built-in sensitive variables that should be sanitized
 	sensitiveBuiltInVars := map[string]bool{
 		config.RegistryPushUsername: true,
@@ -534,7 +554,7 @@ func addZarfVars(pkgVars map[string]overrideData, variables []interface{}) []int
 		// "CONFIG" refers to "UDS_CONFIG" which is not a Zarf variable or override so we skip it
 		if key != "CONFIG" {
 			// Mask potentially secret ENV vars or built-in sensitive variables
-			if fv.source == valuesources.Env || sensitiveBuiltInVars[key] {
+			if fv.source == valuesources.Env || sensitiveBuiltInVars[key] || sensitiveVars[key] {
 				fv.value = hiddenVar
 			}
 			variables = append(variables, map[string]interface{}{key: fv.value})

--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -89,6 +89,10 @@ func deployPackages(ctx context.Context, packagesToDeploy []types.Package, b *Bu
 			}
 			b.bundle.Packages[i] = pkg
 		}
+		sha, err := packageManifestDigest(pkg)
+		if err != nil {
+			return err
+		}
 		pkgTmp, err := zarfUtils.MakeTempDir(config.CommonOptions.TempDirectory)
 		if err != nil {
 			return err
@@ -114,8 +118,6 @@ func deployPackages(ctx context.Context, packagesToDeploy []types.Package, b *Bu
 		if err != nil {
 			return err
 		}
-
-		sha := strings.Split(pkg.Ref, "@sha256:")[1] // using appended SHA from create!
 
 		source, err := sources.NewFromLocation(*b.cfg, pkg, pkgTmp, verifyOpts, config.CommonOptions.SkipSignatureValidation, sha, nsOverrides)
 		if err != nil {
@@ -412,9 +414,12 @@ func (b *Bundle) PreDeployValidation() (string, string, string, error) {
 	return bundleName, string(bundleYAML), source, err
 }
 
-// ConfirmBundleDeploy prompts the user to confirm bundle creation
-func (b *Bundle) ConfirmBundleDeploy() (confirm bool) {
-	pkgviews := formPkgViews(b)
+// ConfirmBundleDeploy prompts the user to confirm bundle deployment
+func (b *Bundle) ConfirmBundleDeploy() (bool, error) {
+	pkgViews, err := formPkgViews(b)
+	if err != nil {
+		return false, err
+	}
 
 	message.HeaderInfof("🎁 BUNDLE DEFINITION")
 
@@ -434,7 +439,7 @@ func (b *Bundle) ConfirmBundleDeploy() (confirm bool) {
 
 	message.Title("Packages:", "definition of packages this bundle deploys, including variable overrides")
 
-	for _, pkg := range pkgviews {
+	for _, pkg := range pkgViews {
 		if err := zarfUtils.ColorPrintYAML(pkg.meta, nil, false); err != nil {
 			message.WarnErr(err, "unable to print package metadata yaml")
 		}
@@ -447,17 +452,21 @@ func (b *Bundle) ConfirmBundleDeploy() (confirm bool) {
 
 	// Display prompt if not auto-confirmed
 	if config.CommonOptions.Confirm {
-		return config.CommonOptions.Confirm
+		return config.CommonOptions.Confirm, nil
 	}
 
 	prompt := &survey.Confirm{
 		Message: "Deploy this bundle?",
 	}
 
-	if err := survey.AskOne(prompt, &confirm); err != nil || !confirm {
-		return false
+	var confirm bool
+	if err := survey.AskOne(prompt, &confirm); err != nil {
+		return false, err
 	}
-	return true
+	if !confirm {
+		return false, nil
+	}
+	return true, nil
 }
 
 type PkgView struct {
@@ -466,7 +475,11 @@ type PkgView struct {
 }
 
 // formPkgViews creates a unique pre deploy view of each package's set overrides and Zarf variables
-func formPkgViews(b *Bundle) []PkgView {
+func formPkgViews(b *Bundle) ([]PkgView, error) {
+	return formPkgViewsWithMetadata(b, b.getMetadata)
+}
+
+func formPkgViewsWithMetadata(b *Bundle, getMetadata func(types.Package) (v1alpha1.ZarfPackage, error)) ([]PkgView, error) {
 	var pkgViews []PkgView
 	for _, pkg := range b.bundle.Packages {
 		variables := make([]interface{}, 0)
@@ -476,7 +489,10 @@ func formPkgViews(b *Bundle) []PkgView {
 		valuesOverrides, _, _ := b.loadChartOverrides(pkg, variableData)
 
 		// Load the package metadata to get the list of sensitive variables for masking their values in the view
-		zarfPkg, err := b.getMetadata(pkg)
+		zarfPkg, err := getMetadata(pkg)
+		if err != nil {
+			return nil, fmt.Errorf("unable to load metadata for package %q: %w", pkg.Name, err)
+		}
 		sensitiveVars := sensitiveZarfVariableNames(zarfPkg.Variables)
 
 		for compName, component := range pkg.Overrides {
@@ -498,17 +514,10 @@ func formPkgViews(b *Bundle) []PkgView {
 			}
 		}
 
-		if err != nil {
-			message.WarnErr(err, fmt.Sprintf("unable to load metadata for package %q; masking all Zarf variable values", pkg.Name))
-			for name := range variableData {
-				sensitiveVars[name] = true
-			}
-		}
-
 		variables = addZarfVars(variableData, variables, sensitiveVars)
 		pkgViews = append(pkgViews, PkgView{meta: formPkgMeta(pkg), overrides: map[string]interface{}{"overrides": variables}})
 	}
-	return pkgViews
+	return pkgViews, nil
 }
 
 func formPkgMeta(pkg types.Package) map[string]string {

--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -406,6 +406,8 @@ func (b *Bundle) PreDeployValidation() (string, string, string, error) {
 		return "", "", "", err
 	}
 
+	b.prefetchPackageMetadata(provider)
+
 	bundleName := b.bundle.Metadata.Name
 	return bundleName, string(bundleYAML), source, err
 }

--- a/src/pkg/bundle/deploy.go
+++ b/src/pkg/bundle/deploy.go
@@ -473,6 +473,10 @@ func formPkgViews(b *Bundle) []PkgView {
 		_, variableData := b.loadVariables(pkg, nil)
 		valuesOverrides, _, _ := b.loadChartOverrides(pkg, variableData)
 
+		// Load the package metadata to get the list of sensitive variables for masking their values in the view
+		zarfPkg, err := b.getMetadata(pkg)
+		sensitiveVars := sensitiveZarfVariableNames(zarfPkg.Variables)
+
 		for compName, component := range pkg.Overrides {
 			for chartName, chart := range component {
 				// filter out bundle overrides so we're left with Zarf Variables
@@ -484,7 +488,7 @@ func formPkgViews(b *Bundle) []PkgView {
 				}
 
 				// takes values from helmChartVars {path: value} and form new map of {name: value}
-				viewVars := extractValues(helmChartVars, chart.Variables)
+				viewVars := extractValues(helmChartVars, chart.Variables, sensitiveVars)
 
 				if len(viewVars) > 0 {
 					variables = append(variables, map[string]map[string]interface{}{chartName: {"variables": viewVars}})
@@ -492,9 +496,6 @@ func formPkgViews(b *Bundle) []PkgView {
 			}
 		}
 
-		// Load the package metadata to get the list of sensitive variables for masking their values in the view
-		zarfPkg, err := b.getMetadata(pkg)
-		sensitiveVars := sensitiveZarfVariableNames(zarfPkg.Variables)
 		if err != nil {
 			message.WarnErr(err, fmt.Sprintf("unable to load metadata for package %q; masking all Zarf variable values", pkg.Name))
 			for name := range variableData {
@@ -564,15 +565,14 @@ func addZarfVars(pkgVars map[string]overrideData, variables []interface{}, sensi
 }
 
 // extractValues returns a map of {name: value} from helmChartVars
-func extractValues(helmChartVars map[string]interface{}, variables []types.BundleChartVariable) map[string]interface{} {
+func extractValues(helmChartVars map[string]interface{}, variables []types.BundleChartVariable, sensitiveVars map[string]bool) map[string]interface{} {
 	viewVars := make(map[string]interface{})
 	for _, v := range variables {
 		// Mask potentially sensitive variables
-		if v.Type == chartvariable.File || v.Source == valuesources.Env || v.Sensitive {
+		if v.Type == chartvariable.File || v.Source == valuesources.Env || v.Sensitive || sensitiveVars[strings.ToUpper(v.Name)] {
 			viewVars[v.Name] = hiddenVar
 			continue
 		}
-
 		// handle complex paths: var.helm.path = { var: { helm: { path: val } } }
 		if strings.Contains(v.Path, ".") {
 			paths := strings.Split(v.Path, ".")

--- a/src/pkg/bundle/deploy_test.go
+++ b/src/pkg/bundle/deploy_test.go
@@ -689,6 +689,23 @@ func TestFormPkgViews(t *testing.T) {
 	}
 }
 
+func TestExtractValuesMasksSensitiveZarfVariableCollisions(t *testing.T) {
+	helmChartVars := map[string]interface{}{
+		"sensitive": "chart-sensitive-value",
+		"public":    "chart-public-value",
+	}
+	chartVariables := []types.BundleChartVariable{
+		{Name: "sensitive_chart_var", Path: "sensitive"},
+		{Name: "PUBLIC_CHART_VAR", Path: "public"},
+	}
+	sensitiveVars := map[string]bool{"SENSITIVE_CHART_VAR": true}
+
+	viewVars := extractValues(helmChartVars, chartVariables, sensitiveVars)
+
+	require.Equal(t, hiddenVar, viewVars["sensitive_chart_var"])
+	require.Equal(t, "chart-public-value", viewVars["PUBLIC_CHART_VAR"])
+}
+
 func TestZarfSensitiveVariablesAreMasked(t *testing.T) {
 	zarfVariables := []v1alpha1.InteractiveVariable{
 		{Variable: v1alpha1.Variable{Name: "SENSITIVE_VAR", Sensitive: true}},

--- a/src/pkg/bundle/deploy_test.go
+++ b/src/pkg/bundle/deploy_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/defenseunicorns/uds-cli/src/config"
 	"github.com/defenseunicorns/uds-cli/src/types"
 	"github.com/defenseunicorns/uds-cli/src/types/chartvariable"
 	"github.com/defenseunicorns/uds-cli/src/types/valuesources"
@@ -701,25 +702,56 @@ func TestExtractValuesMasksSensitiveZarfVariableCollisions(t *testing.T) {
 	require.Equal(t, "chart-public-value", viewVars["PUBLIC_CHART_VAR"])
 }
 
-func TestZarfSensitiveVariablesAreMasked(t *testing.T) {
-	zarfVariables := []v1alpha1.InteractiveVariable{
-		{Variable: v1alpha1.Variable{Name: "SENSITIVE_VAR", Sensitive: true}},
-		{Variable: v1alpha1.Variable{Name: "PUBLIC_VAR"}},
+func TestAddZarfVars(t *testing.T) {
+	tests := []struct {
+		name          string
+		variableData  map[string]overrideData
+		zarfVariables []v1alpha1.InteractiveVariable
+		expected      []interface{}
+	}{
+		{
+			name:         "masks a sensitive variable from config",
+			variableData: map[string]overrideData{"SENSITIVE_VAR": {value: "sensitive-value", source: valuesources.Config}},
+			zarfVariables: []v1alpha1.InteractiveVariable{
+				{Variable: v1alpha1.Variable{Name: "sensitive_var", Sensitive: true}},
+			},
+			expected: []interface{}{map[string]interface{}{"SENSITIVE_VAR": hiddenVar}},
+		},
+		{
+			name:         "masks a sensitive variable from the CLI",
+			variableData: map[string]overrideData{"SENSITIVE_VAR": {value: "sensitive-value", source: valuesources.CLI}},
+			zarfVariables: []v1alpha1.InteractiveVariable{
+				{Variable: v1alpha1.Variable{Name: "SENSITIVE_VAR", Sensitive: true}},
+			},
+			expected: []interface{}{map[string]interface{}{"SENSITIVE_VAR": hiddenVar}},
+		},
+		{
+			name:         "shows a public variable",
+			variableData: map[string]overrideData{"PUBLIC_VAR": {value: "public-value", source: valuesources.Config}},
+			expected:     []interface{}{map[string]interface{}{"PUBLIC_VAR": "public-value"}},
+		},
+		{
+			name:         "masks an environment variable",
+			variableData: map[string]overrideData{"ENV_VAR": {value: "environment-value", source: valuesources.Env}},
+			expected:     []interface{}{map[string]interface{}{"ENV_VAR": hiddenVar}},
+		},
+		{
+			name:         "masks a built-in sensitive variable",
+			variableData: map[string]overrideData{config.RegistryPushPassword: {value: "registry-password", source: valuesources.Config}},
+			expected:     []interface{}{map[string]interface{}{config.RegistryPushPassword: hiddenVar}},
+		},
+		{
+			name:         "skips the UDS config path",
+			variableData: map[string]overrideData{"CONFIG": {value: "uds-config.yaml", source: valuesources.Env}},
+			expected:     []interface{}{},
+		},
 	}
 
-	for _, source := range []valuesources.Source{valuesources.Config, valuesources.CLI} {
-		t.Run(string(source), func(t *testing.T) {
-			variableData := map[string]overrideData{
-				"SENSITIVE_VAR": {value: "sensitive-value", source: source},
-				"PUBLIC_VAR":    {value: "public-value", source: source},
-			}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			variables := addZarfVars(tt.variableData, nil, sensitiveZarfVariableNames(tt.zarfVariables))
 
-			variables := addZarfVars(variableData, nil, sensitiveZarfVariableNames(zarfVariables))
-
-			require.ElementsMatch(t, []interface{}{
-				map[string]interface{}{"SENSITIVE_VAR": hiddenVar},
-				map[string]interface{}{"PUBLIC_VAR": "public-value"},
-			}, variables)
+			require.ElementsMatch(t, tt.expected, variables)
 		})
 	}
 }

--- a/src/pkg/bundle/deploy_test.go
+++ b/src/pkg/bundle/deploy_test.go
@@ -6,6 +6,7 @@ package bundle
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -48,6 +49,16 @@ func newTestPkg(pkgName string, componentName string, chartName string, overVar 
 		Overrides: map[string]map[string]types.BundleChartOverrides{componentName: {chartName: {Variables: []types.BundleChartVariable{
 			overVar,
 		}}}}}
+}
+
+func formTestPkgViews(t *testing.T, bundle *Bundle) []PkgView {
+	t.Helper()
+
+	pkgViews, err := formPkgViewsWithMetadata(bundle, func(types.Package) (v1alpha1.ZarfPackage, error) {
+		return v1alpha1.ZarfPackage{}, nil
+	})
+	require.NoError(t, err)
+	return pkgViews
 }
 
 func TestLoadVariablesPrecedence(t *testing.T) {
@@ -516,7 +527,7 @@ func TestFormPkgViews(t *testing.T) {
 				tc.Bundle.bundle = types.UDSBundle{Packages: []types.Package{newTestPkg(pkgName, componentName, chartName, tc.bundleVars)}}
 			}
 
-			pkgViews := formPkgViews(&tc.Bundle)
+			pkgViews := formTestPkgViews(t, &tc.Bundle)
 			v, ok := pkgViews[0].overrides["overrides"].(anyArr)[0].(viewOverVars)[tc.expectedChart]["variables"]
 
 			// check if the second chart is being used -- Go maps don't have strict ordering so value could be in 0 index or 1 index
@@ -529,22 +540,6 @@ func TestFormPkgViews(t *testing.T) {
 	}
 
 	zarfVarTests := []TestCase{
-		{
-			name: "mask zarf var when package metadata is unavailable",
-			Bundle: newTestBundle(
-				ConfigVariables{
-					pkgName: {
-						"VAR1": "zarf-var-set-by-config",
-					},
-				},
-				nil,
-				nil,
-				"uds-config.yaml",
-				"",
-			),
-			expectedKey: "VAR1",
-			expectedVal: hiddenVar,
-		},
 		{
 			name:        "hide zarf var with env var",
 			loadEnv:     true,
@@ -660,7 +655,7 @@ func TestFormPkgViews(t *testing.T) {
 			}
 
 			zarfVarTest.Bundle.bundle = types.UDSBundle{Packages: []types.Package{{Name: pkgName}}}
-			pkgViews := formPkgViews(&zarfVarTest.Bundle)
+			pkgViews := formTestPkgViews(t, &zarfVarTest.Bundle)
 			actualView := pkgViews[0].overrides["overrides"].(anyArr)[0]
 			require.Contains(t, actualView.(map[string]interface{})[zarfVarTest.expectedKey], zarfVarTest.expectedVal)
 		})
@@ -682,7 +677,7 @@ func TestFormPkgViews(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.Bundle.bundle = types.UDSBundle{Packages: []types.Package{newTestPkg(pkgName, componentName, chartName, tc.bundleVars)}}
 
-			pkgViews := formPkgViews(&tc.Bundle)
+			pkgViews := formTestPkgViews(t, &tc.Bundle)
 			v := pkgViews[0].overrides["overrides"]
 			require.Equal(t, 0, len(v.(anyArr)))
 		})
@@ -729,7 +724,7 @@ func TestZarfSensitiveVariablesAreMasked(t *testing.T) {
 	}
 }
 
-func TestFormPkgViewsMasksZarfVariablesWhenMetadataIsUnavailable(t *testing.T) {
+func TestFormPkgViewsReturnsErrorWhenMetadataIsUnavailable(t *testing.T) {
 	const (
 		pkgName      = "test-package"
 		variableName = "VAR1"
@@ -743,10 +738,22 @@ func TestFormPkgViewsMasksZarfVariablesWhenMetadataIsUnavailable(t *testing.T) {
 	)
 	bundle.bundle = types.UDSBundle{Packages: []types.Package{{Name: pkgName}}}
 
-	pkgViews := formPkgViews(&bundle)
+	metadataErr := errors.New("metadata unavailable")
+	pkgViews, err := formPkgViewsWithMetadata(&bundle, func(types.Package) (v1alpha1.ZarfPackage, error) {
+		return v1alpha1.ZarfPackage{}, metadataErr
+	})
 
-	overrides := pkgViews[0].overrides["overrides"].([]interface{})
-	require.Equal(t, map[string]interface{}{variableName: hiddenVar}, overrides[0])
+	require.Nil(t, pkgViews)
+	require.ErrorContains(t, err, `unable to load metadata for package "test-package"`)
+	require.ErrorIs(t, err, metadataErr)
+}
+
+func TestDeployPackagesRejectsMissingManifestDigest(t *testing.T) {
+	var err error
+	require.NotPanics(t, func() {
+		err = deployPackages(context.Background(), []types.Package{{Name: "test-package", Ref: "0.0.1"}}, &Bundle{})
+	})
+	require.ErrorContains(t, err, `package "test-package" reference is missing a manifest digest`)
 }
 
 func TestFilterOverrides(t *testing.T) {

--- a/src/pkg/bundle/deploy_test.go
+++ b/src/pkg/bundle/deploy_test.go
@@ -530,7 +530,7 @@ func TestFormPkgViews(t *testing.T) {
 
 	zarfVarTests := []TestCase{
 		{
-			name: "show zarf var",
+			name: "mask zarf var when package metadata is unavailable",
 			Bundle: newTestBundle(
 				ConfigVariables{
 					pkgName: {
@@ -543,7 +543,7 @@ func TestFormPkgViews(t *testing.T) {
 				"",
 			),
 			expectedKey: "VAR1",
-			expectedVal: "zarf-var-set-by-config",
+			expectedVal: hiddenVar,
 		},
 		{
 			name:        "hide zarf var with env var",
@@ -687,6 +687,49 @@ func TestFormPkgViews(t *testing.T) {
 			require.Equal(t, 0, len(v.(anyArr)))
 		})
 	}
+}
+
+func TestZarfSensitiveVariablesAreMasked(t *testing.T) {
+	zarfVariables := []v1alpha1.InteractiveVariable{
+		{Variable: v1alpha1.Variable{Name: "SENSITIVE_VAR", Sensitive: true}},
+		{Variable: v1alpha1.Variable{Name: "PUBLIC_VAR"}},
+	}
+
+	for _, source := range []valuesources.Source{valuesources.Config, valuesources.CLI} {
+		t.Run(string(source), func(t *testing.T) {
+			variableData := map[string]overrideData{
+				"SENSITIVE_VAR": {value: "sensitive-value", source: source},
+				"PUBLIC_VAR":    {value: "public-value", source: source},
+			}
+
+			variables := addZarfVars(variableData, nil, sensitiveZarfVariableNames(zarfVariables))
+
+			require.ElementsMatch(t, []interface{}{
+				map[string]interface{}{"SENSITIVE_VAR": hiddenVar},
+				map[string]interface{}{"PUBLIC_VAR": "public-value"},
+			}, variables)
+		})
+	}
+}
+
+func TestFormPkgViewsMasksZarfVariablesWhenMetadataIsUnavailable(t *testing.T) {
+	const (
+		pkgName      = "test-package"
+		variableName = "VAR1"
+	)
+	bundle := newTestBundle(
+		ConfigVariables{pkgName: {variableName: "sensitive-value"}},
+		nil,
+		nil,
+		"uds-config.yaml",
+		"",
+	)
+	bundle.bundle = types.UDSBundle{Packages: []types.Package{{Name: pkgName}}}
+
+	pkgViews := formPkgViews(&bundle)
+
+	overrides := pkgViews[0].overrides["overrides"].([]interface{})
+	require.Equal(t, map[string]interface{}{variableName: hiddenVar}, overrides[0])
 }
 
 func TestFilterOverrides(t *testing.T) {

--- a/src/pkg/bundle/inspect.go
+++ b/src/pkg/bundle/inspect.go
@@ -261,9 +261,9 @@ func (b *Bundle) getMetadata(pkg types.Package) (v1alpha1.ZarfPackage, error) {
 			return v1alpha1.ZarfPackage{}, fmt.Errorf("package %q: %w", pkg.Name, err)
 		}
 
-		_, sha, ok := strings.Cut(pkg.Ref, "@sha256:")
-		if !ok || sha == "" {
-			return v1alpha1.ZarfPackage{}, fmt.Errorf("package %q reference is missing a manifest digest", pkg.Name)
+		sha, err := packageManifestDigest(pkg)
+		if err != nil {
+			return v1alpha1.ZarfPackage{}, err
 		}
 		source, err := sources.NewFromLocation(*b.cfg, pkg, pkgTmp, verifyOpts, config.CommonOptions.SkipSignatureValidation, sha, nil)
 		if err != nil {

--- a/src/pkg/bundle/inspect.go
+++ b/src/pkg/bundle/inspect.go
@@ -258,7 +258,10 @@ func (b *Bundle) getMetadata(pkg types.Package) (v1alpha1.ZarfPackage, error) {
 			return v1alpha1.ZarfPackage{}, fmt.Errorf("package %q: %w", pkg.Name, err)
 		}
 
-		sha := strings.Split(pkg.Ref, "@sha256:")[1] // using appended SHA from create!
+		_, sha, ok := strings.Cut(pkg.Ref, "@sha256:")
+		if !ok || sha == "" {
+			return v1alpha1.ZarfPackage{}, fmt.Errorf("package %q reference is missing a manifest digest", pkg.Name)
+		}
 		source, err := sources.NewFromLocation(*b.cfg, pkg, pkgTmp, verifyOpts, config.CommonOptions.SkipSignatureValidation, sha, nil)
 		if err != nil {
 			return v1alpha1.ZarfPackage{}, err

--- a/src/pkg/bundle/inspect.go
+++ b/src/pkg/bundle/inspect.go
@@ -80,16 +80,7 @@ func (b *Bundle) Inspect() error {
 		// fetch metadata blobs independently.
 		needsPkgMeta := b.cfg.InspectOpts.ListVariables || b.cfg.InspectOpts.ListImages || !config.CommonOptions.SkipSignatureValidation
 		if needsPkgMeta {
-			if tp, ok := provider.(*tarballBundleProvider); ok {
-				cache, perr := tp.prefetchPackageMetadata(context.TODO(), b.bundle.Packages, b.tmp)
-				if perr != nil {
-					// Fall back to the per-package slow path on any error so
-					// inspect still works on bundles the prefetcher can't handle.
-					message.Warnf("package metadata prefetch failed, falling back to per-package extraction: %v", perr)
-				} else {
-					b.pkgMetaCache = cache
-				}
-			}
+			b.prefetchPackageMetadata(provider)
 		}
 	}
 
@@ -132,6 +123,18 @@ func (b *Bundle) Inspect() error {
 	}
 
 	return nil
+}
+func (b *Bundle) prefetchPackageMetadata(provider Provider) {
+	if tp, ok := provider.(*tarballBundleProvider); ok {
+		cache, perr := tp.prefetchPackageMetadata(context.TODO(), b.bundle.Packages, b.tmp)
+		if perr != nil {
+			// Fall back to the per-package slow path on any error so
+			// the operation still works on bundles the prefetcher can't handle.
+			message.Warnf("package metadata prefetch failed, falling back to per-package extraction: %v", perr)
+		} else {
+			b.pkgMetaCache = cache
+		}
+	}
 }
 
 func (b *Bundle) listImages() error {

--- a/src/pkg/bundle/tarball_prefetch.go
+++ b/src/pkg/bundle/tarball_prefetch.go
@@ -160,13 +160,28 @@ func (tp *tarballBundleProvider) prefetchPackageMetadata(ctx context.Context, pa
 		return nil
 	}
 
-	srcFile, err := os.Open(tp.src)
-	if err != nil {
+	runPass := func() error {
+		srcFile, err := os.Open(tp.src)
+		if err != nil {
+			return err
+		}
+		defer srcFile.Close()
+		return config.BundleArchiveFormat.Extract(ctx, srcFile, handler)
+	}
+
+	if err := runPass(); err != nil {
 		return nil, err
 	}
-	defer srcFile.Close()
-	if err := config.BundleArchiveFormat.Extract(ctx, srcFile, handler); err != nil {
-		return nil, err
+	// Pulled or older bundles may place metadata before its package manifest.
+	// Once the first pass has parsed every manifest, retry only the metadata
+	// blobs that appeared too early in the stream.
+	if len(needed) > 0 && len(parsedManifests) == len(entries) {
+		if err := runPass(); err != nil {
+			return nil, err
+		}
+	}
+	if len(needed) > 0 && len(parsedManifests) == len(entries) {
+		return nil, fmt.Errorf("%d required package metadata blobs not found in bundle", len(needed))
 	}
 
 	// Resolve each package: write its metadata files to per-package subdirs.

--- a/src/pkg/bundle/tarball_prefetch_test.go
+++ b/src/pkg/bundle/tarball_prefetch_test.go
@@ -334,7 +334,8 @@ func TestDeployPrefetchReusesMetadataDuringPreview(t *testing.T) {
 	})
 
 	// A visible non-sensitive value distinguishes cache reuse from fail-closed masking.
-	views := formPkgViews(&b)
+	views, err := formPkgViews(&b)
+	require.NoError(t, err)
 	require.Len(t, views, 1)
 	overrides := views[0].overrides["overrides"]
 	require.Contains(t, overrides, map[string]interface{}{"PASSWORD": hiddenVar})

--- a/src/pkg/bundle/tarball_prefetch_test.go
+++ b/src/pkg/bundle/tarball_prefetch_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/api/v1alpha1"
 	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 )
 
@@ -270,4 +271,72 @@ func TestPrefetchPackageMetadata(t *testing.T) {
 		}, t.TempDir())
 		require.ErrorContains(t, err, "not found in bundle")
 	})
+}
+
+func TestDeployPrefetchReusesMetadataDuringPreview(t *testing.T) {
+	ctx := context.Background()
+	// Build valid package metadata containing both sensitive and non-sensitive variables.
+	pkgLayout, err := layout.AssembleSkeleton(ctx, v1alpha1.ZarfPackage{
+		Kind: v1alpha1.ZarfPackageConfig,
+		Metadata: v1alpha1.ZarfMetadata{
+			Name:    "internal-package",
+			Version: "1.2.3",
+		},
+		Variables: []v1alpha1.InteractiveVariable{
+			{
+				Variable: v1alpha1.Variable{
+					Name:      "PASSWORD",
+					Sensitive: true,
+				},
+			},
+			{
+				Variable: v1alpha1.Variable{Name: "PUBLIC_VALUE"},
+			},
+		},
+	}, t.TempDir(), nil, layout.AssembleSkeletonOptions{})
+	require.NoError(t, err)
+
+	pkgYAML, err := os.ReadFile(filepath.Join(pkgLayout.DirPath(), layout.ZarfYAML))
+	require.NoError(t, err)
+	checksums, err := os.ReadFile(filepath.Join(pkgLayout.DirPath(), layout.Checksums))
+	require.NoError(t, err)
+
+	tarPath, hexes := writeFixtureBundle(t, []fixturePkg{{
+		name: "bundle-package",
+		blobs: []fixtureBlob{
+			{title: layout.ZarfYAML, content: pkgYAML},
+			{title: config.ChecksumsTxt, content: checksums},
+		},
+	}}, true)
+	pkg := types.Package{
+		Name: "bundle-package",
+		Ref:  "ghcr.io/example/package@sha256:" + hexes[0],
+	}
+	b := Bundle{
+		cfg: &types.BundleConfig{DeployOpts: types.BundleDeployOptions{
+			Variables: map[string]map[string]interface{}{
+				pkg.Name: {"PASSWORD": "do-not-display", "PUBLIC_VALUE": "display-me"},
+			},
+		}},
+		bundle: types.UDSBundle{Packages: []types.Package{pkg}},
+		tmp:    t.TempDir(),
+	}
+	provider := &tarballBundleProvider{src: tarPath}
+
+	b.prefetchPackageMetadata(provider)
+	// Remove the source after prefetch so the preview can only succeed with cached metadata.
+	require.NoError(t, os.Remove(tarPath))
+
+	previousSkipValidation := config.CommonOptions.SkipSignatureValidation
+	config.CommonOptions.SkipSignatureValidation = true
+	t.Cleanup(func() {
+		config.CommonOptions.SkipSignatureValidation = previousSkipValidation
+	})
+
+	// A visible non-sensitive value distinguishes cache reuse from fail-closed masking.
+	views := formPkgViews(&b)
+	require.Len(t, views, 1)
+	overrides := views[0].overrides["overrides"]
+	require.Contains(t, overrides, map[string]interface{}{"PASSWORD": hiddenVar})
+	require.Contains(t, overrides, map[string]interface{}{"PUBLIC_VALUE": "display-me"})
 }

--- a/src/pkg/bundle/tarball_prefetch_test.go
+++ b/src/pkg/bundle/tarball_prefetch_test.go
@@ -26,6 +26,7 @@ import (
 type fixtureBlob struct {
 	title   string // org.opencontainers.image.title annotation (zarf.yaml/sig/checksums)
 	content []byte
+	omit    bool // include the descriptor in the manifest but omit the blob from the archive
 }
 
 type fixturePkg struct {
@@ -65,13 +66,18 @@ func writeFixtureBundle(t *testing.T, pkgs []fixturePkg, manifestFirst bool) (st
 		var layers []ocispec.Descriptor
 		var metaNames []string
 		for _, b := range p.blobs {
-			d := writeBlob(b.content)
+			d := digest.FromBytes(b.content)
+			if !b.omit {
+				d = writeBlob(b.content)
+			}
 			layers = append(layers, ocispec.Descriptor{
 				Digest:      d,
 				Size:        int64(len(b.content)),
 				Annotations: map[string]string{ocispec.AnnotationTitle: b.title},
 			})
-			metaNames = append(metaNames, config.BlobsDir+"/"+d.Encoded())
+			if !b.omit {
+				metaNames = append(metaNames, config.BlobsDir+"/"+d.Encoded())
+			}
 		}
 
 		manifestBytes, err := json.Marshal(oci.Manifest{Manifest: ocispec.Manifest{Layers: layers}})
@@ -176,11 +182,9 @@ func TestPrefetchPackageMetadata(t *testing.T) {
 		require.FileExists(t, filepath.Join(res.dirPath, layout.Checksums))
 	})
 
-	t.Run("fails when metadata precedes its manifest in the stream", func(t *testing.T) {
-		// This is the single-pass contract that writeTarball satisfies by
-		// ordering each package's manifest before its metadata blobs. If the
-		// metadata streams first, the prefetcher skips it (not yet known to be
-		// needed) and never recovers it in one forward pass.
+	t.Run("recovers when metadata precedes its manifest in the stream", func(t *testing.T) {
+		// Pulled bundles do not guarantee archive entry order. The first pass
+		// learns which metadata blobs were skipped, and the second captures them.
 		pkgs := []fixturePkg{{name: "p", blobs: []fixtureBlob{
 			{title: layout.ZarfYAML, content: zarfYAML("p", "1.0.0")},
 			{title: config.ChecksumsTxt, content: []byte("c")},
@@ -188,10 +192,26 @@ func TestPrefetchPackageMetadata(t *testing.T) {
 		tarPath, hexes := writeFixtureBundle(t, pkgs, false)
 
 		tp := &tarballBundleProvider{src: tarPath}
+		results, err := tp.prefetchPackageMetadata(ctx, []types.Package{
+			{Name: "p", Ref: "ghcr.io/x/p@sha256:" + hexes[0]},
+		}, t.TempDir())
+		require.NoError(t, err)
+		require.FileExists(t, filepath.Join(results["p"].dirPath, layout.ZarfYAML))
+		require.FileExists(t, filepath.Join(results["p"].dirPath, layout.Checksums))
+	})
+
+	t.Run("errors when referenced metadata is absent from the bundle", func(t *testing.T) {
+		pkgs := []fixturePkg{{name: "p", blobs: []fixtureBlob{
+			{title: layout.ZarfYAML, content: zarfYAML("p", "1.0.0")},
+			{title: config.ChecksumsTxt, content: []byte("missing"), omit: true},
+		}}}
+		tarPath, hexes := writeFixtureBundle(t, pkgs, true)
+
+		tp := &tarballBundleProvider{src: tarPath}
 		_, err := tp.prefetchPackageMetadata(ctx, []types.Package{
 			{Name: "p", Ref: "ghcr.io/x/p@sha256:" + hexes[0]},
 		}, t.TempDir())
-		require.Error(t, err)
+		require.ErrorContains(t, err, "required package metadata blobs not found in bundle")
 	})
 
 	t.Run("rejects duplicate package names", func(t *testing.T) {

--- a/src/test/bundles/02-variables/uds-config.yaml
+++ b/src/test/bundles/02-variables/uds-config.yaml
@@ -10,5 +10,6 @@ shared:
 variables:
   output-var:
     country: Scotland
+    sensitive_var: e2e-sensitive-zarf-value
   receive-var:
     precedence: Wales

--- a/src/test/e2e/variable_test.go
+++ b/src/test/e2e/variable_test.go
@@ -25,8 +25,8 @@ func TestBundleVariables(t *testing.T) {
 		bundleTarballPath := filepath.Join(bundleDir, fmt.Sprintf("uds-bundle-variables-%s-0.0.1.tar.zst", e2e.Arch))
 		_, stderr := runCmd(t, fmt.Sprintf("create %s --insecure --confirm -a %s", bundleDir, e2e.Arch))
 		require.Contains(t, stderr, "failed strict unmarshalling")
-		_, stderr = runCmd(t, fmt.Sprintf("deploy %s --retries 1 --confirm", bundleTarballPath))
-		bundleVariablesTestChecks(t, stderr, bundleTarballPath)
+		stdout, stderr := runCmd(t, fmt.Sprintf("deploy %s --retries 1 --confirm --no-color", bundleTarballPath))
+		bundleVariablesTestChecks(t, stdout, stderr, bundleTarballPath)
 	})
 
 	t.Run("bad var name in import", func(t *testing.T) {
@@ -46,8 +46,10 @@ func TestBundleVariables(t *testing.T) {
 	})
 }
 
-func bundleVariablesTestChecks(t *testing.T, stderr string, bundleTarballPath string) {
+func bundleVariablesTestChecks(t *testing.T, stdout, stderr, bundleTarballPath string) {
 	require.NotContains(t, stderr, "CLIVersion is set to 'unset' which can cause issues with package creation and deployment")
+	require.Contains(t, stdout, `SENSITIVE_VAR: "****"`)
+	require.NotContains(t, stdout, "e2e-sensitive-zarf-value")
 	require.Contains(t, stderr, "This fun-fact was imported: Unicorns are the national animal of Scotland")
 	require.Contains(t, stderr, "This fun-fact demonstrates precedence: The Red Dragon is the national symbol of Wales")
 	require.Contains(t, stderr, "shared var in output-var pkg: burning.boats")

--- a/src/test/packages/no-cluster/output-var/zarf.yaml
+++ b/src/test/packages/no-cluster/output-var/zarf.yaml
@@ -17,6 +17,8 @@ variables:
     default: uds.dev
   - name: SPECIFIC_PKG_VAR
     default: not-set
+  - name: SENSITIVE_VAR
+    sensitive: true
 
 components:
   - name: echo


### PR DESCRIPTION
## Description

The deploy preview previously displayed resolved override values without checking the underlying Zarf package metadata. A variable marked sensitive by a package author could therefore appear in terminal output.

This keeps the preview useful for confirming which variables are applied while preserving the boundary that secret values must not reach the terminal.

This PR makes deployment previews now honor each Zarf package variable’s `sensitive: true` declaration.

* Sensitive Zarf variable values are shown as `****`; names remain visible.
* Redaction applies to values supplied through `uds-config.yaml` and `--set` overrides, in addition to existing environment-variable masking.
* Sensitive-variable matching is case-normalized to match override resolution.
* If package metadata cannot be loaded, the preview masks all Zarf variable values for that package rather than risking a secret leak.
* Package references without a manifest digest now return a clear metadata-loading error instead of panicking. This *should* never happen since its added in a bundle create however it showed up in synthetic tests.

### Tests

Tests cover declared-sensitive masking for config and CLI sources, retain visibility for non-sensitive variables, and verify the conservative masking behavior when package metadata is unavailable.

## Related Issue

Fixes defenseunicorns/uds-cli#901  <br>Fixes defenseunicorns/uds-cli#1417

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](<https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md>) followed