### PR TITLE
fix: ensure verification is required when configured

### DIFF
--- a/docs/how-to-guides/verify-keyless-package-signatures.mdx
+++ b/docs/how-to-guides/verify-keyless-package-signatures.mdx
@@ -24,7 +24,7 @@ UDS CLI validates package signatures when it creates, inspects, or deploys packa
 
 ## Before you begin
 
-Keyless package signature verification is configured per package in `uds-bundle.yaml` with `keylessVerification`.
+Keyless package signature verification is configured per package in `uds-bundle.yaml` with `keylessVerification`. Configuring it requires that package to be signed; UDS CLI rejects an unsigned package rather than silently skipping verification.
 
 > [!NOTE]
 > Each package can use one verification method. For keyless-signed packages, configure `keylessVerification` and leave `publicKey` unset.

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -362,7 +362,8 @@ func GetPackageVerificationStrategy(skipSignatureValidation bool) layout.Verific
 	return layout.VerifyAlways
 }
 
-// LoadPackage fetches, verifies (only if signed), and loads a Zarf package from the specified source.
+// LoadPackage fetches and loads a Zarf package from the specified source. Signed packages are
+// verified unless verification is skipped; supplying verification material also requires a signature.
 func LoadPackage(ctx context.Context, source string, opts packager.LoadOptions) (_ *layout.PackageLayout, err error) {
 	verificationStrategy := opts.VerificationStrategy
 
@@ -371,6 +372,10 @@ func LoadPackage(ctx context.Context, source string, opts packager.LoadOptions) 
 	pkgLayout, err := packager.LoadPackage(ctx, source, opts)
 	if err != nil {
 		return pkgLayout, err
+	}
+
+	if err := requireSignatureWhenVerificationConfigured(pkgLayout.IsSigned(), verificationStrategy, opts.VerifyBlobOptions); err != nil {
+		return nil, err
 	}
 
 	// Verify if package is signed and verificationStrategy not set to never (skip)
@@ -385,7 +390,8 @@ func LoadPackage(ctx context.Context, source string, opts packager.LoadOptions) 
 	return pkgLayout, nil
 }
 
-// LoadFromDir loads and verifies a package (only if signed), from the given directory path.
+// LoadFromDir loads a package from the given directory path. Signed packages are verified unless
+// verification is skipped; supplying verification material also requires a signature.
 func LoadPackageFromDir(ctx context.Context, dirPath string, opts layout.PackageLayoutOptions) (*layout.PackageLayout, error) {
 	verificationStrategy := opts.VerificationStrategy
 
@@ -394,6 +400,10 @@ func LoadPackageFromDir(ctx context.Context, dirPath string, opts layout.Package
 	pkgLayout, err := layout.LoadFromDir(ctx, dirPath, opts)
 	if err != nil {
 		return pkgLayout, err
+	}
+
+	if err := requireSignatureWhenVerificationConfigured(pkgLayout.IsSigned(), verificationStrategy, opts.VerifyBlobOptions); err != nil {
+		return nil, err
 	}
 
 	// Verify if package is signed and verificationStrategy not set to never (skip)
@@ -406,6 +416,15 @@ func LoadPackageFromDir(ctx context.Context, dirPath string, opts layout.Package
 	}
 
 	return pkgLayout, nil
+}
+
+// requireSignatureWhenVerificationConfigured prevents verification configuration from silently
+// accepting an unsigned package. An explicit skip-signature-validation request bypasses this check.
+func requireSignatureWhenVerificationConfigured(isSigned bool, verificationStrategy layout.VerificationStrategy, verifyOpts *signing.VerifyBlobOptions) error {
+	if verificationStrategy != layout.VerifyNever && !isSigned && verifyOpts != nil {
+		return errors.New("package is unsigned, but signature verification was configured")
+	}
+	return nil
 }
 
 // VerifyBlobOptionsFromKey constructs VerifyBlobOptions from a public key path.

--- a/src/pkg/utils/utils_test.go
+++ b/src/pkg/utils/utils_test.go
@@ -9,8 +9,64 @@ import (
 
 	"github.com/defenseunicorns/uds-cli/src/types"
 	"github.com/stretchr/testify/require"
+	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 	"github.com/zarf-dev/zarf/src/pkg/signing"
 )
+
+func TestRequireSignatureWhenVerificationConfigured(t *testing.T) {
+	publicKeyOpts := signing.DefaultVerifyBlobOptions()
+	publicKeyOpts.Key = "test-public-key"
+	keylessOpts := signing.DefaultVerifyBlobOptions()
+	keylessOpts.CertVerify.CertIdentity = "https://example.com/release"
+	keylessOpts.CertVerify.CertOidcIssuer = "https://token.actions.githubusercontent.com"
+
+	tests := []struct {
+		name                 string
+		isSigned             bool
+		verificationStrategy layout.VerificationStrategy
+		verifyOpts           *signing.VerifyBlobOptions
+		wantErr              string
+	}{
+		{
+			name:                 "unsigned package without verification configuration is allowed",
+			verificationStrategy: layout.VerifyAlways,
+		},
+		{
+			name:                 "unsigned package with public key verification is rejected",
+			verificationStrategy: layout.VerifyAlways,
+			verifyOpts:           &publicKeyOpts,
+			wantErr:              "package is unsigned, but signature verification was configured",
+		},
+		{
+			name:                 "unsigned package with keyless verification is rejected",
+			verificationStrategy: layout.VerifyAlways,
+			verifyOpts:           &keylessOpts,
+			wantErr:              "package is unsigned, but signature verification was configured",
+		},
+		{
+			name:                 "signed package with verification configuration is allowed",
+			isSigned:             true,
+			verificationStrategy: layout.VerifyAlways,
+			verifyOpts:           &keylessOpts,
+		},
+		{
+			name:                 "skip signature validation allows unsigned package",
+			verificationStrategy: layout.VerifyNever,
+			verifyOpts:           &keylessOpts,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := requireSignatureWhenVerificationConfigured(tt.isSigned, tt.verificationStrategy, tt.verifyOpts)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
 
 func Test_IsRegistryURL(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Description

When verification is configured for a package it should be "forced" and not silently skip for an unsigned package.

Fixes CLI-217

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
