### PR TITLE
chore: configure Renovate for vendored dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,8 @@
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "separateMajorMinor": false,
-  "postUpdateOptions": ["gomodTidy"],
+  "ignorePaths": ["**/vendor/**"],
+  "postUpdateOptions": ["gomodTidy", "gomodVendor"],
   "packageRules": [
     {
       "matchFileNames": ["go.mod", "go.sum"],


### PR DESCRIPTION
## Description

- Ignore vendored paths in Renovate.
- Run `go mod vendor` after Go module updates.

Addresses the follow-up requested in #1476.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
