### PR TITLE
chore: include pre-commit in support deps renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,7 @@
     {
       "matchFileNames": [
         ".github/**",
+        ".pre-commit-config.yaml",
         "README.md",
         "docs/**",
         "tasks/**",


### PR DESCRIPTION
## Description

Puts pre-commit file in support deps.  It is currently creating many prs when they should all be grouped in support.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
