### PR TITLE
chore(ci): add check to verify vendored dependencies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,20 @@ jobs:
       - name: Lint the repository
         run: uds run lint
 
+      - name: Verify vendored dependencies
+        shell: bash
+        run: |
+          go mod vendor
+
+          changes="$(git status --short -- vendor/)"
+          if [[ -n "$changes" ]]; then
+            echo "::error::Vendored dependencies are not generated cleanly from go.mod and go.sum."
+            echo "Run 'go mod vendor', review the resulting vendor/ changes, and commit them."
+            echo
+            echo "$changes"
+            exit 1
+          fi
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/vendor/github.com/defenseunicorns/maru-runner/src/cmd/root.go
+++ b/vendor/github.com/defenseunicorns/maru-runner/src/cmd/root.go
@@ -18,8 +18,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var logLevelString string
-var skipLogFile bool
+var (
+	logLevelString string
+	skipLogFile    bool
+)
 
 var rootCmd = &cobra.Command{
 	Use: "maru COMMAND",
@@ -53,6 +55,7 @@ func RootCmd() *cobra.Command {
 }
 
 func init() {
+	// Unintentional or undesired change
 	initViper()
 
 	v.SetDefault(V_LOG_LEVEL, "info")

--- a/vendor/github.com/defenseunicorns/maru-runner/src/cmd/root.go
+++ b/vendor/github.com/defenseunicorns/maru-runner/src/cmd/root.go
@@ -18,10 +18,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	logLevelString string
-	skipLogFile    bool
-)
+var logLevelString string
+var skipLogFile bool
 
 var rootCmd = &cobra.Command{
 	Use: "maru COMMAND",
@@ -55,7 +53,6 @@ func RootCmd() *cobra.Command {
 }
 
 func init() {
-	// Unintentional or undesired change
 	initViper()
 
 	v.SetDefault(V_LOG_LEVEL, "info")


### PR DESCRIPTION
## Description
Adds check to CI to verify that `./vendor` directory is up to date, matches the expected output of `go mod vendor` and contains no unintended or undesired changes. If there are modifications present after running go mod vendor, the job fails.

Evidence of expected failing behavior in [60aefad](https://github.com/defenseunicorns/uds-cli/pull/1551/commits/60aefadc99dae381ccd5422f9ed5fdb528e34f35) when adding an additional file, and modifying one of the vendored dependencies.
Action: https://github.com/defenseunicorns/uds-cli/actions/runs/34612830133/job/103307325591
<img width="2762" height="600" alt="image" src="https://github.com/user-attachments/assets/12ef0dc4-c69d-4a32-9e71-1b760e8bf505" />


## Related Issue
N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-cli/blob/main/CONTRIBUTING.md) followed
