### PR TITLE
docs: add mise trust

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,7 @@ Install [mise](https://mise.jdx.dev/getting-started.html) and activate it in you
 From the repository root, run:
 
 ```console
+mise trust mise.toml
 mise install
 hk install
 ```


### PR DESCRIPTION
## Description

First-time setup of `mise` requires `mise trust mise.toml`.

...

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
