### PR TITLE
docs: install consistency with uds-core demo

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -24,23 +24,20 @@ By the end of this guide you'll have UDS CLI installed and available on your `PA
 
 <Steps>
 
-1. **Add the Defense Unicorns tap**
+1. **Install UDS CLI via Homebrew**
 
    ```bash
-   brew tap defenseunicorns/tap
+   brew trust --formula defenseunicorns/tap/uds && brew tap defenseunicorns/tap && brew install uds
    ```
 
-2. **Install UDS CLI**
-
-   ```bash
-   brew install uds
-   ```
-
-3. **Verify the installation**
+2. **Verify the installation**
 
    ```bash
    uds version
    ```
+
+   > [!TIP]
+   > All releases are available on the [UDS CLI GitHub releases page](https://github.com/defenseunicorns/uds-cli/releases).
 
 </Steps>
 


### PR DESCRIPTION
## Description

The `uds` installation instructions in this repository required the brew trust amendment 

`brew trust --formula defenseunicorns/tap/uds`

as a precondition for installing `uds`. While providing this, changes were made to make the instructions look more similar to 

https://docs.defenseunicorns.com/core/getting-started/local-demo/install-and-deploy-uds/

as the goal is the same - they should be written similarly for consistency.

This was tested with the `dev-docs` webserver, visually inspecting the rendering. Also, the `uds-docs-validate` task was completed.
...

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
