### PR TITLE
fix(legacy): preserve --set overrides after config reload

### DIFF
--- a/internal/legacy/cli/main_test.go
+++ b/internal/legacy/cli/main_test.go
@@ -192,3 +192,42 @@ func TestConfigurationPreservesChangedDeploySetFlags(t *testing.T) {
 		t.Fatalf("SetVariables = %#v, want %#v", bundleCfg.DeployOpts.SetVariables, want)
 	}
 }
+
+func TestConfigurationMergesDeploySetFlagsWithConfigSetVariables(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "uds-config.yaml")
+	contents := []byte(`setVariables:
+  from_config: yes
+  cli: config
+`)
+	if err := os.WriteFile(configPath, contents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("UDS_CONFIG", configPath)
+
+	root := NewRootCommand()
+	root.SetArgs([]string{
+		"deploy",
+		"./bundle-does-not-need-to-exist.tar.zst",
+		"--confirm",
+		"--no-log-file",
+		"--no-progress",
+		"--set", "cli=flag",
+	})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "failed to validate bundle: invalid reference") {
+		t.Fatalf("error = %v, want bundle validation error", err)
+	}
+
+	want := map[string]string{
+		"from_config": "yes",
+		"cli":         "flag",
+	}
+	for key, value := range want {
+		if got := bundleCfg.DeployOpts.SetVariables[key]; got != value {
+			t.Fatalf("SetVariables[%q] = %q, want %q", key, got, value)
+		}
+	}
+	if len(bundleCfg.DeployOpts.SetVariables) != len(want) {
+		t.Fatalf("SetVariables = %#v, want %#v", bundleCfg.DeployOpts.SetVariables, want)
+	}
+}

--- a/internal/legacy/cli/main_test.go
+++ b/internal/legacy/cli/main_test.go
@@ -156,3 +156,39 @@ func TestConfigurationPreservesChangedDeployFlags(t *testing.T) {
 		t.Fatalf("retries = %d, want 5", bundleCfg.DeployOpts.Retries)
 	}
 }
+
+func TestConfigurationPreservesChangedDeploySetFlags(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "uds-config.yaml")
+	if err := os.WriteFile(configPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("UDS_CONFIG", configPath)
+
+	root := NewRootCommand()
+	root.SetArgs([]string{
+		"deploy",
+		"./bundle-does-not-need-to-exist.tar.zst",
+		"--confirm",
+		"--no-log-file",
+		"--no-progress",
+		"--set", "dependency-operator.OBJECT_STORAGE_PROVIDER=seaweedfs",
+		"--set", "dependency-operator.CI=false",
+	})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "failed to validate bundle: invalid reference") {
+		t.Fatalf("error = %v, want bundle validation error", err)
+	}
+
+	want := map[string]string{
+		"dependency-operator.OBJECT_STORAGE_PROVIDER": "seaweedfs",
+		"dependency-operator.CI":                      "false",
+	}
+	for key, value := range want {
+		if got := bundleCfg.DeployOpts.SetVariables[key]; got != value {
+			t.Fatalf("SetVariables[%q] = %q, want %q", key, got, value)
+		}
+	}
+	if len(bundleCfg.DeployOpts.SetVariables) != len(want) {
+		t.Fatalf("SetVariables = %#v, want %#v", bundleCfg.DeployOpts.SetVariables, want)
+	}
+}

--- a/internal/legacy/cli/root.go
+++ b/internal/legacy/cli/root.go
@@ -226,14 +226,13 @@ func loadViperConfig() error {
 		return err
 	}
 
-	// Preserve parsed --set values because pflag retains its changed state when flags are restored.
-	setVariables := bundleCfg.DeployOpts.SetVariables
+	hadSetVariables := bundleCfg.DeployOpts.SetVariables != nil
 	err = unmarshalAndValidateConfig(configFile, &bundleCfg)
 	if err != nil {
 		return err
 	}
-	if setVariables != nil {
-		bundleCfg.DeployOpts.SetVariables = setVariables
+	if hadSetVariables && bundleCfg.DeployOpts.SetVariables == nil {
+		bundleCfg.DeployOpts.SetVariables = map[string]string{}
 	}
 
 	// ensure the DeployOpts.Variables pkg vars are uppercase

--- a/internal/legacy/cli/root.go
+++ b/internal/legacy/cli/root.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Defense Unicorns
+// Copyright 2024-2026 Defense Unicorns
 // SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 package cmd
@@ -226,9 +226,14 @@ func loadViperConfig() error {
 		return err
 	}
 
+	// Preserve parsed --set values because pflag retains its changed state when flags are restored.
+	setVariables := bundleCfg.DeployOpts.SetVariables
 	err = unmarshalAndValidateConfig(configFile, &bundleCfg)
 	if err != nil {
 		return err
+	}
+	if setVariables != nil {
+		bundleCfg.DeployOpts.SetVariables = setVariables
 	}
 
 	// ensure the DeployOpts.Variables pkg vars are uppercase


### PR DESCRIPTION
## Description

  Preserve parsed Legacy `--set` deploy overrides when `UDS_CONFIG` reloads bundle configuration.

  This prevents `uds deploy` from panicking when pflag restores changed string-to-string flags after config unmarshalling. Adds regression coverage for an empty `uds-config.yaml` and multiple deploy overrides.

  ## Related Issue

  Fixes CLI-326

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Other (security config, docs update, etc)

  ## Steps to Validate

  1. Create an empty `uds-config.yaml`.
  2. Run:

     ```bash
     UDS_CONFIG=./uds-config.yaml \
     uds deploy ./bundle-does-not-need-to-exist.tar.zst --confirm --no-progress \
       --set dependency-operator.OBJECT_STORAGE_PROVIDER=seaweedfs \
       --set dependency-operator.CI=false

  3. Verify the command reaches bundle validation and does not panic.

  Validation run: `uds run test:unit`

  ## Checklist before merging

  - [x] Test added. Documentation and ADR updates are not needed for this regression fix.
  - [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed