### PR TITLE
fix: gitleaks shall ignore uds-docs

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,7 +7,3 @@ useDefault = true
 [[allowlists]]
 description = "vendored Go dependencies"
 paths = ['''^vendor/''']
-
-[[allowlists]]
-description = "local generated documentation workspace"
-paths = ['''^uds-docs/''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,3 +7,7 @@ useDefault = true
 [[allowlists]]
 description = "vendored Go dependencies"
 paths = ['''^vendor/''']
+
+[[allowlists]]
+description = "local generated documentation workspace"
+paths = ['''^uds-docs/''']

--- a/hk.pkl
+++ b/hk.pkl
@@ -20,7 +20,7 @@ local checks = new Mapping<String, Step> {
     ["detect-secrets"] {
         check = "gitleaks detect --source . --no-git --redact --no-banner --exit-code 1"
         glob = List("**/*")
-        exclude = List("build/**", "vendor/**")
+        exclude = List("build/**", "vendor/**", "uds-docs/**")
     }
     ["end-of-file-fixer"] = (Builtins.newlines) {
         exclude = List("docs/reference/commands/**", "build/**", "vendor/**")


### PR DESCRIPTION
## Description

After running `uds run dev-docs`, there is a directory `uds-docs` left behind (that is in `.gitignore`) that will be scanned by `gitleaks` via the pre-commit hook invoked by `hk`. Commits cannot take place since `gitleaks` will find objectionable matter in `uds-docs`. 

This change causes `gitleaks` to skip the generated (and `.gitignore`'d) `uds-docs` path.
...

## Related Issue

Fixes #CLI-321

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed

This was tested by running `uds run dev-docs` and then trying to commit this PR change itself.