### PR TITLE
fix: use .Version and pivot to goreleaser

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -54,9 +54,9 @@ jobs:
       - name: Stage release artifacts
         run: |
           mkdir build
-          jq -r '.[] | select((.type == "Binary" and .extra.Format == "binary") or .type == "Linux Package" or .type == "Checksum") | [.path, .name] | @tsv' dist/artifacts.json |
-            while IFS=$'\t' read -r artifact_path artifact_name; do
-              cp "$artifact_path" "build/$artifact_name"
+          jq -r '.[] | select((.type == "Binary" and .extra.Format == "binary") or .type == "Linux Package" or .type == "Checksum") | .path' dist/artifacts.json |
+            while IFS= read -r artifact_path; do
+              cp "$artifact_path" build/
             done
 
       - name: Update nightly-unstable tag

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -31,19 +31,33 @@ jobs:
       - name: Setup golang
         uses: ./.github/actions/golang
 
-      - name: Install UDS CLI
-        uses: ./.github/actions/install-uds-cli
-
-      - name: Build binary artifacts
+      - name: Setup release ENV vars
         run: |
-          uds run build-all
+          K8S_MODULES_VER=$(go list -f '{{.Version}}' -m k8s.io/client-go | sed 's/v//; s/\./ /g')
+          echo K8S_MODULES_MAJOR_VER=$(expr $(echo "$K8S_MODULES_VER" | cut -d " " -f 1) + 1) >> $GITHUB_ENV
+          echo K8S_MODULES_MINOR_VER=$(echo "$K8S_MODULES_VER" | cut -d " " -f 2) >> $GITHUB_ENV
+          echo K8S_MODULES_PATCH_VER=$(echo "$K8S_MODULES_VER" | cut -d " " -f 3) >> $GITHUB_ENV
 
-      - name: Rename artifacts for readability
+          echo K9S_VERSION=$(go list -f '{{.Version}}' -m github.com/derailed/k9s) >> $GITHUB_ENV
+          echo CRANE_VERSION=$(go list -f '{{.Version}}' -m github.com/google/go-containerregistry) >> $GITHUB_ENV
+          echo SYFT_VERSION=$(go list -f '{{.Version}}' -m github.com/anchore/syft) >> $GITHUB_ENV
+          echo ARCHIVES_VERSION=$(go list -f '{{.Version}}' -m github.com/mholt/archives) >> $GITHUB_ENV
+          echo HELM_VERSION=$(go list -f '{{.Version}}' -m helm.sh/helm/v4) >> $GITHUB_ENV
+
+      - name: Build release artifacts
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean --snapshot --skip=homebrew,sbom --config .goreleaser.yaml
+
+      - name: Stage release artifacts
         run: |
-          mv build/uds build/uds-nightly-linux-amd64
-          mv build/uds-arm build/uds-nightly-linux-arm64
-          mv build/uds-mac-apple build/uds-nightly-darwin-arm64
-          mv build/uds-mac-intel build/uds-nightly-darwin-amd64
+          mkdir build
+          jq -r '.[] | select((.type == "Binary" and .extra.Format == "binary") or .type == "Linux Package" or .type == "Checksum") | [.path, .name] | @tsv' dist/artifacts.json |
+            while IFS=$'\t' read -r artifact_path artifact_name; do
+              cp "$artifact_path" "build/$artifact_name"
+            done
 
       - name: Update nightly-unstable tag
         env:

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -54,9 +54,9 @@ jobs:
       - name: Stage release artifacts
         run: |
           mkdir build
-          jq -r '.[] | select((.type == "Binary" and .extra.Format == "binary") or .type == "Linux Package" or .type == "Checksum") | .path' dist/artifacts.json |
-            while IFS= read -r artifact_path; do
-              cp "$artifact_path" build/
+          jq -r '.[] | select((.type == "Binary" and .extra.Format == "binary") or .type == "Linux Package" or .type == "Checksum") | [.path, .name] | @tsv' dist/artifacts.json |
+            while IFS=$'\t' read -r artifact_path artifact_name; do
+              cp "$artifact_path" "build/$artifact_name"
             done
 
       - name: Update nightly-unstable tag

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,7 +19,7 @@ builds:
       - darwin
     ldflags:
       - -s -w
-      - -X 'github.com/defenseunicorns/uds-cli/src/config.CLIVersion={{.Tag}}'
+      - -X 'github.com/defenseunicorns/uds-cli/src/config.CLIVersion=v{{.Version}}'
       - -X 'github.com/zarf-dev/zarf/src/config.ActionsCommandZarfPrefix=zarf'
       - -X 'k8s.io/component-base/version.gitVersion=v{{.Env.K8S_MODULES_MAJOR_VER}}.{{.Env.K8S_MODULES_MINOR_VER}}.{{.Env.K8S_MODULES_PATCH_VER}}'
       - -X 'k8s.io/component-base/version.gitCommit={{.FullCommit}}'
@@ -55,7 +55,7 @@ nfpms:
 # Save the built artifacts as binaries (instead of wrapping them in a tarball)
 archives:
   - formats: binary
-    name_template: "{{ .ProjectName }}_{{ .Tag }}_{{- title .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_v{{ .Version }}_{{- title .Os }}_{{ .Arch }}"
 
 # generate a sha256 checksum of all release artifacts
 checksum:


### PR DESCRIPTION
## Description

Moves Goreleaser to `.Version` instead of `.Tag` due to snapshot naming.

The Tag would be like `v0.0.0` yet the version is just `0.0.0`.

For not official releases `--snapshot` uses version and appends the version template. 

```
snapshot:
  version_template: "{{ incpatch .Version }}-snapshot"
```

TLDR - to delineate dev versions `uds run build-goreleaser` of the CLI itself. We just want to have `v{{ .Version }}` so when a user runs `uds version` it doesnt confuse us when we find that they might accidentally be running a snapshot release.

Uses primarily same logic as below in regular release.

https://github.com/defenseunicorns/uds-cli/blob/44d73fe285223ec1a7a9d6689b580cd4aa627f7b/.github/workflows/release.yaml#L52-L64 

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
