### PR TITLE
chore: add go mod tidy to hk/lint checks

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -36,6 +36,11 @@ local checks = new Mapping<String, Step> {
         fix = "golangci-lint run --fix ./..."
         glob = List("**/*.go", "go.mod", "go.sum")
     }
+    ["go-mod-tidy"] {
+        check = "go mod tidy -diff"
+        fix = "go mod tidy"
+        glob = List("**/*.go", "go.mod", "go.sum")
+    }
     ["schema"] {
         check = "uds run schema:test"
         glob = List("cmd/**/*.go", "internal/**/*.go", "pkg/**/*.go", "hack/generate-schema.sh", "tasks/schema.yaml")


### PR DESCRIPTION
## Description

Adds `go mod tidy` check to hk/lint checks.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
