### PR TITLE
fix(mise): mise install jq

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,7 @@
 [tools]
 go = "1.26.5"
 hk = "1.54.0"
+jq = "1.8.2"
 golangci-lint = "2.12.2"
 "github:goreleaser/goreleaser" = "2.17.1"
 "github:gitleaks/gitleaks" = "8.30.1"


### PR DESCRIPTION
## Description

On MacOS and many CI runners, `jq` is installed by default. On many linux distributions, it is not. The result is the `hk check --all` will appear to fail. This PR lets `mise` install it. The fix was verified on debian stable.

## Related Issue

Fixes CLI-305

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
