### PR TITLE
add docs for uds zarf

### DIFF
--- a/docs/reference/commands/uds.md
+++ b/docs/reference/commands/uds.md
@@ -41,4 +41,5 @@ uds COMMAND [flags]
 * [uds remove](/reference/commands/uds_remove/)	 - Remove a bundle that has been deployed already
 * [uds run](/reference/commands/uds_run/)	 - Run a task using maru-runner
 * [uds version](/reference/commands/uds_version/)	 - Shows the version of the running UDS-CLI binary
+* [uds zarf](/reference/commands/uds_zarf) - Run a zarf command
 

--- a/docs/reference/commands/uds_zarf.md
+++ b/docs/reference/commands/uds_zarf.md
@@ -1,0 +1,43 @@
+---
+title: uds zarf
+description: UDS CLI command reference for <code>uds zarf</code>.
+---
+## uds zarf
+
+Run a zarf command
+
+### Synopsis
+
+Run a zarf command. See [zarf command documentation](https://docs.zarf.dev/commands/zarf/)
+
+```
+uds zarf COMMAND [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for zarf
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --architecture string         Architecture for UDS bundles and Zarf packages
+      --insecure                    Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
+  -l, --log-level string            Log level when running UDS-CLI. Valid options are: warn, info, debug, trace (default "info")
+      --no-color                    Disable color output
+      --no-log-file                 Disable log file creation
+      --no-progress                 Disable fancy UI progress bars, spinners, logos, etc
+      --oci-concurrency int         Number of concurrent layer operations to perform when interacting with a remote bundle. (default 3)
+      --skip-signature-validation   Skip signature validation for packages
+      --tmpdir string               Specify the temporary directory to use for intermediate files
+      --uds-cache string            Specify the location of the UDS cache directory (default "~/.uds-cache")
+```
+
+### SEE ALSO
+
+* [uds](/reference/commands/uds/)	 - CLI for UDS Bundles
+* [zarf documentation](https://docs.zarf.dev/)
+
+


### PR DESCRIPTION
## Description

https://docs.defenseunicorns.com/cli/reference/commands/uds/ does not have an entry for `uds zarf`.

I figured this was not intentional, just an oversight. I added a new page for the subcommand with links out to the official zarf documentation for full reference.

If the lack of documentation for this subcommand was intentional, I'll just close this.

This was tested by running `uds run -f tasks.yaml dev-docs` and inspecting the pages. 

Additionally,  `uds run -f tasks.yaml uds-docs-validate` was also completed.
...

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
