### PR TITLE
docs: update init ref, add publicKey

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -41,10 +41,28 @@ To understand how bundles fit into the UDS ecosystem, see [Bundles](/core/concep
    packages:
      - name: init
        repository: ghcr.io/zarf-dev/packages/init
-       ref: v0.73.1
+       ref: v0.82.0
+       keylessVerification:
+         certificateIdentityRegexp: https://github\.com/zarf-dev/zarf/\.github/workflows/release\.yml@refs/tags/v\d+\.\d+\.\d+
+         certificateOIDCIssuer: https://token.actions.githubusercontent.com
      - name: dos-games
        repository: ghcr.io/zarf-dev/packages/dos-games
        ref: 1.3.0
+       publicKey: |
+         -----BEGIN PUBLIC KEY-----
+         MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvzCVJ8lhKn7VrH8TyGRq
+         Ie7BZhILJMsEJYUJTI/2meoEqHwsESM606QRIftD9KG3tk7eVA5h9Fnw8hPathwq
+         9HGgfQAwdSUlEZK152u1QRD50elcT2EFs1FcFyFdoSYyORAFwAGY/nsEklfslpbc
+         a7KXOgEMGKbOsdcIMjDzemBL6oyiwUEJWu+ZElCOkRgF7v+VpJhvqlGok2dPcNRt
+         OLML3rU+sKrbsYRR89H32AOrrXnyQ6jHbPQ4DOhVQGGUCpKgHTrdp2Io+8ixEjRr
+         kDm1ya9SzekXf9Yc7pHTjrTF7BkaxfeLKHHqT5DkmLlEjQqmYvvFmfVjrEEFJai4
+         Gseul1aZMPHmLYLjoCeNFbJ9LaJVZ1KLTzPG3Js0lfTInfxMvcp9la2XJwViXvtO
+         uSmVJEMe9bY7lrgwl/X022DArgz5R3EdQW64TLXvtKUQl232cC9wB4p4B5a0Dd+6
+         yTUHHSj+0HpsInJWYk7+IJen8i28AVFdQxXIwI2sfWhwLg/udImhpKZdgRlsscjl
+         +sHpe+RvqCRjKWhbDee/AcvIzvvsJfv+5OkqKlZBAu5NG6zOjDU+eHl1DhSdKsKZ
+         XIhyiT1ZGF9PplLixSjg/9ZkXemg0ImybX/q3kMZiwL5Vii6ZLUUwQ1+SSTazfLg
+         wJLcBrRj83HRenrsBoERXj0CAwEAAQ==
+         -----END PUBLIC KEY-----
    ```
 
    This bundle deploys the Zarf init package followed by [dos-games](https://github.com/zarf-dev/zarf/tree/main/examples/dos-games).


### PR DESCRIPTION
## Description

The instructions in `quickstart.mdx` for installing a test bundle were failing as stated. Notably, `dos-games` requires the zarf cosign public key to be provided (or `--skip-signature-validation`, but providing the public key is better as it doesn't train users to avoid security mechanisms).

In addition to the `dos-games` public key, the `init` package was updated to align with current features and requirements, copied from https://github.com/defenseunicorns/uds-core/blob/main/bundles/k3d-slim-dev/uds-bundle.yaml#L34-L39 .

This was tested with the `dev-docs` webserver, pasting the new `uds-bundle.yaml` locally and building the associated bundle and deploying it to a local testing cluster. Also, the `uds-docs-validate` task was completed.
...

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
