### PR TITLE
feat(next)!: align ZarfPackageLayout with upstream PackageLayout

### DIFF
--- a/internal/zarf/deploy.go
+++ b/internal/zarf/deploy.go
@@ -282,7 +282,7 @@ func (d *ZarfDeployer) DeployPackage(ctx context.Context, pkg *spec.Package, opt
 		return err
 	}
 
-	pkgLayout, isPartial, err := loader.LoadPackageLayout(ctx, pkg, pkgTmp, LoadOptions{Streams: log, IsPartial: opts.IsPartial})
+	loadResult, err := loader.LoadPackageLayout(ctx, pkg, pkgTmp, LoadOptions{Streams: log, IsPartial: opts.IsPartial})
 	if err != nil && colocatedStaging && isRetryableStagingError(err) {
 		// A cache can be writable but too small or unsuitable for staging.
 		// Retry once in the user-configured temporary directory before failing.
@@ -294,15 +294,16 @@ func (d *ZarfDeployer) DeployPackage(ctx context.Context, pkg *spec.Package, opt
 			return fmt.Errorf("creating fallback temp directory: %w", err)
 		}
 		log.Debug("retrying package staging in configured temporary directory", "dir", opts.Config.Options.TmpDir)
-		pkgLayout, isPartial, err = loader.LoadPackageLayout(ctx, pkg, pkgTmp, LoadOptions{Streams: log, IsPartial: opts.IsPartial})
+		loadResult, err = loader.LoadPackageLayout(ctx, pkg, pkgTmp, LoadOptions{Streams: log, IsPartial: opts.IsPartial})
 	}
 	if err != nil {
 		return err
 	}
