### PR TITLE
docs: replace "Better Bundles" with "Bundles Next"

### DIFF
--- a/docs/adr/0001-bundles-next-spec.md
+++ b/docs/adr/0001-bundles-next-spec.md
@@ -1,7 +1,7 @@
-# 1. Better Bundles Spec
+# 1. Bundles Next Spec
 
 Date: 2026-01-22
-Updated: 2026-05-05
+Updated: 2026-08-27
 
 ## Changelog
 
@@ -9,6 +9,7 @@ Updated: 2026-05-05
 |------|--------|
 | 2026-01-22 | Initial ADR - HCL bundle definition, `bundle.uds.hcl` and `config.uds.hcl` schemas, OCI layout, custom media types |
 | 2026-05-05 | CLI-136: the `variables` block accepts list, set, and tuple values in addition to scalars and objects. Layer overrides replace collections wholesale (Helm convention). |
+| 2026-08-27 | CLI-318: replace "Better Bundles" with "Bundles Next". |
 
 ## Status
 

--- a/docs/adr/0008-bundle-reconfigure-operation.md
+++ b/docs/adr/0008-bundle-reconfigure-operation.md
@@ -8,7 +8,7 @@ Accepted
 
 ## Context
 
-The original Better Bundles design doc introduces the concept of a "reconfigure" operation:
+The original Bundles Next design doc introduces the concept of a "reconfigure" operation:
 
 > Variables could (and should) also include "defaults" at build time, providing a way of both documenting available values, and actually setting default configuration that can be changed later. Any defaults can be overridden at either deploy time OR with a targeted "reconfigure" operation that allows swapping in a new set of defaults as a *build* operation. This reconfiguration would result in a new bundle that could be published/deployed, but would share the majority of the underlying OCI layers.
 
@@ -161,7 +161,7 @@ The annotation value is the source child-index digest: the canonical artifact di
 
 ### Signing considerations
 
-The original Better Bundles design doc explicitly defers signing, SBOMs, and checksums to future work:
+The original Bundles Next design doc explicitly defers signing, SBOMs, and checksums to future work:
 
 > This example does not include signatures, sboms, checksums, or other additional artifacts. Anything of this nature would live at the same level as `bundle.uds.hcl`, but is currently not identified/designed explicitly for here.
 

--- a/docs/adr/0011-validation-at-public-library-entrypoints.md
+++ b/docs/adr/0011-validation-at-public-library-entrypoints.md
@@ -18,7 +18,7 @@ The original draft of this ADR referenced `--prompt` together with `--concurrenc
 
 ## Context
 
-First-class library support for deploying Better Bundles in UDS Fleet requires amending the `Complete → Validate → Run` pattern (established by [ADR-0002](0002-cli-architecture-patterns.md)) and performing additional validation at the method level for every public interface (located in the `types.go` files).
+First-class library support for deploying Bundles Next in UDS Fleet requires amending the `Complete → Validate → Run` pattern (established by [ADR-0002](0002-cli-architecture-patterns.md)) and performing additional validation at the method level for every public interface (located in the `types.go` files).
 
 This means there are two types of validation performed:
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -13,7 +13,7 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 UDS CLI is the command-line DevX for working with the UDS ecosystem. It is the primary way to run UDS workflows from a terminal, including bundle authoring, artifact creation, deployment, publishing, cluster operations, and task automation.
 
 > [!NOTE]
-> UDS CLI currently supports Legacy and Next modes. Legacy remains the default while Next matures as an alpha preview. Next mode introduces the Better Bundles HCL flow and next-generation artifact deployment model. See [UDS CLI Next Mode](/cli/reference/next-mode/) for why it exists and current capabilities. More Next mode docs will be added as the mode matures.
+> UDS CLI currently supports Legacy and Next modes. Legacy remains the default while Next matures as an alpha preview. Next mode introduces the Bundles Next HCL flow and next-generation artifact deployment model. See [UDS CLI Next Mode](/cli/reference/next-mode/) for why it exists and current capabilities. More Next mode docs will be added as the mode matures.
 
 ## Key Commands
 

--- a/docs/reference/next-mode.mdx
+++ b/docs/reference/next-mode.mdx
@@ -14,7 +14,7 @@ UDS CLI Next is the next-generation implementation of UDS CLI. It is available a
 
 UDS CLI Next is designed to support the next phase of UDS bundle workflows:
 
-- [Better Bundles design](#better-bundles-design)
+- [Bundles Next design](#bundles-next-design)
   - next-generation bundle authoring and artifact structure
   - self-contained OCI artifacts for registry-backed and offline workflows
 - HCL-based bundle definitions with `bundle.uds.hcl`
@@ -26,11 +26,11 @@ UDS CLI Next is designed to support the next phase of UDS bundle workflows:
 - a library-first design that other UDS tools can consume directly
 - stronger artifact integrity, signing, and verification paths
 
-## Better Bundles Design
+## Bundles Next Design
 
-UDS CLI Next implements the Better Bundles design for the next generation of UDS bundles. The previous bundle design fell short as UDS workflows matured: bundle configuration relied on bespoke `overrides`, package contents were hidden behind indirect OCI blob references, bundles did not have a distinct media type for registries to identify, and the artifact shape was harder for downstream tools to parse consistently.
+UDS CLI Next implements the Bundles Next design for the next generation of UDS bundles. The previous bundle design fell short as UDS workflows matured: bundle configuration relied on bespoke `overrides`, package contents were hidden behind indirect OCI blob references, bundles did not have a distinct media type for registries to identify, and the artifact shape was harder for downstream tools to parse consistently.
 
-Better Bundles focuses on making bundle artifacts easier for humans, registries, and downstream deployment tools to reason about. Beyond the HCL authoring model above, it defines:
+Bundles Next focuses on making bundle artifacts easier for humans, registries, and downstream deployment tools to reason about. Beyond the HCL authoring model above, it defines:
 
 - a bundle-specific OCI media type so registries and tooling can identify UDS bundles directly
 - an artifact layout where package manifests and layers are represented explicitly instead of hidden behind generic blob indirection

--- a/tests/test_data/bundles/spec-compliant/bundle.uds.hcl
+++ b/tests/test_data/bundles/spec-compliant/bundle.uds.hcl
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 # This bundle is a spec-compliant example that uses ONLY the attributes
-# defined in the Better Bundles Technical Design (docs/specs/1_Better_Bundles.md).
+# defined in the Bundles Next Technical Design (docs/adr/0001-bundles-next-spec.md).
 # It serves as the baseline for testing HCL parsing and the inspect command.
 #
 # This example demonstrates:

--- a/tests/test_data/bundles/spec-compliant/config.uds.hcl
+++ b/tests/test_data/bundles/spec-compliant/config.uds.hcl
@@ -6,7 +6,7 @@
 # This file demonstrates how to provide deploy-time variables that are used
 # to template values files. Variables use the {{ .vars.* }} syntax in YAML files.
 #
-# Reference: docs/specs/1_Better_Bundles.md
+# Reference: docs/adr/0001-bundles-next-spec.md
 
 # CLI options for bundle deployment
 options {


### PR DESCRIPTION
## Description

Replace "Better Bundles" with "Bundles Next" in documentation given the recent decision to retire the term "Better Bundles"

This includes the original ADR describing the bundles enhancement; while this rewrites history, it keeps the ADRs consistent with present conventions.

Only in one place did I leave "Better Bundles" in place - as a reference to the original Notion design doc that is one individual's personal prototyping, and is not part of the official public record.

...

## Related Issue

Fixes #CLI-318

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed

This PR was validated using `uds run dev-docs` and `uds run uds-docs-validate`.