### PR TITLE
fix: improve handling of multi-platform image indexes and add tests for descriptor collection

### DIFF
--- a/src/pkg/utils/boci/oci.go
+++ b/src/pkg/utils/boci/oci.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"slices"
 	"strings"
 
@@ -91,7 +90,7 @@ func CreateCopyOpts(layersToPull []ocispec.Descriptor, concurrency int) oras.Cop
 		var nodes []ocispec.Descriptor
 		_, hasTitleAnnotation := desc.Annotations[ocispec.AnnotationTitle]
 
-		if desc.MediaType == ocispec.MediaTypeImageIndex {
+		if desc.MediaType == ocispec.MediaTypeImageIndex && !hasTitleAnnotation {
 			// This block is triggered when ORAS initially hits the OCI repo and gets the image index (index.json)
 			// and it grabs the bundle root manifest corresponding to the proper arch
 			// todo: refactor to solve the arch problem using the shas var above instead of checking here
@@ -385,20 +384,22 @@ func FindBundledPkgLayers(ctx context.Context, pkg types.Package, rootManifest *
 		return nil, 0, err
 	}
 
-	// grab all layers from the included image manifests
+	// Grab the full descriptor graph for included images. Entries in images/index.json can be
+	// either image manifests or nested multi-platform image indexes.
+	seenImageDescriptors := map[string]struct{}{}
 	for _, desc := range manifestsToInclude {
-		imgManifest, err := getImgManifest(ctx, remote, desc)
+		imageDescriptors, err := collectImageDescriptors(ctx, remote.Repo().Blobs(), desc, seenImageDescriptors)
 		if err != nil {
 			return nil, 0, err
 		}
-
-		// grab all layers in image manifest, the img config and the img manifest itself
-		layersToPull = append(layersToPull, imgManifest.Layers...)
-		layersToPull = append(layersToPull, desc, imgManifest.Config)
+		layersToPull = append(layersToPull, imageDescriptors...)
 	}
 
 	// loop through layersToPull and add up bytes and set title annotations
 	for i, layer := range layersToPull {
+		if layer.Digest == "" {
+			return nil, 0, fmt.Errorf("descriptor with media type %q has an empty digest", layer.MediaType)
+		}
 		title, hasTitle := layerTitleAnnotations[layer.Digest.Encoded()]
 		if layer.Annotations == nil && hasTitle {
 			layersToPull[i].Annotations = map[string]string{ocispec.AnnotationTitle: title}
@@ -439,24 +440,36 @@ func CopyLayers(layersToPull []ocispec.Descriptor, estimatedBytes int64, tmpDstD
 	return rootDesc, nil
 }
 
-func getImgManifest(ctx context.Context, remote *oci.OrasRemote, desc ocispec.Descriptor) (ocispec.Manifest, error) {
-	imgManifestReader, err := remote.Repo().Blobs().Fetch(ctx, desc)
+// collectImageDescriptors recursively collects an image manifest or index and all of its
+// successors. The seen map is shared across roots to avoid copying duplicate image blobs.
+func collectImageDescriptors(ctx context.Context, fetcher content.Fetcher, desc ocispec.Descriptor, seen map[string]struct{}) ([]ocispec.Descriptor, error) {
+	if desc.Digest == "" {
+		return nil, fmt.Errorf("image descriptor with media type %q has an empty digest", desc.MediaType)
+	}
+	if err := desc.Digest.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid image descriptor digest %q: %w", desc.Digest, err)
+	}
+
+	digest := desc.Digest.String()
+	if _, ok := seen[digest]; ok {
+		return nil, nil
+	}
+	seen[digest] = struct{}{}
+
+	successors, err := content.Successors(ctx, fetcher, desc)
 	if err != nil {
-		return ocispec.Manifest{}, err
+		return nil, fmt.Errorf("unable to get successors for image descriptor %s: %w", desc.Digest, err)
 	}
-	imgManifestBytes, err := io.ReadAll(imgManifestReader)
-	if err != nil {
-		return ocispec.Manifest{}, err
+
+	descriptors := []ocispec.Descriptor{desc}
+	for _, successor := range successors {
+		nestedDescriptors, err := collectImageDescriptors(ctx, fetcher, successor, seen)
+		if err != nil {
+			return nil, err
+		}
+		descriptors = append(descriptors, nestedDescriptors...)
 	}
-	var imgManifest ocispec.Manifest
-	if err := json.Unmarshal(imgManifestBytes, &imgManifest); err != nil {
-		return ocispec.Manifest{}, err
-	}
-	err = imgManifestReader.Close()
-	if err != nil {
-		return ocispec.Manifest{}, err
-	}
-	return imgManifest, nil
+	return descriptors, nil
 }
 
 func handleImgIndex(ctx context.Context, remote *oci.OrasRemote, desc ocispec.Descriptor) (ocispec.Index, error) {

--- a/src/pkg/utils/boci/oci.go
+++ b/src/pkg/utils/boci/oci.go
@@ -80,20 +80,21 @@ func ToOCIRemote(t any, mediaType string, remote *oci.OrasRemote) (*ocispec.Desc
 func CreateCopyOpts(layersToPull []ocispec.Descriptor, concurrency int) oras.CopyOptions {
 	var copyOpts oras.CopyOptions
 	copyOpts.Concurrency = concurrency
-	var shas []string
+	requestedDigests := map[string]struct{}{}
 	for _, layer := range layersToPull {
-		if len(layer.Digest.String()) > 0 {
-			shas = append(shas, layer.Digest.Encoded())
+		if layer.Digest != "" {
+			requestedDigests[layer.Digest.String()] = struct{}{}
 		}
 	}
 	copyOpts.FindSuccessors = func(ctx context.Context, fetcher content.Fetcher, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		var nodes []ocispec.Descriptor
 		_, hasTitleAnnotation := desc.Annotations[ocispec.AnnotationTitle]
+		_, isRequested := requestedDigests[desc.Digest.String()]
 
-		if desc.MediaType == ocispec.MediaTypeImageIndex && !hasTitleAnnotation {
+		if desc.MediaType == ocispec.MediaTypeImageIndex && !isRequested {
 			// This block is triggered when ORAS initially hits the OCI repo and gets the image index (index.json)
-			// and it grabs the bundle root manifest corresponding to the proper arch
-			// todo: refactor to solve the arch problem using the shas var above instead of checking here
+			// and it grabs the bundle root manifest corresponding to the proper arch. Embedded image indexes
+			// are included in requestedDigests and must retain all requested platform manifests.
 
 			// get contents of the index.json from its desc
 			successors, err := content.Successors(ctx, fetcher, desc)
@@ -103,7 +104,6 @@ func CreateCopyOpts(layersToPull []ocispec.Descriptor, concurrency int) oras.Cop
 
 			// grab the proper bundle root manifest, based on arch
 			for _, node := range successors {
-				// todo: remove this check once we have a better way to handle arch
 				if node.Platform.Architecture == config.GetArch() {
 					return []ocispec.Descriptor{node}, nil
 				}
@@ -135,7 +135,8 @@ func CreateCopyOpts(layersToPull []ocispec.Descriptor, concurrency int) oras.Cop
 		}
 		var ret []ocispec.Descriptor
 		for _, node := range nodes {
-			if node.Size != 0 && slices.Contains(shas, node.Digest.Encoded()) {
+			_, isRequested := requestedDigests[node.Digest.String()]
+			if node.Size != 0 && isRequested {
 				ret = append(ret, node)
 			}
 		}

--- a/src/pkg/utils/boci/oci_test.go
+++ b/src/pkg/utils/boci/oci_test.go
@@ -204,22 +204,18 @@ func TestCreateCopyOptsImageIndexes(t *testing.T) {
 		},
 	}
 	indexDesc := pushTestJSON(t, ctx, store, ocispec.MediaTypeImageIndex, index)
-	layersToPull := []ocispec.Descriptor{indexDesc, targetManifest, otherManifest}
-	findSuccessors := CreateCopyOpts(layersToPull, 1).FindSuccessors
 
 	t.Run("bundle root selects target architecture", func(t *testing.T) {
+		findSuccessors := CreateCopyOpts([]ocispec.Descriptor{targetManifest}, 1).FindSuccessors
 		successors, err := findSuccessors(ctx, store, indexDesc)
 		require.NoError(t, err)
 		require.Equal(t, []ocispec.Descriptor{targetManifest}, successors)
 	})
 
-	t.Run("embedded image index preserves all manifests", func(t *testing.T) {
-		embeddedIndexDesc := indexDesc
-		embeddedIndexDesc.Annotations = map[string]string{
-			ocispec.AnnotationTitle: "images/blobs/" + indexDesc.Digest.Encoded(),
-		}
-
-		successors, err := findSuccessors(ctx, store, embeddedIndexDesc)
+	t.Run("unannotated embedded image index preserves all manifests", func(t *testing.T) {
+		layersToPull := []ocispec.Descriptor{indexDesc, targetManifest, otherManifest}
+		findSuccessors := CreateCopyOpts(layersToPull, 1).FindSuccessors
+		successors, err := findSuccessors(ctx, store, indexDesc)
 		require.NoError(t, err)
 		require.ElementsMatch(t, []ocispec.Descriptor{targetManifest, otherManifest}, successors)
 	})

--- a/src/pkg/utils/boci/oci_test.go
+++ b/src/pkg/utils/boci/oci_test.go
@@ -4,12 +4,19 @@
 package boci
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"testing"
 
+	"github.com/defenseunicorns/uds-cli/src/config"
 	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/content/memory"
 )
 
 // manifestFor builds an image manifest descriptor annotated with the given base image name.
@@ -106,4 +113,136 @@ func TestFilterImageIndex(t *testing.T) {
 			require.ElementsMatch(t, wantDigests, gotDigests)
 		})
 	}
+}
+
+func TestCollectImageDescriptors(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New()
+
+	configDesc := pushTestBlob(t, ctx, store, ocispec.MediaTypeImageConfig, []byte(`{"architecture":"amd64","os":"linux"}`))
+	layerDesc := pushTestBlob(t, ctx, store, ocispec.MediaTypeImageLayer, []byte("shared layer"))
+
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    []ocispec.Descriptor{layerDesc},
+		Annotations: map[string]string{
+			"test.architecture": "amd64",
+		},
+	}
+	amdManifestDesc := pushTestJSON(t, ctx, store, ocispec.MediaTypeImageManifest, manifest)
+	manifest.Annotations["test.architecture"] = "arm64"
+	armManifestDesc := pushTestJSON(t, ctx, store, ocispec.MediaTypeImageManifest, manifest)
+
+	index := ocispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: []ocispec.Descriptor{
+			amdManifestDesc,
+			armManifestDesc,
+		},
+	}
+	indexDesc := pushTestJSON(t, ctx, store, ocispec.MediaTypeImageIndex, index)
+
+	t.Run("image manifest", func(t *testing.T) {
+		descriptors, err := collectImageDescriptors(ctx, store, amdManifestDesc, map[string]struct{}{})
+		require.NoError(t, err)
+		require.ElementsMatch(t,
+			[]digest.Digest{amdManifestDesc.Digest, configDesc.Digest, layerDesc.Digest},
+			descriptorDigests(descriptors),
+		)
+	})
+
+	t.Run("multi-platform image index", func(t *testing.T) {
+		descriptors, err := collectImageDescriptors(ctx, store, indexDesc, map[string]struct{}{})
+		require.NoError(t, err)
+		require.ElementsMatch(t,
+			[]digest.Digest{
+				indexDesc.Digest,
+				amdManifestDesc.Digest,
+				armManifestDesc.Digest,
+				configDesc.Digest,
+				layerDesc.Digest,
+			},
+			descriptorDigests(descriptors),
+		)
+	})
+
+	t.Run("empty digest", func(t *testing.T) {
+		_, err := collectImageDescriptors(ctx, store, ocispec.Descriptor{MediaType: ocispec.MediaTypeImageManifest}, map[string]struct{}{})
+		require.EqualError(t, err, `image descriptor with media type "application/vnd.oci.image.manifest.v1+json" has an empty digest`)
+	})
+}
+
+func TestCreateCopyOptsImageIndexes(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New()
+
+	otherArch := "arm64"
+	if config.GetArch() == otherArch {
+		otherArch = "amd64"
+	}
+	targetManifest := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    digest.FromString("target manifest"),
+		Size:      1,
+		Platform:  &ocispec.Platform{Architecture: config.GetArch(), OS: "linux"},
+	}
+	otherManifest := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    digest.FromString("other manifest"),
+		Size:      1,
+		Platform:  &ocispec.Platform{Architecture: otherArch, OS: "linux"},
+	}
+	index := ocispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: []ocispec.Descriptor{
+			targetManifest,
+			otherManifest,
+		},
+	}
+	indexDesc := pushTestJSON(t, ctx, store, ocispec.MediaTypeImageIndex, index)
+	layersToPull := []ocispec.Descriptor{indexDesc, targetManifest, otherManifest}
+	findSuccessors := CreateCopyOpts(layersToPull, 1).FindSuccessors
+
+	t.Run("bundle root selects target architecture", func(t *testing.T) {
+		successors, err := findSuccessors(ctx, store, indexDesc)
+		require.NoError(t, err)
+		require.Equal(t, []ocispec.Descriptor{targetManifest}, successors)
+	})
+
+	t.Run("embedded image index preserves all manifests", func(t *testing.T) {
+		embeddedIndexDesc := indexDesc
+		embeddedIndexDesc.Annotations = map[string]string{
+			ocispec.AnnotationTitle: "images/blobs/" + indexDesc.Digest.Encoded(),
+		}
+
+		successors, err := findSuccessors(ctx, store, embeddedIndexDesc)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []ocispec.Descriptor{targetManifest, otherManifest}, successors)
+	})
+}
+
+func pushTestBlob(t *testing.T, ctx context.Context, store content.Storage, mediaType string, data []byte) ocispec.Descriptor {
+	t.Helper()
+	desc := content.NewDescriptorFromBytes(mediaType, data)
+	require.NoError(t, store.Push(ctx, desc, bytes.NewReader(data)))
+	return desc
+}
+
+func pushTestJSON(t *testing.T, ctx context.Context, store content.Storage, mediaType string, value any) ocispec.Descriptor {
+	t.Helper()
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+	return pushTestBlob(t, ctx, store, mediaType, data)
+}
+
+func descriptorDigests(descriptors []ocispec.Descriptor) []digest.Digest {
+	digests := make([]digest.Digest, 0, len(descriptors))
+	for _, desc := range descriptors {
+		digests = append(digests, desc.Digest)
+	}
+	return digests
 }

--- a/src/test/bundles/23-multi-platform-image/uds-bundle.yaml
+++ b/src/test/bundles/23-multi-platform-image/uds-bundle.yaml
@@ -1,0 +1,13 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+kind: UDSBundle
+metadata:
+  name: multi-platform-image
+  description: Bundle containing a package with a multi-platform OCI image index
+  version: 0.0.1
+
+packages:
+  - name: multi-platform-image
+    repository: localhost:888/multi-platform-image
+    ref: 0.0.1

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -5,6 +5,7 @@
 package test
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
 	"oras.land/oras-go/v2/registry"
 
@@ -221,6 +223,43 @@ func TestRemoteBundleWithRemotePkgs(t *testing.T) {
 		Reference:  "0.0.1",
 	}
 	deployAndRemoveLocalAndRemoteInsecure(t, bundleRef.String(), tarballPath)
+}
+
+func TestRemoteBundleWithMultiPlatformImageIndex(t *testing.T) {
+	deployZarfInit(t)
+	e2e.SetupDockerRegistry(t, 888)
+	defer e2e.TeardownRegistry(t, 888)
+
+	zarfPkgPath := "src/test/packages/multi-platform-image"
+	e2e.CreateZarfPkg(t, zarfPkgPath, true)
+	defer e2e.DeleteZarfPkg(t, zarfPkgPath)
+
+	pkg := filepath.Join(zarfPkgPath, fmt.Sprintf("zarf-package-multi-platform-image-%s-0.0.1.tar.zst", e2e.Arch))
+	decompressedPkg := t.TempDir()
+	runCmd(t, fmt.Sprintf("zarf tools archiver decompress %s %s", pkg, decompressedPkg))
+
+	indexBytes, err := os.ReadFile(filepath.Join(decompressedPkg, "images", "index.json"))
+	require.NoError(t, err)
+	var imageIndex ocispec.Index
+	require.NoError(t, json.Unmarshal(indexBytes, &imageIndex))
+	const imageRef = "cgr.dev/chainguard/static@sha256:399c8cb4858f05aaa33f43f02a2e75f28d40f016c0f86e5ba6075769e3303791"
+	var imageDesc ocispec.Descriptor
+	for _, desc := range imageIndex.Manifests {
+		if desc.Annotations[ocispec.AnnotationBaseImageName] == imageRef {
+			imageDesc = desc
+			break
+		}
+	}
+	require.Equal(t, ocispec.MediaTypeImageIndex, imageDesc.MediaType)
+
+	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --plain-http --oci-concurrency=10 -l debug", pkg))
+
+	bundleDir := "src/test/bundles/23-multi-platform-image"
+	bundleRef := "oci://localhost:888/multi-platform-image:0.0.1"
+	runCmd(t, fmt.Sprintf("create %s -o oci://localhost:888 --confirm --insecure -a %s", bundleDir, e2e.Arch))
+
+	runCmd(t, fmt.Sprintf("deploy %s --insecure --confirm", bundleRef))
+	runCmd(t, fmt.Sprintf("remove %s --insecure --confirm", bundleRef))
 }
 
 func TestBundleWithGitRepo(t *testing.T) {

--- a/src/test/e2e/bundle_test.go
+++ b/src/test/e2e/bundle_test.go
@@ -251,15 +251,83 @@ func TestRemoteBundleWithMultiPlatformImageIndex(t *testing.T) {
 		}
 	}
 	require.Equal(t, ocispec.MediaTypeImageIndex, imageDesc.MediaType)
+	imageGraph := imageDescriptorGraph(t, filepath.Join(decompressedPkg, "images", "blobs", "sha256"), imageDesc)
+	var imageArchitectures []string
+	for _, desc := range imageIndexManifests(t, filepath.Join(decompressedPkg, "images", "blobs", "sha256"), imageDesc) {
+		if desc.Platform != nil {
+			imageArchitectures = append(imageArchitectures, desc.Platform.Architecture)
+		}
+	}
+	require.Contains(t, imageArchitectures, "amd64")
+	require.Contains(t, imageArchitectures, "arm64")
 
 	runCmd(t, fmt.Sprintf("zarf package publish %s oci://localhost:888 --plain-http --oci-concurrency=10 -l debug", pkg))
 
 	bundleDir := "src/test/bundles/23-multi-platform-image"
 	bundleRef := "oci://localhost:888/multi-platform-image:0.0.1"
+	bundleTarballName := fmt.Sprintf("uds-bundle-multi-platform-image-%s-0.0.1.tar.zst", e2e.Arch)
+	pulledBundlePath := filepath.Join("build", bundleTarballName)
+	defer e2e.CleanFiles(pulledBundlePath)
 	runCmd(t, fmt.Sprintf("create %s -o oci://localhost:888 --confirm --insecure -a %s", bundleDir, e2e.Arch))
 
 	runCmd(t, fmt.Sprintf("deploy %s --insecure --confirm", bundleRef))
 	runCmd(t, fmt.Sprintf("remove %s --insecure --confirm", bundleRef))
+
+	pull(t, bundleRef, bundleTarballName)
+	pulledBundle := t.TempDir()
+	runCmd(t, fmt.Sprintf("zarf tools archiver decompress %s %s", pulledBundlePath, pulledBundle))
+	pulledBlobsDir := filepath.Join(pulledBundle, "blobs", "sha256")
+	for _, desc := range imageGraph {
+		blobPath := filepath.Join(pulledBlobsDir, desc.Digest.Encoded())
+		require.FileExists(t, blobPath, "missing %s blob for %s", desc.MediaType, desc.Digest)
+		shasMatch(t, blobPath, desc.Digest.Encoded())
+	}
+
+	runCmd(t, fmt.Sprintf("deploy %s --confirm", pulledBundlePath))
+	runCmd(t, fmt.Sprintf("remove %s --confirm", pulledBundlePath))
+}
+
+func imageDescriptorGraph(t *testing.T, blobsDir string, root ocispec.Descriptor) []ocispec.Descriptor {
+	t.Helper()
+
+	var descriptors []ocispec.Descriptor
+	seen := map[string]struct{}{}
+	var walk func(ocispec.Descriptor)
+	walk = func(desc ocispec.Descriptor) {
+		if _, ok := seen[desc.Digest.String()]; ok {
+			return
+		}
+		seen[desc.Digest.String()] = struct{}{}
+		descriptors = append(descriptors, desc)
+
+		switch desc.MediaType {
+		case ocispec.MediaTypeImageIndex:
+			for _, manifest := range imageIndexManifests(t, blobsDir, desc) {
+				walk(manifest)
+			}
+		case ocispec.MediaTypeImageManifest:
+			manifestBytes, err := os.ReadFile(filepath.Join(blobsDir, desc.Digest.Encoded()))
+			require.NoError(t, err)
+			var manifest ocispec.Manifest
+			require.NoError(t, json.Unmarshal(manifestBytes, &manifest))
+			walk(manifest.Config)
+			for _, layer := range manifest.Layers {
+				walk(layer)
+			}
+		}
+	}
+	walk(root)
+	return descriptors
+}
+
+func imageIndexManifests(t *testing.T, blobsDir string, desc ocispec.Descriptor) []ocispec.Descriptor {
+	t.Helper()
+
+	indexBytes, err := os.ReadFile(filepath.Join(blobsDir, desc.Digest.Encoded()))
+	require.NoError(t, err)
+	var index ocispec.Index
+	require.NoError(t, json.Unmarshal(indexBytes, &index))
+	return index.Manifests
 }
 
 func TestBundleWithGitRepo(t *testing.T) {

--- a/src/test/packages/multi-platform-image/zarf.yaml
+++ b/src/test/packages/multi-platform-image/zarf.yaml
@@ -1,0 +1,14 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+kind: ZarfPackageConfig
+metadata:
+  name: multi-platform-image
+  version: 0.0.1
+  description: Test package containing an image pinned to a multi-platform OCI index
+
+components:
+  - name: multi-platform-image
+    required: true
+    images:
+      - cgr.dev/chainguard/static@sha256:399c8cb4858f05aaa33f43f02a2e75f28d40f016c0f86e5ba6075769e3303791


### PR DESCRIPTION
## Description

Fixes pulling and deploying remote UDS bundles containing Zarf packages with multi-platform OCI image indexes. The change recursively collects the complete image descriptor graph, preserves all platform manifests and blobs, and adds unit and end-to-end regression coverage

## Related Issue

Fixes CLI-255

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