-	if pkgLayout == nil {
-		return fmt.Errorf("package layout loader returned a nil layout for package %q: %w", pkg.Name, ErrLoadPackage)
+	if loadResult == nil {
+		return fmt.Errorf("package layout loader returned a nil result for package %q: %w", pkg.Name, ErrLoadPackage)
 	}
-	opts.IsPartial = isPartial
+	pkgLayout := &loadResult.Layout
+	opts.IsPartial = loadResult.IsPartial
 	defer func() {
 		if err := pkgLayout.Cleanup(); err != nil {
 			log.Warn("failed to clean up package layout", "name", pkg.Name, "error", err)

--- a/internal/zarf/deploy_test.go
+++ b/internal/zarf/deploy_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zarf-dev/zarf/src/api/v1alpha1"
-	"github.com/zarf-dev/zarf/src/pkg/packager/layout"
 )
 
 type stagingRetryLoader struct {
@@ -35,13 +34,13 @@ func (l *stagingRetryLoader) PackageStagingRoot(context.Context) string {
 	return l.stagingRoot
 }
 
-func (l *stagingRetryLoader) LoadPackageLayout(_ context.Context, _ *spec.Package, dstDir string, _ LoadOptions) (*layout.PackageLayout, bool, error) {
+func (l *stagingRetryLoader) LoadPackageLayout(_ context.Context, _ *spec.Package, dstDir string, _ LoadOptions) (*PackageLayoutLoadResult, error) {
 	l.stagedDirs = append(l.stagedDirs, dstDir)
 	if len(l.stagedDirs) == 2 {
 		_, err := os.Stat(l.stagedDirs[0])
 		l.firstRemovedBeforeRetry = os.IsNotExist(err)
 	}
-	return nil, false, l.errs[len(l.stagedDirs)-1]
+	return nil, l.errs[len(l.stagedDirs)-1]
 }
 
 func TestIsRetryableStagingError(t *testing.T) {

--- a/internal/zarf/layout.go
+++ b/internal/zarf/layout.go
@@ -33,7 +33,13 @@ type LoadOptions struct {
 
 // PackageLayoutLoader loads a package into a deployable Zarf layout.
 type PackageLayoutLoader interface {
-	LoadPackageLayout(context.Context, *spec.Package, string, LoadOptions) (*layout.PackageLayout, bool, error)
+	LoadPackageLayout(context.Context, *spec.Package, string, LoadOptions) (*PackageLayoutLoadResult, error)
+}
+
+// PackageLayoutLoadResult is the return type of LoadPackageLayout
+type PackageLayoutLoadResult struct {
+	Layout    layout.PackageLayout
+	IsPartial bool
 }
 
 // ExtractedArtifactPackageLayoutLoader reads package OCI blobs from an extracted bundle artifact.
@@ -65,7 +71,7 @@ func (l *ExtractedArtifactPackageLayoutLoader) PackageStagingRoot(_ context.Cont
 }
 
 // LoadPackageLayout stages indexed OCI layers into dstDir.
-func (l *ExtractedArtifactPackageLayoutLoader) LoadPackageLayout(ctx context.Context, pkg *spec.Package, dstDir string, opts LoadOptions) (*layout.PackageLayout, bool, error) {
+func (l *ExtractedArtifactPackageLayoutLoader) LoadPackageLayout(ctx context.Context, pkg *spec.Package, dstDir string, opts LoadOptions) (*PackageLayoutLoadResult, error) {
 	s := opts.Streams
 	s.Debug("loading package layout", "name", pkg.Name, "dir", dstDir)
 	key := pkg.Name
@@ -75,62 +81,62 @@ func (l *ExtractedArtifactPackageLayoutLoader) LoadPackageLayout(ctx context.Con
 		for k := range l.PackageManifests {
 			keys = append(keys, k)
 		}
-		return nil, false, fmt.Errorf("package %q (source %q) not found in bundle artifact index; available: %v: %w", pkg.Name, pkg.Source, keys, ErrPackageNotFoundInArtifact)
+		return nil, fmt.Errorf("package %q (source %q) not found in bundle artifact index; available: %v: %w", pkg.Name, pkg.Source, keys, ErrPackageNotFoundInArtifact)
 	}
 
 	cleanOCIDir, err := filepath.Abs(filepath.Clean(l.OCIDir))
 	if err != nil {
-		return nil, false, fmt.Errorf("resolving artifact OCI directory: %w", err)
+		return nil, fmt.Errorf("resolving artifact OCI directory: %w", err)
 	}
 	blobDir := filepath.Join(cleanOCIDir, "blobs", "sha256")
 	store, err := udsoci.OpenReadOnlyStore(cleanOCIDir)
 	if err != nil {
-		return nil, false, fmt.Errorf("package %q: %w: %w", pkg.Name, ErrOpenOCILayout, err)
+		return nil, fmt.Errorf("package %q: %w: %w", pkg.Name, ErrOpenOCILayout, err)
 	}
 	manifestData, err := udsoci.FetchBytes(ctx, store, descriptor)
 	if err != nil {
-		return nil, false, fmt.Errorf("package %q: %w: %w", pkg.Name, ErrReadPackageManifest, err)
+		return nil, fmt.Errorf("package %q: %w: %w", pkg.Name, ErrReadPackageManifest, err)
 	}
 	var manifest ocispec.Manifest
 	if err := json.Unmarshal(manifestData, &manifest); err != nil {
-		return nil, false, fmt.Errorf("package %q: %w: %w", pkg.Name, ErrReadPackageManifest, err)
+		return nil, fmt.Errorf("package %q: %w: %w", pkg.Name, ErrReadPackageManifest, err)
 	}
 
 	cleanDstDir, err := filepath.Abs(filepath.Clean(dstDir))
 	if err != nil {
-		return nil, false, fmt.Errorf("%w %q for package %q: %w", ErrResolveDestinationDirectory, dstDir, pkg.Name, err)
+		return nil, fmt.Errorf("%w %q for package %q: %w", ErrResolveDestinationDirectory, dstDir, pkg.Name, err)
 	}
 	dstRoot, err := os.OpenRoot(cleanDstDir)
 	if err != nil {
-		return nil, false, fmt.Errorf("opening package destination directory: %w", err)
+		return nil, fmt.Errorf("opening package destination directory: %w", err)
 	}
 	defer func() { _ = dstRoot.Close() }()
 	workspaceDir := filepath.Dir(cleanOCIDir)
 	workspaceRoot, err := os.OpenRoot(workspaceDir)
 	if err != nil {
-		return nil, false, fmt.Errorf("opening artifact workspace directory: %w", err)
+		return nil, fmt.Errorf("opening artifact workspace directory: %w", err)
 	}
 	defer func() { _ = workspaceRoot.Close() }()
 	for _, layer := range manifest.Layers {
 		title := layer.Annotations[ocispec.AnnotationTitle]
 		if title == "" {
-			return nil, false, fmt.Errorf("manifest for package %q missing title annotation on layer with digest %q: %w", pkg.Name, layer.Digest, ErrMissingLayerTitle)
+			return nil, fmt.Errorf("manifest for package %q missing title annotation on layer with digest %q: %w", pkg.Name, layer.Digest, ErrMissingLayerTitle)
 		}
 		src := filepath.Join(blobDir, layer.Digest.Hex())
 		relSrc, err := filepath.Rel(workspaceDir, src)
 		if err != nil {
-			return nil, false, fmt.Errorf("resolving layer %q relative to artifact workspace: %w", title, err)
+			return nil, fmt.Errorf("resolving layer %q relative to artifact workspace: %w", title, err)
 		}
 		dst, err := safeLayerDestinationPath(cleanDstDir, cleanDstDir, title)
 		if err != nil {
-			return nil, false, err
+			return nil, err
 		}
 		relDst, err := filepath.Rel(cleanDstDir, dst)
 		if err != nil {
-			return nil, false, fmt.Errorf("resolving layer %q relative to package destination: %w", title, err)
+			return nil, fmt.Errorf("resolving layer %q relative to package destination: %w", title, err)
 		}
 		if err := dstRoot.MkdirAll(filepath.Dir(relDst), filesystem.PrivateDirectoryMode); err != nil {
-			return nil, false, fmt.Errorf("layer %q: %w: %w", title, ErrCreateLayerDirectory, err)
+			return nil, fmt.Errorf("layer %q: %w: %w", title, ErrCreateLayerDirectory, err)
 		}
 		workspaceDst, err := filepath.Rel(workspaceDir, dst)
 		stageRoot := dstRoot
@@ -143,7 +149,7 @@ func (l *ExtractedArtifactPackageLayoutLoader) LoadPackageLayout(ctx context.Con
 			stageDst = workspaceDst
 		}
 		if err := stageArtifactPackageLayer(ctx, workspaceRoot, relSrc, stageRoot, stageDst, title, canLink); err != nil {
-			return nil, false, fmt.Errorf("layer %q for package %q: %w: %w", title, pkg.Name, ErrStagePackageLayer, err)
+			return nil, fmt.Errorf("layer %q for package %q: %w: %w", title, pkg.Name, ErrStagePackageLayer, err)
 		}
 	}
 
@@ -152,9 +158,9 @@ func (l *ExtractedArtifactPackageLayoutLoader) LoadPackageLayout(ctx context.Con
 	// layers ingested at create time; checksums.txt may reference filtered-out blobs.
 	pkgLayout, err := layout.LoadFromDir(ctx, dstDir, artifactPackageLayoutOptions(filter, true))
 	if err != nil {
-		return nil, false, fmt.Errorf("package %q: %w: %w", pkg.Name, ErrLoadPackage, err)
+		return nil, fmt.Errorf("package %q: %w: %w", pkg.Name, ErrLoadPackage, err)
 	}
-	return pkgLayout, true, nil
+	return &PackageLayoutLoadResult{Layout: *pkgLayout, IsPartial: true}, nil
 }
 
 // stageArtifactPackageLayer links regular immutable blobs inside one workspace
@@ -197,7 +203,7 @@ func artifactPackageLayoutOptions(filter filters.ComponentFilterStrategy, isPart
 var _ PackageLayoutLoader = (*SourcePackageLayoutLoader)(nil)
 
 // LoadPackageLayout pulls a package source into a deployable layout.
-func (l *SourcePackageLayoutLoader) LoadPackageLayout(ctx context.Context, pkg *spec.Package, dstDir string, opts LoadOptions) (*layout.PackageLayout, bool, error) {
+func (l *SourcePackageLayoutLoader) LoadPackageLayout(ctx context.Context, pkg *spec.Package, dstDir string, opts LoadOptions) (*PackageLayoutLoadResult, error) {
 	s := opts.Streams
 	s.Info("pulling package", "source", pkg.Source)
 	source := NewPackageSource(pkg.Source, l.configOpts, l.bundleDir, opts.Streams)
@@ -208,10 +214,10 @@ func (l *SourcePackageLayoutLoader) LoadPackageLayout(ctx context.Context, pkg *
 		VerificationStrategy: layout.VerifyNever,
 	})
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to load package %q from %s: %w: %w", pkg.Name, pkg.Source, ErrLoadPackage, err)
+		return nil, fmt.Errorf("failed to load package %q from %s: %w: %w", pkg.Name, pkg.Source, ErrLoadPackage, err)
 	}
 	advisoryVerifyPackage(ctx, pkgLayout, pkg, l.configOpts.TmpDir, s)
-	return pkgLayout, opts.IsPartial, nil
+	return &PackageLayoutLoadResult{Layout: *pkgLayout, IsPartial: opts.IsPartial}, nil
 }
 
 // copyFileContentsBetweenRoots copies src atomically between rooted

--- a/internal/zarf/layout_test.go
+++ b/internal/zarf/layout_test.go
@@ -76,7 +76,7 @@ func TestExtractedArtifactPackageLayoutLoader_LoadPackageLayout(t *testing.T) {
 				OCIDir:           t.TempDir(),
 				PackageManifests: tt.manifests,
 			}
-			_, _, err := loader.LoadPackageLayout(t.Context(), tt.pkg, t.TempDir(), LoadOptions{})
+			_, err := loader.LoadPackageLayout(t.Context(), tt.pkg, t.TempDir(), LoadOptions{})
 			require.Error(t, err)
 			if tt.wantNotFound {
 				assert.Contains(t, err.Error(), "not found in bundle artifact index")
@@ -147,15 +147,15 @@ func TestSourcePackageLayoutLoaderAdvisoryVerification(t *testing.T) {
 				configOpts: bundleinternal.ConfigOptions{Architecture: "amd64", TmpDir: t.TempDir()},
 			}
 
-			pkgLayout, _, err := loader.LoadPackageLayout(t.Context(), &spec.Package{
+			result, err := loader.LoadPackageLayout(t.Context(), &spec.Package{
 				Name:                  "test",
 				Source:                pkgDir,
 				SignatureVerification: tt.verification,
 			}, t.TempDir(), LoadOptions{Streams: streams})
 			require.NoError(t, err)
-			require.NotNil(t, pkgLayout)
+			require.NotNil(t, result)
 			assert.Contains(t, out.String()+errOut.String(), tt.wantWarning)
-			require.NoError(t, pkgLayout.Cleanup())
+			require.NoError(t, result.Layout.Cleanup())
 		})
 	}
 }
@@ -168,7 +168,7 @@ func TestExtractedArtifactPackageLayoutLoader_StagesFiles(t *testing.T) {
 
 	// LoadPackageLayout fails at layout.LoadFromDir since fixture has fake content,
 	// not a valid Zarf package. Confirm layer files were staged before that failure.
-	_, _, err := loader.LoadPackageLayout(t.Context(), pkg, dstDir, LoadOptions{})
+	_, err := loader.LoadPackageLayout(t.Context(), pkg, dstDir, LoadOptions{})
 	require.Error(t, err)
 
 	assert.FileExists(t, filepath.Join(dstDir, "zarf.yaml"), "zarf.yaml layer should be staged before LoadFromDir is called")
@@ -181,7 +181,7 @@ func TestExtractedArtifactPackageLayoutLoader_StagesFilesWithRelativeOCIDir(t *t
 	loader.OCIDir = filepath.Base(loader.OCIDir)
 
 	dstDir := t.TempDir()
-	_, _, err := loader.LoadPackageLayout(t.Context(), &spec.Package{Name: "mypkg", Source: "oci://example.com/pkg:v1"}, dstDir, LoadOptions{})
+	_, err := loader.LoadPackageLayout(t.Context(), &spec.Package{Name: "mypkg", Source: "oci://example.com/pkg:v1"}, dstDir, LoadOptions{})
 	require.Error(t, err, "fixture is not a complete Zarf package")
 	assert.FileExists(t, filepath.Join(dstDir, "zarf.yaml"))
 }
@@ -256,7 +256,7 @@ func TestExtractedArtifactPackageLayoutLoader_RejectsEscapingLayerTitle(t *testi
 	dstDir := t.TempDir()
 	escapedPath := filepath.Clean(filepath.Join(dstDir, filepath.FromSlash(escapingTitle)))
 
-	_, _, err := loader.LoadPackageLayout(t.Context(), &spec.Package{Name: "mypkg", Source: "oci://example.com/pkg:v1"}, dstDir, LoadOptions{})
+	_, err := loader.LoadPackageLayout(t.Context(), &spec.Package{Name: "mypkg", Source: "oci://example.com/pkg:v1"}, dstDir, LoadOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "escapes destination directory")
 	var pathErr LayerPathEscapeError
@@ -271,7 +271,7 @@ func TestExtractedArtifactPackageLayoutLoader_RejectsDestinationSymlinkEscape(t 
 	escapedDir := t.TempDir()
 	require.NoError(t, os.Symlink(escapedDir, filepath.Join(dstDir, "escape")))
 
-	_, _, err := loader.LoadPackageLayout(t.Context(), &spec.Package{Name: "mypkg", Source: "oci://example.com/pkg:v1"}, dstDir, LoadOptions{})
+	_, err := loader.LoadPackageLayout(t.Context(), &spec.Package{Name: "mypkg", Source: "oci://example.com/pkg:v1"}, dstDir, LoadOptions{})
 	require.Error(t, err)
 	assert.NoFileExists(t, filepath.Join(escapedDir, "zarf.yaml"))
 }
@@ -280,7 +280,7 @@ func TestExtractedArtifactPackageLayoutLoader_RejectsMissingLayerTitle(t *testin
 	loader := newArtifactPackageLayoutLoader(t, "")
 	dstDir := t.TempDir()
 
-	_, _, err := loader.LoadPackageLayout(t.Context(), &spec.Package{Name: "mypkg", Source: "oci://example.com/pkg:v1"}, dstDir, LoadOptions{})
+	_, err := loader.LoadPackageLayout(t.Context(), &spec.Package{Name: "mypkg", Source: "oci://example.com/pkg:v1"}, dstDir, LoadOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `manifest for package "mypkg" missing title annotation on layer`)
 
@@ -332,7 +332,7 @@ func TestExtractedArtifactPackageLayoutLoader_RejectsUnindexedLocalSource(t *tes
 		loader := &ExtractedArtifactPackageLayoutLoader{PackageManifests: map[string]ocispec.Descriptor{}}
 		pkg := &spec.Package{Name: "mypkg", Source: pkgDir}
 
-		_, _, err := loader.LoadPackageLayout(t.Context(), pkg, dstDir, LoadOptions{})
+		_, err := loader.LoadPackageLayout(t.Context(), pkg, dstDir, LoadOptions{})
 		require.Error(t, err)
 
 		assert.Contains(t, err.Error(), "not found in bundle artifact index")
@@ -348,7 +348,7 @@ func TestExtractedArtifactPackageLayoutLoader_RejectsUnindexedLocalSource(t *tes
 	t.Run("OCI source not in PackageManifests returns error", func(t *testing.T) {
 		loader := &ExtractedArtifactPackageLayoutLoader{PackageManifests: map[string]ocispec.Descriptor{}}
 		pkg := &spec.Package{Name: "mypkg", Source: "oci://example.com/pkg:v1"}
-		_, _, err := loader.LoadPackageLayout(t.Context(), pkg, t.TempDir(), LoadOptions{})
+		_, err := loader.LoadPackageLayout(t.Context(), pkg, t.TempDir(), LoadOptions{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found in bundle artifact index")
 	})

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -27,7 +27,9 @@ type DeployPackageOptions struct {
 	Config             *UDSBundleConfig
 	BundleDir          string
 	PackageDeployHooks PackageDeployHooks
-	Streams            iostreams.IOStreams
+	// IsPartial reports whether the loaded layout omits checksum-referenced layers.
+	IsPartial bool
+	Streams   iostreams.IOStreams
 }
 
 // ZarfPackageLayoutLoadOptions carries options for loading a Zarf package layout.
@@ -40,7 +42,13 @@ type ZarfPackageLayoutLoadOptions struct {
 // Implementations may pull from pkg.Source, load from an extracted bundle
 // artifact, or return an already-staged layout.
 type ZarfPackageLayoutLoader interface {
-	LoadPackageLayout(ctx context.Context, pkg *spec.Package, dstDir string, opts ZarfPackageLayoutLoadOptions) (*ZarfPackageLayout, error)
+	LoadPackageLayout(ctx context.Context, pkg *spec.Package, dstDir string, opts ZarfPackageLayoutLoadOptions) (*ZarfPackageLayoutLoadResult, error)
+}
+
+// ZarfPackageLayoutLoadResult contains a loaded layout and metadata discovered while loading it.
+type ZarfPackageLayoutLoadResult struct {
+	Layout    ZarfPackageLayout
+	IsPartial bool
 }
 
 // PackageDeployHooks provides deployment process extensibility on a per-package basis.
@@ -264,6 +272,7 @@ func toZarfDeployPackageOptions(opts DeployPackageOptions) internalzarf.DeployPa
 		Config:             toZarfConfig(opts.Config),
 		BundleDir:          opts.BundleDir,
 		PackageDeployHooks: toZarfPackageHooks(opts.PackageDeployHooks),
+		IsPartial:          opts.IsPartial,
 		Streams:            opts.Streams,
 	}
 }
@@ -272,6 +281,7 @@ func fromZarfDeployPackageOptions(opts internalzarf.DeployPackageOptions) Deploy
 	return DeployPackageOptions{
 		Config:    fromZarfConfig(opts.Config),
 		BundleDir: opts.BundleDir,
+		IsPartial: opts.IsPartial,
 		Streams:   opts.Streams,
 	}
 }
@@ -283,7 +293,6 @@ func toZarfPackageHooks(hooks PackageDeployHooks) internalzarf.PackageDeployHook
 			publicOpts := fromZarfDeployPackageOptions(*internalOpts)
 			publicOpts.PackageDeployHooks = hooks
 			publicLayout := fromZarfPackageLayout(pkgLayout)
-			publicLayout.IsPartial = internalOpts.IsPartial
 			err := hooks.PreDeploy(ctx, pkg, publicLayout, &publicOpts)
 			if applyErr := applyPublicPackageLayout(pkgLayout, publicLayout); applyErr != nil {
 				return applyErr
@@ -299,7 +308,7 @@ func toZarfPackageHooks(hooks PackageDeployHooks) internalzarf.PackageDeployHook
 			internalOpts.Config = toZarfConfig(publicOpts.Config)
 			internalOpts.BundleDir = publicOpts.BundleDir
 			internalOpts.PackageDeployHooks = toZarfPackageHooks(publicOpts.PackageDeployHooks)
-			internalOpts.IsPartial = publicLayout.IsPartial
+			internalOpts.IsPartial = publicOpts.IsPartial
 			internalOpts.Streams = publicOpts.Streams
 			return nil
 		}

--- a/pkg/bundle/deploy.go
+++ b/pkg/bundle/deploy.go
@@ -39,8 +39,10 @@ type ZarfPackageLayoutLoadOptions struct {
 }
 
 // ZarfPackageLayoutLoader prepares a Zarf package layout for a bundle package.
-// Implementations may pull from pkg.Source, load from an extracted bundle
-// artifact, or return an already-staged layout.
+// Implementations must stage a complete Zarf package in dstDir. They may pull
+// from pkg.Source, copy from an extracted bundle artifact, or populate dstDir
+// from another source. The adapter loads the staged package to preserve Zarf's
+// private deployment state before applying supported public layout mutations.
 type ZarfPackageLayoutLoader interface {
 	LoadPackageLayout(ctx context.Context, pkg *spec.Package, dstDir string, opts ZarfPackageLayoutLoadOptions) (*ZarfPackageLayoutLoadResult, error)
 }

--- a/pkg/bundle/zarf.go
+++ b/pkg/bundle/zarf.go
@@ -18,19 +18,25 @@ import (
 // github.com/zarf-dev/zarf/src/pkg/packager/layout.PackageLayout exposed during
 // bundle deploy. Fields not exposed here are preserved by the adapter.
 type ZarfPackageLayout struct {
-	Directory string
-	// IsPartial indicates that the layout may omit files referenced by its checksums.
-	IsPartial      bool
-	Pkg            ZarfPackage
-	registryDigest string
+	dirPath string
+	Pkg     ZarfPackage
+	digest  string
 }
 
 // SetDeployedDigest records the registry-resolved manifest digest that Zarf
 // should store as the deployed package identity.
 func (p *ZarfPackageLayout) SetDeployedDigest(digest string) {
 	if p != nil {
-		p.registryDigest = digest
+		p.digest = digest
 	}
+}
+
+func (p *ZarfPackageLayout) DirPath() string {
+	return p.dirPath
+}
+
+func (p *ZarfPackageLayout) Digest() string {
+	return p.digest
 }
 
 // ZarfPackage is the supported public subset of
@@ -69,14 +75,15 @@ type PackageStagingRootProvider interface {
 	PackageStagingRoot(context.Context) string
 }
 
-func (l *extractedArtifactPackageLayoutLoader) LoadPackageLayout(ctx context.Context, pkg *spec.Package, dstDir string, opts ZarfPackageLayoutLoadOptions) (*ZarfPackageLayout, error) {
-	pkgLayout, isPartial, err := l.loader.LoadPackageLayout(ctx, pkg, dstDir, zarf.LoadOptions{Streams: opts.Streams, IsPartial: opts.IsPartial})
+func (l *extractedArtifactPackageLayoutLoader) LoadPackageLayout(ctx context.Context, pkg *spec.Package, dstDir string, opts ZarfPackageLayoutLoadOptions) (*ZarfPackageLayoutLoadResult, error) {
+	result, err := l.loader.LoadPackageLayout(ctx, pkg, dstDir, zarf.LoadOptions{Streams: opts.Streams, IsPartial: opts.IsPartial})
 	if err != nil {
 		return nil, err
 	}
-	result := fromZarfPackageLayout(pkgLayout)
-	result.IsPartial = isPartial
-	return result, nil
+	return &ZarfPackageLayoutLoadResult{
+		Layout:    *fromZarfPackageLayout(&result.Layout),
+		IsPartial: result.IsPartial,
+	}, nil
 }
 
 // PackageStagingRoot returns the parent of OCIDir so package staging can share
@@ -94,33 +101,38 @@ type packageLayoutLoaderAdapter struct {
 }
 
 // LoadPackageLayout delegates package loading through the public loader contract.
-func (a packageLayoutLoaderAdapter) LoadPackageLayout(ctx context.Context, pkg *spec.Package, dstDir string, opts zarf.LoadOptions) (*layout.PackageLayout, bool, error) {
-	publicLayout, err := a.loader.LoadPackageLayout(ctx, pkg, dstDir, ZarfPackageLayoutLoadOptions{Streams: opts.Streams, IsPartial: opts.IsPartial})
+func (a packageLayoutLoaderAdapter) LoadPackageLayout(ctx context.Context, pkg *spec.Package, dstDir string, opts zarf.LoadOptions) (*zarf.PackageLayoutLoadResult, error) {
+	publicResult, err := a.loader.LoadPackageLayout(ctx, pkg, dstDir, ZarfPackageLayoutLoadOptions{Streams: opts.Streams, IsPartial: opts.IsPartial})
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
-	if publicLayout == nil {
-		return nil, false, fmt.Errorf("package layout loader returned a nil layout")
+	if publicResult == nil {
+		return nil, fmt.Errorf("package layout loader returned a nil result")
 	}
-	publicLayout.IsPartial = publicLayout.IsPartial || opts.IsPartial
-	if publicLayout.Directory != "" {
+
+	publicLayout := &publicResult.Layout
+	isPartial := publicResult.IsPartial || opts.IsPartial
+	if publicLayout.dirPath != "" {
 		cleanDst, err := filepath.Abs(filepath.Clean(dstDir))
 		if err != nil {
-			return nil, false, err
+			return nil, err
 		}
-		cleanLayout, err := filepath.Abs(filepath.Clean(publicLayout.Directory))
+		cleanLayout, err := filepath.Abs(filepath.Clean(publicLayout.dirPath))
 		if err != nil {
-			return nil, false, err
+			return nil, err
 		}
 		if cleanLayout != cleanDst {
-			return nil, false, fmt.Errorf("package layout directory %q must be the supplied staging directory %q", publicLayout.Directory, dstDir)
+			return nil, fmt.Errorf("package layout directory %q must be the supplied staging directory %q", publicLayout.dirPath, dstDir)
 		}
 	}
-	internalLayout, err := toZarfPackageLayout(ctx, publicLayout, publicLayout.IsPartial)
+	internalLayout, err := toZarfPackageLayout(ctx, publicLayout, isPartial)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
-	return internalLayout, publicLayout.IsPartial, nil
+	return &zarf.PackageLayoutLoadResult{
+		Layout:    *internalLayout,
+		IsPartial: isPartial,
+	}, nil
 }
 
 // PackageStagingRoot forwards an optional staging preference. An empty result
@@ -137,11 +149,11 @@ func fromZarfPackageLayout(pkgLayout *layout.PackageLayout) *ZarfPackageLayout {
 		return nil
 	}
 	result := &ZarfPackageLayout{
-		Directory: pkgLayout.DirPath(),
-		Pkg:       ZarfPackage{Components: make([]ZarfPackageComponent, len(pkgLayout.Pkg.Components))},
+		dirPath: pkgLayout.DirPath(),
+		Pkg:     ZarfPackage{Components: make([]ZarfPackageComponent, len(pkgLayout.Pkg.Components))},
 	}
 	if !pkgLayout.IsPushable() && pkgLayout.Digest() != "" {
-		result.registryDigest = pkgLayout.Digest()
+		result.digest = pkgLayout.Digest()
 	}
 	for i, component := range pkgLayout.Pkg.Components {
 		result.Pkg.Components[i] = ZarfPackageComponent{
@@ -164,8 +176,8 @@ func toZarfPackageLayout(ctx context.Context, pkgLayout *ZarfPackageLayout, isPa
 	if pkgLayout == nil {
 		return nil, nil
 	}
-	if pkgLayout.Directory != "" {
-		result, err := layout.LoadFromDir(ctx, pkgLayout.Directory, layout.PackageLayoutOptions{
+	if pkgLayout.dirPath != "" {
+		result, err := layout.LoadFromDir(ctx, pkgLayout.dirPath, layout.PackageLayoutOptions{
 			IsPartial:            isPartial,
 			VerificationStrategy: layout.VerifyNever,
 		})
@@ -239,8 +251,8 @@ func applyPublicPackageLayout(dst *layout.PackageLayout, src *ZarfPackageLayout)
 		components[i] = private
 	}
 	dst.Pkg.Components = components
-	if src.registryDigest != "" {
-		dst.SetRegistryDigest(src.registryDigest)
+	if src.digest != "" {
+		dst.SetRegistryDigest(src.digest)
 	}
 	return nil
 }

--- a/pkg/bundle/zarf.go
+++ b/pkg/bundle/zarf.go
@@ -112,22 +112,16 @@ func (a packageLayoutLoaderAdapter) LoadPackageLayout(ctx context.Context, pkg *
 
 	publicLayout := &publicResult.Layout
 	isPartial := publicResult.IsPartial || opts.IsPartial
-	if publicLayout.dirPath != "" {
-		cleanDst, err := filepath.Abs(filepath.Clean(dstDir))
-		if err != nil {
-			return nil, err
-		}
-		cleanLayout, err := filepath.Abs(filepath.Clean(publicLayout.dirPath))
-		if err != nil {
-			return nil, err
-		}
-		if cleanLayout != cleanDst {
-			return nil, fmt.Errorf("package layout directory %q must be the supplied staging directory %q", publicLayout.dirPath, dstDir)
-		}
+	stagedDir, err := filepath.Abs(filepath.Clean(dstDir))
+	if err != nil {
+		return nil, fmt.Errorf("resolving package staging directory %q: %w", dstDir, err)
 	}
+	// The adapter owns the staging directory. Public loaders populate dstDir but
+	// cannot and should not set layout-private path state.
+	publicLayout.dirPath = stagedDir
 	internalLayout, err := toZarfPackageLayout(ctx, publicLayout, isPartial)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("loading package layout staged in %q: %w", stagedDir, err)
 	}
 	return &zarf.PackageLayoutLoadResult{
 		Layout:    *internalLayout,

--- a/pkg/bundle/zarf_test.go
+++ b/pkg/bundle/zarf_test.go
@@ -326,6 +326,43 @@ func TestPublicPreDeployPreservesRename(t *testing.T) {
 	assert.Equal(t, "manifest.yaml", internalLayout.Pkg.Components[0].Manifests[0].Name)
 }
 
+func TestPackageLayoutLoaderAdapterPreservesStagedPrivateDeploymentData(t *testing.T) {
+	dir := t.TempDir()
+	const zarfYAML = `kind: ZarfPackageConfig
+metadata:
+  name: test
+  version: 0.0.1
+  aggregateChecksum: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+components:
+  - name: main
+    required: true
+    charts:
+      - name: chart
+        version: 1.0.0
+        url: https://example.com/charts
+    manifests:
+      - name: manifests
+        files:
+          - manifest.yaml
+    files:
+      - source: file.txt
+        target: /tmp/file.txt
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "zarf.yaml"), []byte(zarfYAML), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "checksums.txt"), nil, 0o600))
+
+	loader := packageLayoutLoaderAdapter{loader: staticPackageLayoutLoader{
+		layout: &ZarfPackageLayout{Pkg: ZarfPackage{Components: []ZarfPackageComponent{{Name: "main"}}}},
+	}}
+	result, err := loader.LoadPackageLayout(t.Context(), &spec.Package{Name: "test"}, dir, internalzarf.LoadOptions{IsPartial: true})
+	require.NoError(t, err)
+	require.Len(t, result.Layout.Pkg.Components, 1)
+	component := result.Layout.Pkg.Components[0]
+	assert.Equal(t, "chart", component.Charts[0].Name)
+	assert.Equal(t, "manifests", component.Manifests[0].Name)
+	assert.Equal(t, "/tmp/file.txt", component.Files[0].Target)
+}
+
 func TestPackageLayoutLoaderAdapterPreservesPartialLayout(t *testing.T) {
 	dir := t.TempDir()
 	missingFileDigest := sha256.Sum256([]byte("optional component"))
@@ -343,23 +380,48 @@ func TestPackageLayoutLoaderAdapterPreservesPartialLayout(t *testing.T) {
 	assert.True(t, result.IsPartial)
 }
 
-func TestPackageLayoutLoaderAdapterRejectsCallerOwnedDirectory(t *testing.T) {
+func TestPackageLayoutLoaderAdapterRequiresStagedPackage(t *testing.T) {
+	loader := packageLayoutLoaderAdapter{loader: staticPackageLayoutLoader{
+		layout:      &ZarfPackageLayout{},
+		skipStaging: true,
+	}}
+
+	_, err := loader.LoadPackageLayout(t.Context(), &spec.Package{Name: "test"}, t.TempDir(), internalzarf.LoadOptions{})
+	require.ErrorContains(t, err, "loading package layout staged")
+}
+
+func TestPackageLayoutLoaderAdapterUsesSuppliedStagingDirectory(t *testing.T) {
 	stagingDir := t.TempDir()
 	ownedDir := t.TempDir()
 	loader := packageLayoutLoaderAdapter{loader: staticPackageLayoutLoader{layout: &ZarfPackageLayout{dirPath: ownedDir}}}
 
-	_, err := loader.LoadPackageLayout(t.Context(), &spec.Package{Name: "test"}, stagingDir, internalzarf.LoadOptions{})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must be the supplied staging directory")
+	result, err := loader.LoadPackageLayout(t.Context(), &spec.Package{Name: "test"}, stagingDir, internalzarf.LoadOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, stagingDir, result.Layout.DirPath())
 	assert.DirExists(t, ownedDir)
 }
 
 type staticPackageLayoutLoader struct {
-	layout    *ZarfPackageLayout
-	isPartial bool
+	layout      *ZarfPackageLayout
+	isPartial   bool
+	skipStaging bool
 }
 
-func (l staticPackageLayoutLoader) LoadPackageLayout(context.Context, *spec.Package, string, ZarfPackageLayoutLoadOptions) (*ZarfPackageLayoutLoadResult, error) {
+func (l staticPackageLayoutLoader) LoadPackageLayout(_ context.Context, _ *spec.Package, dstDir string, _ ZarfPackageLayoutLoadOptions) (*ZarfPackageLayoutLoadResult, error) {
+	zarfYAML := filepath.Join(dstDir, "zarf.yaml")
+	_, err := os.Stat(zarfYAML)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	if errors.Is(err, os.ErrNotExist) && !l.skipStaging {
+		const contents = "kind: ZarfPackageConfig\nmetadata:\n  name: test\n  version: 0.0.1\n  aggregateChecksum: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\ncomponents: []\n"
+		if err := os.WriteFile(zarfYAML, []byte(contents), 0o600); err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(filepath.Join(dstDir, "checksums.txt"), nil, 0o600); err != nil {
+			return nil, err
+		}
+	}
 	return &ZarfPackageLayoutLoadResult{Layout: *l.layout, IsPartial: l.isPartial}, nil
 }
 

--- a/pkg/bundle/zarf_test.go
+++ b/pkg/bundle/zarf_test.go
@@ -147,10 +147,10 @@ func TestAdjacentDefaultsPathPropagatesStatErrors(t *testing.T) {
 	assert.Empty(t, defaultsPath)
 }
 
-func TestPublicPackageHookPreservesPartialLayout(t *testing.T) {
+func TestPublicPackageHookPreservesPartialMetadata(t *testing.T) {
 	var partial bool
-	hooks := toZarfPackageHooks(PackageDeployHooks{PreDeploy: func(_ context.Context, _ *spec.Package, pkgLayout *ZarfPackageLayout, _ *DeployPackageOptions) error {
-		partial = pkgLayout.IsPartial
+	hooks := toZarfPackageHooks(PackageDeployHooks{PreDeploy: func(_ context.Context, _ *spec.Package, _ *ZarfPackageLayout, opts *DeployPackageOptions) error {
+		partial = opts.IsPartial
 		return nil
 	}})
 	dir := t.TempDir()
@@ -290,7 +290,7 @@ func TestPublicPreDeployReceivesStagedDirectory(t *testing.T) {
 	internalOpts := toZarfDeployPackageOptions(DeployPackageOptions{Config: validValidationConfig(), BundleDir: dir})
 	internalOpts.PackageDeployHooks = toZarfPackageHooks(PackageDeployHooks{
 		PreDeploy: func(_ context.Context, _ *spec.Package, pkgLayout *ZarfPackageLayout, _ *DeployPackageOptions) error {
-			assert.Equal(t, dir, pkgLayout.Directory)
+			assert.Equal(t, dir, pkgLayout.dirPath)
 			return nil
 		},
 	})
@@ -334,26 +334,33 @@ func TestPackageLayoutLoaderAdapterPreservesPartialLayout(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "zarf.yaml"), []byte("metadata:\n  name: test\n  version: 0.0.1\n  aggregateChecksum: "+hex.EncodeToString(checksum[:])+"\ncomponents: []\n"), 0o600))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "checksums.txt"), checksums, 0o600))
 
-	loader := packageLayoutLoaderAdapter{loader: staticPackageLayoutLoader{layout: &ZarfPackageLayout{Directory: dir, IsPartial: true}}}
-	_, _, err := loader.LoadPackageLayout(t.Context(), &spec.Package{Name: "test"}, dir, internalzarf.LoadOptions{})
+	loader := packageLayoutLoaderAdapter{loader: staticPackageLayoutLoader{
+		layout:    &ZarfPackageLayout{dirPath: dir},
+		isPartial: true,
+	}}
+	result, err := loader.LoadPackageLayout(t.Context(), &spec.Package{Name: "test"}, dir, internalzarf.LoadOptions{})
 	require.NoError(t, err)
+	assert.True(t, result.IsPartial)
 }
 
 func TestPackageLayoutLoaderAdapterRejectsCallerOwnedDirectory(t *testing.T) {
 	stagingDir := t.TempDir()
 	ownedDir := t.TempDir()
-	loader := packageLayoutLoaderAdapter{loader: staticPackageLayoutLoader{layout: &ZarfPackageLayout{Directory: ownedDir}}}
+	loader := packageLayoutLoaderAdapter{loader: staticPackageLayoutLoader{layout: &ZarfPackageLayout{dirPath: ownedDir}}}
 
-	_, _, err := loader.LoadPackageLayout(t.Context(), &spec.Package{Name: "test"}, stagingDir, internalzarf.LoadOptions{})
+	_, err := loader.LoadPackageLayout(t.Context(), &spec.Package{Name: "test"}, stagingDir, internalzarf.LoadOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must be the supplied staging directory")
 	assert.DirExists(t, ownedDir)
 }
 
-type staticPackageLayoutLoader struct{ layout *ZarfPackageLayout }
+type staticPackageLayoutLoader struct {
+	layout    *ZarfPackageLayout
+	isPartial bool
+}
 
-func (l staticPackageLayoutLoader) LoadPackageLayout(context.Context, *spec.Package, string, ZarfPackageLayoutLoadOptions) (*ZarfPackageLayout, error) {
-	return l.layout, nil
+func (l staticPackageLayoutLoader) LoadPackageLayout(context.Context, *spec.Package, string, ZarfPackageLayoutLoadOptions) (*ZarfPackageLayoutLoadResult, error) {
+	return &ZarfPackageLayoutLoadResult{Layout: *l.layout, IsPartial: l.isPartial}, nil
 }
 
 func TestZarfRemoverRemoveBundleValidatesRemovalSafety(t *testing.T) {

--- a/tests/library/deployer_hooks_test.go
+++ b/tests/library/deployer_hooks_test.go
@@ -29,8 +29,11 @@ type staticLoaderImpl struct {
 	err error
 }
 
-func (l *staticLoaderImpl) LoadPackageLayout(_ context.Context, _ *spec.Package, _ string, _ bundle.ZarfPackageLayoutLoadOptions) (*bundle.ZarfPackageLayout, error) {
-	return l.pkg, l.err
+func (l *staticLoaderImpl) LoadPackageLayout(_ context.Context, _ *spec.Package, _ string, _ bundle.ZarfPackageLayoutLoadOptions) (*bundle.ZarfPackageLayoutLoadResult, error) {
+	if l.err != nil {
+		return nil, l.err
+	}
+	return &bundle.ZarfPackageLayoutLoadResult{Layout: *l.pkg}, nil
 }
 
 func imageLayoutLib() *bundle.ZarfPackageLayout {

--- a/tests/library/deployer_hooks_test.go
+++ b/tests/library/deployer_hooks_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sync"
 	"testing"
@@ -29,9 +30,16 @@ type staticLoaderImpl struct {
 	err error
 }
 
-func (l *staticLoaderImpl) LoadPackageLayout(_ context.Context, _ *spec.Package, _ string, _ bundle.ZarfPackageLayoutLoadOptions) (*bundle.ZarfPackageLayoutLoadResult, error) {
+func (l *staticLoaderImpl) LoadPackageLayout(_ context.Context, _ *spec.Package, dstDir string, _ bundle.ZarfPackageLayoutLoadOptions) (*bundle.ZarfPackageLayoutLoadResult, error) {
 	if l.err != nil {
 		return nil, l.err
+	}
+	const zarfYAML = "kind: ZarfPackageConfig\nmetadata:\n  name: test\n  version: 0.0.1\n  aggregateChecksum: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\ncomponents: []\n"
+	if err := os.WriteFile(filepath.Join(dstDir, "zarf.yaml"), []byte(zarfYAML), 0o600); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(filepath.Join(dstDir, "checksums.txt"), nil, 0o600); err != nil {
+		return nil, err
 	}
 	return &bundle.ZarfPackageLayoutLoadResult{Layout: *l.pkg}, nil
 }


### PR DESCRIPTION
## Description

This PR aligns our public ZarfPackageLayout withe the zarf type by renaming some fields and moving IsPartial out to a new type ZarfPackageLayoutLoadResult

## Related Issue

Fixes CLI-207

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
